### PR TITLE
Fix typo in locators docs section

### DIFF
--- a/docs/react.md
+++ b/docs/react.md
@@ -64,6 +64,6 @@ I.seeElement({ react: 't', props: { title: 'Clicked' }});
 
 To find React element names and props in a tree use [React DevTools](https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi) extension.
 
-> Turn off minifcation for application builds otherwise component names will be uglified as well
+> Turn off minification for application builds otherwise component names will be uglified as well
 
 React locators work via [resq](https://github.com/baruchvlz/resq) library, which handles React 16 and above.


### PR DESCRIPTION
## Motivation/Description of the PR
Just a fix for typo in documentation - `minifcation` -> `minification`

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [x] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
