### PR TITLE
add warning await within()

### DIFF
--- a/docs/basics.md
+++ b/docs/basics.md
@@ -637,6 +637,7 @@ I.see('There were problems creating your account.');
 ```
 
 > ⚠ `within` can cause problems when used incorrectly. If you see a weird behavior of a test try to refactor it to not use `within`. It is recommended to keep within for simplest cases when possible.
+> Since `within` returns a Promise, it may be necessary to `await` the result even when you're not intending to use the return value.
 
 `within` can also work with IFrames. A special `frame` locator is required to locate the iframe and get into its context.
 


### PR DESCRIPTION
## Motivation/Description of the PR
- Description of this PR, which problem it solves
We ran into issues using the within() function. It seems that when running with Selenoid, the within() step would never complete and need to be aborted manually. However this was fixed easily by adding an `await` to our within function call (we were using async Webdriver methods inside the `within` call). I thought adding a line about this to the existing warning about `within` in the docs might help, though I'm open to other ways of doing this!

- Resolves #issueId (if applicable).
None I think
Applicable helpers:

- [x] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [x] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [x] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
