### PR TITLE
add missing REST helper

### DIFF
--- a/lib/plugin/standardActingHelpers.js
+++ b/lib/plugin/standardActingHelpers.js
@@ -8,6 +8,7 @@ const standardActingHelpers = [
   'Puppeteer',
   'Playwright',
   'TestCafe',
+  'REST'
 ];
 
 module.exports = standardActingHelpers;


### PR DESCRIPTION
## Motivation/Description of the PR
- Currently using REST helper to writing API tests, I would like to add the delay in between those steps, so we miss the REST helper in the standard acting helpers. This aims to add the missing helper.

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [x] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [x] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
