### PR TITLE
Adding code to fix force click and ignore HTTPS errors in playwright

### DIFF
--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -543,7 +543,7 @@ class Playwright extends Helper {
     this.browser.on('targetchanged', (target) => {
       this.debugSection('Url', target.url());
     });
-    this.browserContext = await this.browser.newContext({ ignoreHTTPSErrors :this.options.ignoreHTTPSErrors,acceptDownloads: true, ...this.options.emulate });//Adding the HTTPSError ignore in the context so that we can ignore those errors
+    this.browserContext = await this.browser.newContext({ ignoreHTTPSErrors: this.options.ignoreHTTPSErrors,acceptDownloads: true, ...this.options.emulate });//Adding the HTTPSError ignore in the context so that we can ignore those errors
 
     const existingPages = await this.browserContext.pages();
 

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -543,7 +543,7 @@ class Playwright extends Helper {
     this.browser.on('targetchanged', (target) => {
       this.debugSection('Url', target.url());
     });
-    this.browserContext = await this.browser.newContext({ ignoreHTTPSErrors :this.options.ignoreSSLErrors,acceptDownloads: true, ...this.options.emulate });//Adding the HTTPSError ignore in the context so that we can ignore those errors
+    this.browserContext = await this.browser.newContext({ ignoreHTTPSErrors :this.options.ignoreHTTPSErrors,acceptDownloads: true, ...this.options.emulate });//Adding the HTTPSError ignore in the context so that we can ignore those errors
 
     const existingPages = await this.browserContext.pages();
 

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -234,6 +234,7 @@ class Playwright extends Helper {
       keepBrowserState: false,
       show: false,
       defaultPopupAction: 'accept',
+      ignoreHTTPSErrors: false, //Adding it here o that context can be set up to ignore the SSL errors
     };
 
     config = Object.assign(defaults, config);
@@ -542,7 +543,7 @@ class Playwright extends Helper {
     this.browser.on('targetchanged', (target) => {
       this.debugSection('Url', target.url());
     });
-    this.browserContext = await this.browser.newContext({ acceptDownloads: true, ...this.options.emulate });
+    this.browserContext = await this.browser.newContext({ ignoreHTTPSErrors :this.options.ignoreSSLErrors,acceptDownloads: true, ...this.options.emulate });//Adding the HTTPSError ignore in the context so that we can ignore those errors
 
     const existingPages = await this.browserContext.pages();
 
@@ -2100,7 +2101,14 @@ async function proceedClick(locator, context = null, options = {}) {
   } else {
     assertElementExists(els, locator, 'Clickable element');
   }
-  await els[0].click(options);
+  /*
+    using the force true options itself but instead dispatching a click
+  */
+  if(options.force){
+    await els[0].dispatchEvent('click');
+  }else{
+    await els[0].click(options);
+  }
   const promises = [];
   if (options.waitForNavigation) {
     promises.push(this.waitForNavigation());

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "mocha-parallel-tests": "^2.3.0",
     "nightmare": "^3.0.2",
     "nodemon": "^1.19.4",
-    "playwright": "^1.1.1",
+    "playwright": "^1.3.0",
     "protractor": "^5.4.4",
     "puppeteer": "^4.0.0",
     "qrcode-terminal": "^0.12.0",


### PR DESCRIPTION
## Motivation/Description of the PR
 I am exploring playwright as an option in my organization and SSL certificate errors plus forceClick fix was one of the functions that we needed to fix so that we could proceed further

- Description of this PR, which problem it solves
This pull request resolves both the issues. Note the description of playwright configuration has to be updated to include ignoreHTTPSErrors 

- Resolves #issueId (if applicable).
None applicable

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [-] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [-] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added (Not applicable)
- [ ] Documentation has been added (Run `npm run docs`) (Don't know about this but I added comments)
- [ ] Lint checking (Run `npm run lint`) 
- [-] Local tests are passed (Run `npm test`) Yes they passed only for file system it failed but the contents seemed similar
