### PR TITLE
feat(Puppeteer): Wait lazy loading elements correctly

### DIFF
--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -192,6 +192,7 @@ class Puppeteer extends Helper {
       manualStart: false,
       getPageTimeout: 30000,
       waitForNavigation: 'load',
+      waitForLazyLoading: ['domcontentloaded'],
       restart: true,
       keepCookies: false,
       keepBrowserState: false,
@@ -590,7 +591,38 @@ class Puppeteer extends Helper {
       }
     }
 
-    await this.page.goto(url, { waitUntil: this.options.waitForNavigation });
+    let stopWaitLoading = null;
+    const stopPromise = new Promise(x => stopWaitLoading = x);
+
+    const attachedFrames = {};
+
+    this.page.on('frameattached', async (frame) => {
+      if (!Object.keys(attachedFrames).includes(frame._id)) {
+        attachedFrames[frame._id] = {
+          frame,
+          isMainFrame: !frame._parentFrame,
+        };
+        if (frame._parentFrame) {
+          attachedFrames[frame._parentFrame._id] = {
+            frame: frame._parentFrame,
+            isMainFrame: true,
+          };
+        }
+      }
+    });
+
+    this.page._client.on('Page.frameStoppedLoading', (frame) => {
+      attachedFrames[frame.frameId].stopped = true;
+      if (attachedFrames[frame.frameId].isMainFrame) {
+        const isFired = checkLifecycle.call(this, attachedFrames[frame.frameId].frame, this.options.waitForNavigation);
+        if (isFired) return stopWaitLoading();
+      }
+    });
+
+    await Promise.race([
+      this.page.goto(url, { waitUntil: this.options.waitForNavigation }),
+      stopPromise,
+    ]);
 
     const performanceTiming = JSON.parse(await this.page.evaluate(() => JSON.stringify(window.performance.timing)));
 
@@ -2539,4 +2571,23 @@ function getNormalizedKey(key) {
     return keyDefinitionMap[normalizedKey];
   }
   return normalizedKey;
+}
+
+const lifecycleEvents = {
+  load: 'load',
+  domcontentloaded: 'DOMContentLoaded',
+  networkidle0: 'networkIdle',
+  networkidle2: 'networkAlmostIdle',
+};
+
+function checkLifecycle(frame, lifecycle) {
+  const expectedLifecycle = typeof lifecycle === 'string' ? [lifecycle] : lifecycle;
+
+  for (const event of expectedLifecycle) {
+    if (!frame._lifecycleEvents.has(lifecycleEvents[event.toLowerCase()])) return false;
+  }
+  for (const child of frame.childFrames()) {
+    if (!checkLifecycle(child, this.options.waitForLazyLoading)) return false;
+  }
+  return true;
 }


### PR DESCRIPTION
## Motivation/Description of the PR
- Description of this PR, which problem it solves
- Resolves #issueId (if applicable).

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
