### PR TITLE
Improve error logging for screenshotOnFail

### DIFF
--- a/lib/plugin/screenshotOnFail.js
+++ b/lib/plugin/screenshotOnFail.js
@@ -86,7 +86,7 @@ module.exports = function (config) {
       } else {
         fileName += '.failed.png';
       }
-      output.plugin('screenshotOnFail', 'Test failed, saving screenshot');
+      output.plugin('screenshotOnFail', 'Test failed, try to save a screenshot');
 
       try {
         if (options.reportDir) {
@@ -107,6 +107,7 @@ module.exports = function (config) {
           allureReporter.addAttachment('Last Seen Screenshot', fs.readFileSync(path.join(global.output_dir, fileName)), 'image/png');
         }
       } catch (err) {
+        output.plugin(err);
         if (
           err
           && err.type


### PR DESCRIPTION
## Motivation/Description of the PR

Log general error.

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [x] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [x] :nail_care: Polish code
