### PR TITLE
Rearranged typeof check to handle null parameter

### DIFF
--- a/lib/step.js
+++ b/lib/step.js
@@ -112,10 +112,10 @@ class Step {
         return `${arg}`;
       } else if (arg instanceof Secret) {
         return '*****';
-      } else if (arg.toString && arg.toString() !== '[object Object]') {
-        return arg.toString();
       } else if (typeof arg === 'object') {
         return JSON.stringify(arg);
+      } else if (arg.toString && arg.toString() !== '[object Object]') {
+        return arg.toString();
       }
       return arg;
     }).join(', ');

--- a/lib/step.js
+++ b/lib/step.js
@@ -95,10 +95,10 @@ class Step {
 
   /** @return {string} */
   humanizeArgs() {
-    if ( !args ) {
-      return '';
-    }
     return this.args.map((arg) => {
+      if ( !arg ) {
+        return '';
+      }
       if (typeof arg === 'string') {
         return `"${arg}"`;
       }

--- a/lib/step.js
+++ b/lib/step.js
@@ -95,6 +95,9 @@ class Step {
 
   /** @return {string} */
   humanizeArgs() {
+    if ( !args ) {
+      return '';
+    }
     return this.args.map((arg) => {
       if (typeof arg === 'string') {
         return `"${arg}"`;
@@ -112,10 +115,10 @@ class Step {
         return `${arg}`;
       } else if (arg instanceof Secret) {
         return '*****';
-      } else if (typeof arg === 'object') {
-        return JSON.stringify(arg);
       } else if (arg.toString && arg.toString() !== '[object Object]') {
         return arg.toString();
+      } else if (typeof arg === 'object') {
+        return JSON.stringify(arg);
       }
       return arg;
     }).join(', ');


### PR DESCRIPTION
Error:
Cannot read property 'toString' of null
  typeError: Cannot read property 'toString' of null
      at G:\CodeceptJS-Test\node_modules\codeceptjs\lib\step.js:115:22

Solution: Rearranged typeof check to handle crash when helper method is called with null parameter.

## Motivation/Description of the PR
- Resolves #2493 .

Applicable helpers:

- [x] WebDriver
- [x] Puppeteer
- [x] Nightmare
- [x] REST
- [x] FileHelper
- [x] Appium
- [x] Protractor
- [x] TestCafe
- [x] Playwright

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
