### PR TITLE
Fix playwright set cookie

### DIFF
--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -1402,7 +1402,7 @@ class Playwright extends Helper {
    */
   async setCookie(cookie) {
     if (Array.isArray(cookie)) {
-      return this.browserContext.addCookies(...cookie);
+      return this.browserContext.addCookies(cookie);
     }
     return this.browserContext.addCookies([cookie]);
   }

--- a/lib/mochaFactory.js
+++ b/lib/mochaFactory.js
@@ -55,7 +55,6 @@ class MochaFactory {
     };
 
     const presetReporter = opts.reporter || config.reporter;
-    
     // use standard reporter
     if (!presetReporter) {
       mocha.reporter(reporter, opts);


### PR DESCRIPTION
## Motivation/Description of the PR
- If an array of cookies gets passed to `setCookie` and Playwright is being used as the helper, it fails because the helper spreads the cookies when calling the browser context method i.e. `this.browserContext.addCookies(...cookie)` when Playwright is expecting an array i.e. `this.browserContext.addCookies(cookie)`. 

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [X] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [X] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [X] Tests have been added
- [X]  Documentation has been added (Run `npm run docs`)
- [X] Lint checking (Run `npm run lint`)
- [X] Local tests are passed (Run `npm test`)
