### PR TITLE
Fix: Using Dynamic Configs Cuts WaitForTimeout by 1000 Each Time

### DIFF
--- a/lib/listener/config.js
+++ b/lib/listener/config.js
@@ -16,6 +16,11 @@ module.exports = function () {
     event.dispatcher.on(event[type].before, (context = {}) => {
       function updateHelperConfig(helper, config) {
         const oldConfig = { ...helper.options };
+        if (['WebDriver', 'Appium', 'Protractor'].includes(helper.constructor.name)) {
+          // Allows next helper._setConfig() conversion back from ms to sec
+          oldConfig.waitForTimeout *= 1000;
+        }
+
         try {
           helper._setConfig(deepMerge(deepClone(oldConfig), config));
           debug(`[${ucfirst(type)} Config] ${helper.constructor.name} ${JSON.stringify(config)}`);

--- a/test/acceptance/config_test.js
+++ b/test/acceptance/config_test.js
@@ -37,3 +37,18 @@ Scenario('change config 6 @WebDriverIO @Puppeteer @Playwright @Protractor @Night
   await new Promise(r => setTimeout(r, 50));
   return { url: 'https://github.com' };
 });
+
+const assert = require('assert');
+const webDriver = require('../codecept/lib/container').helpers('WebDriver');
+
+Scenario('Check custom waitForTimeout @WebDriverIO', () => {
+  assert.strictEqual(webDriver.options.waitForTimeout, 15);
+}).config({ waitForTimeout: 15000 });
+
+Scenario('Check default waitForTimeout @WebDriverIO', () => {
+  assert.strictEqual(webDriver.options.waitForTimeout, 1); // Check that previous scenario reset the timeout when finished
+});
+
+Scenario('Check that default waitForTimeout is still set @WebDriverIO', () => {
+  assert.strictEqual(webDriver.options.waitForTimeout, 1);
+});

--- a/test/acceptance/config_test.js
+++ b/test/acceptance/config_test.js
@@ -39,7 +39,14 @@ Scenario('change config 6 @WebDriverIO @Puppeteer @Playwright @Protractor @Night
 });
 
 const assert = require('assert');
-const webDriver = require('../codecept/lib/container').helpers('WebDriver');
+
+let container;
+try {
+  container = require('../codecept/lib/container'); // Tests started over docker-compose (e.g. WebDriver)
+} catch (error) {
+  container = require('../../lib/container'); // Tests started in non-docker env (e.g. Playwright)
+}
+const webDriver = container.helpers('WebDriver');
 
 Scenario('Check custom waitForTimeout @WebDriverIO', () => {
   assert.strictEqual(webDriver.options.waitForTimeout, 15);


### PR DESCRIPTION
## Motivation/Description of the PR
- Solves cutting of `waitForTimeout` in scenario with dynamic config.
I considered fixing in helper (WebDriver/Appium/Protractor) instead of fix in listener, by skipping `config.waitForTimeout /= 1000;` if `waitForTimeout` from original config matches current value * 1000. But the current fix in listener IMHO looks better.  
The fix seems to be needed for WebDriver/Appium/Protractor only. Other helpers don't convert ms to sec in `_setConfig()`
- Resolves #1995 

Applicable helpers:

- [x] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [x] Appium
- [x] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [x] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
