### PR TITLE
added grep support

### DIFF
--- a/docs/bdd.md
+++ b/docs/bdd.md
@@ -185,6 +185,12 @@ To list all defined steps run `gherkin:steps` command:
 npx codeceptjs gherkin:steps
 ```
 
+Use `grep` to find steps in a list (grep works on Linux & MacOS):
+
+```
+npx codeceptjs gherkin:steps | grep user
+```
+
 To run tests and see step-by step output use `--steps` optoin:
 
 ```

--- a/lib/command/gherkin/steps.js
+++ b/lib/command/gherkin/steps.js
@@ -12,11 +12,11 @@ module.exports = function (genPath, options) {
   const codecept = new Codecept(config, {});
   codecept.init(testsPath);
 
-  output.print('Gherkin Step definitions:');
+  output.print('Gherkin Step Definitions:');
   output.print();
   const steps = getSteps();
   for (const step of Object.keys(steps)) {
-    output.print(`  ${output.colors.bold(step)} \n    => ${output.colors.green(steps[step].line || '')}`);
+    output.print(`  ${output.colors.bold(step)} ${output.colors.green(steps[step].line || '')}`);
   }
   output.print();
   if (!Object.keys(steps).length) {

--- a/lib/interfaces/bdd.js
+++ b/lib/interfaces/bdd.js
@@ -12,7 +12,12 @@ const addStep = (step, fn) => {
   const stack = (new Error()).stack;
   steps[step] = fn;
   fn.line = stack && stack.split('\n')[STACK_POSITION];
-  if (fn.line) fn.line = fn.line.trim().replace(/^at (.*?)\(/, '(');
+  if (fn.line) {
+    fn.line = fn.line
+      .trim()
+      .replace(/^at (.*?)\(/, '(')
+      .replace(codecept_dir, '.');
+  }
 };
 
 const parameterTypeRegistry = new ParameterTypeRegistry();


### PR DESCRIPTION
## Motivation/Description of the PR

When running `bdd:steps` displays step & file on the same line so they could be easily grepped

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
