### PR TITLE
Save feature opts in suite

### DIFF
--- a/lib/ui.js
+++ b/lib/ui.js
@@ -99,6 +99,7 @@ module.exports = function (suite) {
 
       const suite = Suite.create(suites[0], title);
       if (!opts) opts = {};
+      suite.opts = opts;
       suite.timeout(0);
 
       if (opts.retries) suite.retries(opts.retries);


### PR DESCRIPTION
## Motivation/Description of the PR

For our allure integration we want to add some common fields just one time for suite.

```
Feature('Suite title', { allureLabels: { component: 'auth' } })

Scenario('Scenarion one title', { allureLabels: { package: 'package1' } })

Scenario('Scenarion two title', { allureLabels: { package: 'package2' } })
```

`component auth` is common for several Scenarios, and we dont want to copypaste it for every test.

Right now it is not possible to get `component auth` inside our allure plugin. With this pr it will be possible.
