### PR TITLE
fix(testcafe): fix debug in grabAttributeFrom method

### DIFF
--- a/lib/helper/TestCafe.js
+++ b/lib/helper/TestCafe.js
@@ -834,7 +834,7 @@ class TestCafe extends Helper {
     assertElementExists(sel);
     const attrs = await this.grabAttributeFromAll(locator, attr);
     if (attrs.length > 1) {
-      this.debugSelection('GrabAttribute', `Using first element out of ${attrs.length}`);
+      this.debugSection('GrabAttribute', `Using first element out of ${attrs.length}`);
     }
 
     return attrs[0];


### PR DESCRIPTION
## Motivation/Description of the PR

I tried the beta of codeceptjs and I got an error on the grabAttributeFrom.

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [x] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
