### PR TITLE
fix(shadow): Fix shadow support in locator.js

### DIFF
--- a/docs/locators.md
+++ b/docs/locators.md
@@ -17,7 +17,7 @@ CodeceptJS provides flexible strategies for locating elements:
 
 Most methods in CodeceptJS use locators which can be either a string or an object.
 
-If the locator is an object, it should have a single element, with the key signifying the locator type (`id`, `name`, `css`, `xpath`, `link`, `react`, or `class`) and the value being the locator itself. This is called a "strict" locator.
+If the locator is an object, it should have a single element, with the key signifying the locator type (`id`, `name`, `css`, `xpath`, `link`, `react`, `class` or `shadow`) and the value being the locator itself. This is called a "strict" locator.
 
 Examples:
 

--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -2158,7 +2158,9 @@ class WebDriver extends Helper {
       }, aSec * 1000, `element (${new Locator(locator)}) still not visible after ${aSec} sec`);
     }
     return this.browser.waitUntil(async () => {
-      const res = await this.$$(withStrictLocator(locator));
+      const res = (this._isShadowLocator(locator))
+        ? await this._locate(withStrictLocator(locator))
+        : await this.$$(withStrictLocator(locator));
       if (!res || res.length === 0) return false;
       const selected = await forEachAsync(res, async el => el.isDisplayed());
       if (Array.isArray(selected)) {

--- a/lib/locator.js
+++ b/lib/locator.js
@@ -353,7 +353,8 @@ function isXPath(locator) {
 }
 
 function isShadow(locator) {
-  return locator[0] === '{';
+  const hasShadowProperty = (locator.shadow !== undefined) && (Object.keys(locator).length === 1);
+  return hasShadowProperty;
 }
 
 function isXPathStartingWithRoundBrackets(locator) {

--- a/lib/locator.js
+++ b/lib/locator.js
@@ -3,7 +3,7 @@ const { sprintf } = require('sprintf-js');
 
 const { xpathLocator } = require('./utils');
 
-const locatorTypes = ['css', 'by', 'xpath', 'id', 'name', 'fuzzy', 'frame'];
+const locatorTypes = ['css', 'by', 'xpath', 'id', 'name', 'fuzzy', 'frame', 'shadow'];
 /** @class */
 class Locator {
   /**
@@ -43,6 +43,9 @@ class Locator {
     if (isXPath(locator)) {
       this.type = 'xpath';
     }
+    if (isShadow(locator)) {
+      this.type = 'shadow';
+    }
 
     Locator.filters.forEach(f => f(locator, this));
   }
@@ -61,6 +64,8 @@ class Locator {
         return `[name="${this.value}"]`;
       case 'fuzzy':
         return this.value;
+      case 'shadow':
+        return { shadow: this.value };
     }
     return this.value;
   }
@@ -79,6 +84,10 @@ class Locator {
 
   isFuzzy() {
     return this.type === 'fuzzy';
+  }
+
+  isShadow() {
+    return this.type === 'shadow';
   }
 
   isFrame() {
@@ -165,6 +174,7 @@ class Locator {
   at(position) {
     if (position < 0) {
       position++; // -1 points to the last element
+      // @ts-ignore
       position = `last()-${Math.abs(position)}`;
     }
     if (position === 0) {
@@ -340,6 +350,10 @@ function isAccessibility(locator) {
 function isXPath(locator) {
   const trimmed = locator.replace(/^\(+/, '').substr(0, 2);
   return trimmed === '//' || trimmed === './';
+}
+
+function isShadow(locator) {
+  return locator[0] === '{';
 }
 
 function isXPathStartingWithRoundBrackets(locator) {

--- a/test/unit/locator_test.js
+++ b/test/unit/locator_test.js
@@ -86,10 +86,10 @@ describe('Locator', () => {
       });
 
       it('should create shadow locator', () => {
-        const l = new Locator({ shadow: '["my-app", "recipe-hello-binding", "ui-input", "input.input"]' });
+        const l = new Locator({ shadow: ['my-app', 'recipe-hello-binding', 'ui-input', 'input.input'] });
         expect(l.type).to.equal('shadow');
-        expect(l.value).to.equal('["my-app", "recipe-hello-binding", "ui-input", "input.input"]');
-        expect(l.toString()).to.equal('{shadow: ["my-app", "recipe-hello-binding", "ui-input", "input.input"]}');
+        expect(l.value).to.deep.equal(['my-app', 'recipe-hello-binding', 'ui-input', 'input.input']);
+        expect(l.toString()).to.equal('{shadow: my-app,recipe-hello-binding,ui-input,input.input}');
       });
 
       it('should create described custom default type locator', () => {

--- a/test/unit/locator_test.js
+++ b/test/unit/locator_test.js
@@ -86,10 +86,10 @@ describe('Locator', () => {
       });
 
       it('should create shadow locator', () => {
-        const l = new Locator('{ shadow: ["my-app", "recipe-hello-binding", "ui-input", "input.input"] }');
+        const l = new Locator({ shadow: '["my-app", "recipe-hello-binding", "ui-input", "input.input"]' });
         expect(l.type).to.equal('shadow');
-        expect(l.value).to.equal('{ shadow: ["my-app", "recipe-hello-binding", "ui-input", "input.input"] }');
-        expect(l.toString()).to.equal('{ shadow: ["my-app", "recipe-hello-binding", "ui-input", "input.input"] }');
+        expect(l.value).to.equal('["my-app", "recipe-hello-binding", "ui-input", "input.input"]');
+        expect(l.toString()).to.equal('{shadow: ["my-app", "recipe-hello-binding", "ui-input", "input.input"]}');
       });
 
       it('should create described custom default type locator', () => {

--- a/test/unit/locator_test.js
+++ b/test/unit/locator_test.js
@@ -85,6 +85,13 @@ describe('Locator', () => {
         expect(l.toString()).to.equal('foo');
       });
 
+      it('should create shadow locator', () => {
+        const l = new Locator('{ shadow: ["my-app", "recipe-hello-binding", "ui-input", "input.input"] }');
+        expect(l.type).to.equal('shadow');
+        expect(l.value).to.equal('{ shadow: ["my-app", "recipe-hello-binding", "ui-input", "input.input"] }');
+        expect(l.toString()).to.equal('{ shadow: ["my-app", "recipe-hello-binding", "ui-input", "input.input"] }');
+      });
+
       it('should create described custom default type locator', () => {
         const l = new Locator('foo', 'defaultLocator');
         expect(l.type).to.equal('defaultLocator');


### PR DESCRIPTION
## Motivation/Description of the PR
- We need to use scrollTo method for scrolling on shadow elements - it didnt work correctly for this case.
- We also use resemble helper for visual testing, which uses webdriver methods and here was also problem with shadow selectors. This PR resolves both.
- Resolves https://github.com/codeceptjs/CodeceptJS/issues/2585 

Applicable helpers:

- [ ] WebDriver


## Type of change

- [x] :bug: Bug fix

## Checklist:

- [ok] Tests have been added
- [ok] Documentation has been added (Run `npm run docs`)
- [ok] Lint checking (Run `npm run lint`)
- [ok] Local tests are passed (Run `npm test`)
