### PR TITLE
Fixed error handling in Scenario.js

### DIFF
--- a/lib/scenario.js
+++ b/lib/scenario.js
@@ -67,21 +67,26 @@ module.exports.test = (test) => {
         });
       };
 
+      let injectedArguments;
       try {
-        testFn.call(test, getInjectedArguments(testFn, test)).then(() => {
-          // Promise.resolve().then(() => testFn.call(test, getInjectedArguments(testFn, test))).then(() => {
-          recorder.add('fire test.passed', () => {
-            event.emit(event.test.passed, test);
-            event.emit(event.test.finished, test);
-          });
-          recorder.add('finish test', () => done());
-          recorder.catch();
-        }).catch(catchError);
+        injectedArguments = getInjectedArguments(testFn, test);
       } catch (e) {
         catchError(e);
+        return;
       }
+
+      testFn.call(test, injectedArguments).then(() => {
+        // Promise.resolve().then(() => testFn.call(test, getInjectedArguments(testFn, test))).then(() => {
+        recorder.add('fire test.passed', () => {
+          event.emit(event.test.passed, test);
+          event.emit(event.test.finished, test);
+        });
+        recorder.add('finish test', () => done());
+        recorder.catch();
+      }).catch(catchError);
       return;
     }
+
     try {
       event.emit(event.test.started, test);
       testFn.call(test, getInjectedArguments(testFn, test));

--- a/lib/scenario.js
+++ b/lib/scenario.js
@@ -54,7 +54,7 @@ module.exports.test = (test) => {
 
     if (isAsyncFunction(testFn)) {
       event.emit(event.test.started, test);
-      testFn.call(test, getInjectedArguments(testFn, test)).then(() => {
+      Promise.resolve().then(() => testFn.call(test, getInjectedArguments(testFn, test))).then(() => {
         recorder.add('fire test.passed', () => {
           event.emit(event.test.passed, test);
           event.emit(event.test.finished, test);

--- a/lib/scenario.js
+++ b/lib/scenario.js
@@ -54,14 +54,8 @@ module.exports.test = (test) => {
 
     if (isAsyncFunction(testFn)) {
       event.emit(event.test.started, test);
-      Promise.resolve().then(() => testFn.call(test, getInjectedArguments(testFn, test))).then(() => {
-        recorder.add('fire test.passed', () => {
-          event.emit(event.test.passed, test);
-          event.emit(event.test.finished, test);
-        });
-        recorder.add('finish test', () => done());
-        recorder.catch();
-      }).catch((e) => {
+
+      const catchError = e => {
         recorder.throw(e);
         recorder.catch((e) => {
           const err = (recorder.getAsyncErr() === null) ? e : recorder.getAsyncErr();
@@ -71,7 +65,21 @@ module.exports.test = (test) => {
           event.emit(event.test.finished, test);
           recorder.add(() => done(err));
         });
-      });
+      };
+
+      try {
+        testFn.call(test, getInjectedArguments(testFn, test)).then(() => {
+          // Promise.resolve().then(() => testFn.call(test, getInjectedArguments(testFn, test))).then(() => {
+          recorder.add('fire test.passed', () => {
+            event.emit(event.test.passed, test);
+            event.emit(event.test.finished, test);
+          });
+          recorder.add('finish test', () => done());
+          recorder.catch();
+        }).catch(catchError);
+      } catch (e) {
+        catchError(e);
+      }
       return;
     }
     try {

--- a/lib/scenario.js
+++ b/lib/scenario.js
@@ -76,7 +76,6 @@ module.exports.test = (test) => {
       }
 
       testFn.call(test, injectedArguments).then(() => {
-        // Promise.resolve().then(() => testFn.call(test, getInjectedArguments(testFn, test))).then(() => {
         recorder.add('fire test.passed', () => {
           event.emit(event.test.passed, test);
           event.emit(event.test.finished, test);

--- a/test/unit/bdd_test.js
+++ b/test/unit/bdd_test.js
@@ -217,8 +217,9 @@ describe('BDD', () => {
     const suite = run(text);
     const done = () => { };
     suite._beforeEach.forEach(hook => hook.run(done));
-    suite.tests[0].fn(done);
-    assert.equal(2, sum);
+    suite.tests[0].fn(() => {
+      assert.equal(2, sum);
+    });
   });
 
   it('should execute scenario outlines', (done) => {

--- a/test/unit/bdd_test.js
+++ b/test/unit/bdd_test.js
@@ -217,9 +217,8 @@ describe('BDD', () => {
     const suite = run(text);
     const done = () => { };
     suite._beforeEach.forEach(hook => hook.run(done));
-    suite.tests[0].fn(() => {
-      assert.equal(2, sum);
-    });
+    suite.tests[0].fn(done);
+    assert.equal(2, sum);
   });
 
   it('should execute scenario outlines', (done) => {


### PR DESCRIPTION
## Motivation/Description of the PR
This PR will fix next behavior:
1. Add to codeceptjs.config.js some Include with incorrect name of unexisting file like that:
```
    include: {
      someObject: 'unexisted-file.js',
    },
```
2. Use this object in Scenario **without any Data()** methods (this is important):
```
Scenario('my scenario', async ({ I, someObject }) => {
  await someObject.method()
})
```
3. Got an error - this is OK
4. Got an **exit code 0** - this is the problem.

Also, if test looks like this:
```
Scenario('my scenario', ({ I, someObject }) => {
  someObject.method()
})
```
We got **exit code 1**, what is ok.

The problem is in **getInjectedArguments**, which error doesn't throw into `recorder.catch` and `recorder.throw`.

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
