### PR TITLE
move all unit tests to expect chai lib

### DIFF
--- a/test/unit/actor_test.js
+++ b/test/unit/actor_test.js
@@ -1,12 +1,10 @@
 const path = require('path');
 const expect = require('expect');
-const sinon = require('sinon');
+
 const actor = require('../../lib/actor');
 const container = require('../../lib/container');
 const recorder = require('../../lib/recorder');
 const event = require('../../lib/event');
-const Step = require('../../lib/step');
-const { MetaStep } = require('../../lib/step');
 
 global.codecept_dir = path.join(__dirname, '/..');
 let I;

--- a/test/unit/assert/empty_test.js
+++ b/test/unit/assert/empty_test.js
@@ -1,6 +1,6 @@
-const chai = require('chai');
+const { expect } = require('chai');
 
-const Assertion = require('../../../lib/assert/empty').Assertion;
+const { Assertion } = require('../../../lib/assert/empty');
 const AssertionError = require('../../../lib/assert/error');
 
 let empty;
@@ -12,23 +12,23 @@ describe('empty assertion', () => {
 
   it('should check for something to be empty', () => {
     empty.assert(null);
-    chai.expect(() => empty.negate(null)).to.throw(AssertionError);
+    expect(() => empty.negate(null)).to.throw(AssertionError);
   });
 
   it('should check for something not to be empty', () => {
     empty.negate('something');
-    chai.expect(() => empty.assert('something')).to.throw(AssertionError);
+    expect(() => empty.assert('something')).to.throw(AssertionError);
   });
 
   it('should provide nice assert error message', () => {
     empty.params.value = '/nothing';
     const err = empty.getFailedAssertion();
-    err.inspect().should.equal("expected web page '/nothing' to be empty");
+    expect(err.inspect()).to.equal("expected web page '/nothing' to be empty");
   });
 
   it('should provide nice negate error message', () => {
     empty.params.value = '/nothing';
     const err = empty.getFailedNegation();
-    err.inspect().should.equal("expected web page '/nothing' not to be empty");
+    expect(err.inspect()).to.equal("expected web page '/nothing' not to be empty");
   });
 });

--- a/test/unit/assert/equal_test.js
+++ b/test/unit/assert/equal_test.js
@@ -1,6 +1,6 @@
-const chai = require('chai');
+const { expect } = require('chai');
 
-const Assertion = require('../../../lib/assert/equal').Assertion;
+const { Assertion } = require('../../../lib/assert/equal');
 const AssertionError = require('../../../lib/assert/error');
 
 let equal;
@@ -12,25 +12,25 @@ describe('equal assertion', () => {
 
   it('should check for equality', () => {
     equal.assert('hello', 'hello');
-    chai.expect(() => equal.negate('hello', 'hello')).to.throw(AssertionError);
+    expect(() => equal.negate('hello', 'hello')).to.throw(AssertionError);
   });
 
   it('should check for something not to be equal', () => {
     equal.negate('hello', 'hi');
-    chai.expect(() => equal.assert('hello', 'hi')).to.throw(AssertionError);
+    expect(() => equal.assert('hello', 'hi')).to.throw(AssertionError);
   });
 
   it('should provide nice assert error message', () => {
     equal.params.expected = 'hello';
     equal.params.actual = 'hi';
     const err = equal.getFailedAssertion();
-    err.inspect().should.equal('expected contents of webpage "hello" to equal "hi"');
+    expect(err.inspect()).to.equal('expected contents of webpage "hello" to equal "hi"');
   });
 
   it('should provide nice negate error message', () => {
     equal.params.expected = 'hello';
     equal.params.actual = 'hello';
     const err = equal.getFailedNegation();
-    err.inspect().should.equal('expected contents of webpage "hello" not to equal "hello"');
+    expect(err.inspect()).to.equal('expected contents of webpage "hello" not to equal "hello"');
   });
 });

--- a/test/unit/assert/include_test.js
+++ b/test/unit/assert/include_test.js
@@ -1,4 +1,4 @@
-const chai = require('chai');
+const { expect } = require('chai');
 
 const Assertion = require('../../../lib/assert/include').Assertion;
 const AssertionError = require('../../../lib/assert/error');
@@ -12,25 +12,25 @@ describe('equal assertion', () => {
 
   it('should check for inclusion', () => {
     equal.assert('h', 'hello');
-    chai.expect(() => equal.negate('h', 'hello')).to.throw(AssertionError);
+    expect(() => equal.negate('h', 'hello')).to.throw(AssertionError);
   });
 
   it('should check !include', () => {
     equal.negate('x', 'hello');
-    chai.expect(() => equal.assert('x', 'hello')).to.throw(AssertionError);
+    expect(() => equal.assert('x', 'hello')).to.throw(AssertionError);
   });
 
   it('should provide nice assert error message', () => {
     equal.params.needle = 'hello';
     equal.params.haystack = 'x';
     const err = equal.getFailedAssertion();
-    err.inspect().should.equal('expected contents of webpage to include "hello"');
+    expect(err.inspect()).to.equal('expected contents of webpage to include "hello"');
   });
 
   it('should provide nice negate error message', () => {
     equal.params.needle = 'hello';
     equal.params.haystack = 'h';
     const err = equal.getFailedNegation();
-    err.inspect().should.equal('expected contents of webpage not to include "hello"');
+    expect(err.inspect()).to.equal('expected contents of webpage not to include "hello"');
   });
 });

--- a/test/unit/assert_test.js
+++ b/test/unit/assert_test.js
@@ -1,4 +1,4 @@
-const chai = require('chai');
+const { expect } = require('chai');
 
 const Assertion = require('../../lib/assert');
 const AssertionError = require('../../lib/assert/error');
@@ -14,11 +14,11 @@ describe('Assertion', () => {
 
   it('should handle asserts', () => {
     assertion.assert(1, 1);
-    chai.expect(() => assertion.assert(1, 2)).to.throw(AssertionError);
+    expect(() => assertion.assert(1, 2)).to.throw(AssertionError);
   });
 
   it('should handle negative asserts', () => {
     assertion.negate(1, 2);
-    chai.expect(() => assertion.negate(1, 1)).to.throw(AssertionError);
+    expect(() => assertion.negate(1, 1)).to.throw(AssertionError);
   });
 });

--- a/test/unit/bdd_test.js
+++ b/test/unit/bdd_test.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+const { expect } = require('chai');
 const { Parser } = require('gherkin');
 const {
   Given,
@@ -45,18 +45,18 @@ describe('BDD', () => {
     // console.log('Feature', ast.feature);
     // console.log('Scenario', ast.feature.children);
     // console.log('Steps', ast.feature.children[0].steps[0]);
-    assert.ok(ast.feature);
-    assert.ok(ast.feature.children);
-    assert.ok(ast.feature.children[0].steps);
+    expect(ast.feature).is.ok;
+    expect(ast.feature.children).is.ok;
+    expect(ast.feature.children[0].steps).is.ok;
   });
 
   it('should load step definitions', () => {
     Given('I am a bird', () => 1);
     When('I fly over ocean', () => 2);
     Then(/I see (.*?)/, () => 3);
-    assert.equal(1, matchStep('I am a bird')());
-    assert.equal(3, matchStep('I see ocean')());
-    assert.equal(3, matchStep('I see world')());
+    expect(1).is.equal(matchStep('I am a bird')());
+    expect(3).is.equal(matchStep('I see ocean')());
+    expect(3).is.equal(matchStep('I see world')());
   });
 
   it('should contain tags', async () => {
@@ -65,8 +65,8 @@ describe('BDD', () => {
     When('I go to checkout process', () => sum += 10);
     const suite = run(text);
     suite.tests[0].fn(() => {});
-    assert.ok(suite.tests[0].tags);
-    assert.equal('@super', suite.tests[0].tags[0]);
+    expect(suite.tests[0].tags).is.ok;
+    expect('@super').is.equal(suite.tests[0].tags[0]);
   });
 
   it('should load step definitions', (done) => {
@@ -74,10 +74,10 @@ describe('BDD', () => {
     Given(/I have product with (\d+) price/, param => sum += parseInt(param, 10));
     When('I go to checkout process', () => sum += 10);
     const suite = run(text);
-    assert.equal('checkout process', suite.title);
+    expect('checkout process').is.equal(suite.title);
     suite.tests[0].fn(() => {
-      assert.ok(suite.tests[0].steps);
-      assert.equal(1610, sum);
+      expect(suite.tests[0].steps).is.ok;
+      expect(1610).is.equal(sum);
       done();
     });
   });
@@ -85,13 +85,13 @@ describe('BDD', () => {
   it('should allow failed steps', (done) => {
     let sum = 0;
     Given(/I have product with (\d+) price/, param => sum += parseInt(param, 10));
-    When('I go to checkout process', () => assert(false));
+    When('I go to checkout process', () => expect(false).is.false);
     const suite = run(text);
-    assert.equal('checkout process', suite.title);
+    expect('checkout process').is.equal(suite.title);
     let errored = false;
     suite.tests[0].fn((err) => {
       errored = !!err;
-      assert(errored);
+      expect(errored).is.exist;
       done();
     });
   });
@@ -106,10 +106,10 @@ describe('BDD', () => {
       });
     });
     const suite = run(text);
-    assert.equal('checkout process', suite.title);
+    expect('checkout process').is.equal(suite.title);
     suite.tests[0].fn(() => {
-      assert.ok(suite.tests[0].steps);
-      assert.equal(1610, sum);
+      expect(suite.tests[0].steps).is.ok;
+      expect(1610).is.equal(sum);
       done();
     });
   });
@@ -163,7 +163,7 @@ describe('BDD', () => {
   it('should match step with params', () => {
     Given('I am a {word}', param => param);
     const fn = matchStep('I am a bird');
-    assert.equal('bird', fn.params[0]);
+    expect('bird').is.equal(fn.params[0]);
   });
 
   it('should produce step events', (done) => {
@@ -192,13 +192,13 @@ describe('BDD', () => {
     Given('I have ${int} in my pocket', params => params[0]); // eslint-disable-line no-template-curly-in-string
     Given('I have also ${float} in my pocket', params => params[0]); // eslint-disable-line no-template-curly-in-string
     fn = matchStep('I am a bird');
-    assert.equal('bird', fn(fn.params));
+    expect('bird').is.equal(fn(fn.params));
     fn = matchStep('I have 2 wings and 2 eyes');
-    assert.equal(4, fn(fn.params));
+    expect(4).is.equal(fn(fn.params));
     fn = matchStep('I have $500 in my pocket');
-    assert.equal(500, fn(fn.params));
+    expect(500).is.equal(fn(fn.params));
     fn = matchStep('I have also $500.30 in my pocket');
-    assert.equal(500.30, fn(fn.params));
+    expect(500.30).is.equal(fn(fn.params));
   });
 
   it('should attach before hook for Background', () => {
@@ -218,7 +218,7 @@ describe('BDD', () => {
     const done = () => { };
     suite._beforeEach.forEach(hook => hook.run(done));
     suite.tests[0].fn(done);
-    assert.equal(2, sum);
+    expect(2).is.equal(sum);
   });
 
   it('should execute scenario outlines', (done) => {
@@ -256,18 +256,18 @@ describe('BDD', () => {
 
     const suite = run(text);
 
-    assert.ok(suite.tests[0].tags);
-    assert.deepEqual(['@awesome', '@cool', '@super'], suite.tests[0].tags);
-    assert.deepEqual(['@awesome', '@cool', '@super', '@exampleTag1', '@exampleTag2'], suite.tests[1].tags);
+    expect(suite.tests[0].tags).is.ok;
+    expect(['@awesome', '@cool', '@super']).is.deep.equal(suite.tests[0].tags);
+    expect(['@awesome', '@cool', '@super', '@exampleTag1', '@exampleTag2']).is.deep.equal(suite.tests[1].tags);
 
-    assert.equal(2, suite.tests.length);
+    expect(2).is.equal(suite.tests.length);
     suite.tests[0].fn(() => {
-      assert.equal(9, cart);
-      assert.equal(9, sum);
+      expect(9).is.equal(cart);
+      expect(9).is.equal(sum);
 
       suite.tests[1].fn(() => {
-        assert.equal(18, cart);
-        assert.equal(18, sum);
+        expect(18).is.equal(cart);
+        expect(18).is.equal(sum);
         done();
       });
     });
@@ -308,8 +308,8 @@ describe('BDD', () => {
       ['cookies', '12'],
     ];
     suite.tests[0].fn(() => {
-      assert.deepEqual(givenParsedRows.rawData, expectedParsedDataTable);
-      assert.deepEqual(thenParsedRows.rawData, expectedParsedDataTable);
+      expect(givenParsedRows.rawData).is.deep.equal(expectedParsedDataTable);
+      expect(thenParsedRows.rawData).is.deep.equal(expectedParsedDataTable);
       done();
     });
   });

--- a/test/unit/container_test.js
+++ b/test/unit/container_test.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+const { expect } = require('chai');
 const path = require('path');
 
 const FileSystem = require('../../lib/helper/FileSystem');
@@ -25,33 +25,33 @@ describe('Container', () => {
 
     it('should create empty translation', () => {
       container.create({});
-      container.translation().should.be.instanceOf(Translation);
-      container.translation().loaded.should.be.false;
-      container.translation().actionAliasFor('see').should.eql('see');
+      expect(container.translation()).to.be.instanceOf(Translation);
+      expect(container.translation().loaded).to.be.false;
+      expect(container.translation().actionAliasFor('see')).to.eql('see');
     });
 
     it('should create Russian translation', () => {
       container.create({ translation: 'ru-RU' });
-      container.translation().should.be.instanceOf(Translation);
-      container.translation().loaded.should.be.true;
-      container.translation().I.should.eql('Я');
-      container.translation().actionAliasFor('see').should.eql('вижу');
+      expect(container.translation()).to.be.instanceOf(Translation);
+      expect(container.translation().loaded).to.be.true;
+      expect(container.translation().I).to.eql('Я');
+      expect(container.translation().actionAliasFor('see')).to.eql('вижу');
     });
 
     it('should create Italian translation', () => {
       container.create({ translation: 'it-IT' });
-      container.translation().should.be.instanceOf(Translation);
-      container.translation().loaded.should.be.true;
-      container.translation().I.should.eql('io');
-      container.translation().value('contexts').Feature.should.eql('Caratteristica');
+      expect(container.translation()).to.be.instanceOf(Translation);
+      expect(container.translation().loaded).to.be.true;
+      expect(container.translation().I).to.eql('io');
+      expect(container.translation().value('contexts').Feature).to.eql('Caratteristica');
     });
 
     it('should create French translation', () => {
       container.create({ translation: 'fr-FR' });
-      container.translation().should.be.instanceOf(Translation);
-      container.translation().loaded.should.be.true;
-      container.translation().I.should.eql('Je');
-      container.translation().value('contexts').Feature.should.eql('Fonctionnalité');
+      expect(container.translation()).to.be.instanceOf(Translation);
+      expect(container.translation().loaded).to.be.true;
+      expect(container.translation().I).to.eql('Je');
+      expect(container.translation().value('contexts').Feature).to.eql('Fonctionnalité');
     });
   });
 
@@ -63,14 +63,14 @@ describe('Container', () => {
       });
     });
 
-    it('should return all helper with no args', () => container.helpers().should.have.keys('helper1', 'helper2'));
+    it('should return all helper with no args', () => expect(container.helpers()).to.have.keys('helper1', 'helper2'));
 
     it('should return helper by name', () => {
-      container.helpers('helper1').should.be.ok;
-      container.helpers('helper1').name.should.eql('hello');
-      container.helpers('helper2').should.be.ok;
-      container.helpers('helper2').name.should.eql('world');
-      assert.ok(!container.helpers('helper3'));
+      expect(container.helpers('helper1')).is.ok;
+      expect(container.helpers('helper1').name).to.eql('hello');
+      expect(container.helpers('helper2')).is.ok;
+      expect(container.helpers('helper2').name).to.eql('world');
+      expect(!container.helpers('helper3')).is.ok;
     });
   });
 
@@ -82,14 +82,14 @@ describe('Container', () => {
       });
     });
 
-    it('should return all support objects', () => container.support().should.have.keys('support1', 'support2'));
+    it('should return all support objects', () => expect(container.support()).to.have.keys('support1', 'support2'));
 
     it('should support object by name', () => {
-      container.support('support1').should.be.ok;
-      container.support('support1').name.should.eql('hello');
-      container.support('support2').should.be.ok;
-      container.support('support2').name.should.eql('world');
-      assert.ok(!container.support('support3'));
+      expect(container.support('support1')).is.ok;
+      expect(container.support('support1').name).to.eql('hello');
+      expect(container.support('support2')).is.ok;
+      expect(container.support('support2').name).to.eql('world');
+      expect(!container.support('support3')).is.ok;
     });
   });
 
@@ -101,14 +101,14 @@ describe('Container', () => {
       });
     });
 
-    it('should return all plugins', () => container.plugins().should.have.keys('plugin1', 'plugin2'));
+    it('should return all plugins', () => expect(container.plugins()).to.have.keys('plugin1', 'plugin2'));
 
     it('should get plugin by name', () => {
-      container.plugins('plugin1').should.be.ok;
-      container.plugins('plugin1').name.should.eql('hello');
-      container.plugins('plugin2').should.be.ok;
-      container.plugins('plugin2').name.should.eql('world');
-      assert.ok(!container.plugins('plugin3'));
+      expect(container.plugins('plugin1')).is.ok;
+      expect(container.plugins('plugin1').name).is.eql('hello');
+      expect(container.plugins('plugin2')).is.ok;
+      expect(container.plugins('plugin2').name).is.eql('world');
+      expect(!container.plugins('plugin3')).is.ok;
     });
   });
 
@@ -124,17 +124,17 @@ describe('Container', () => {
       };
       container.create(config);
       // custom helpers
-      assert.ok(container.helpers('MyHelper'));
-      container.helpers('MyHelper').method().should.eql('hello world');
+      expect(container.helpers('MyHelper')).is.ok;
+      expect(container.helpers('MyHelper').method()).to.eql('hello world');
 
       // built-in helpers
-      assert.ok(container.helpers('FileSystem'));
-      container.helpers('FileSystem').should.be.instanceOf(FileSystem);
+      expect(container.helpers('FileSystem')).is.ok;
+      expect(container.helpers('FileSystem')).to.be.instanceOf(FileSystem);
     });
 
     it('should always create I', () => {
       container.create({});
-      assert.ok(container.support('I'));
+      expect(container.support('I')).is.ok;
     });
 
     it('should load DI and return a reference to the module', () => {
@@ -144,7 +144,7 @@ describe('Container', () => {
         },
       });
       const dummyPage = require('../data/dummy_page');
-      container.support('dummyPage').should.be.eql(dummyPage);
+      expect(container.support('dummyPage')).is.eql(dummyPage);
     });
 
     it('should load I from path and execute _init', () => {
@@ -153,9 +153,9 @@ describe('Container', () => {
           I: './data/I',
         },
       });
-      assert.ok(container.support('I'));
-      container.support('I').should.include.keys('_init', 'doSomething');
-      assert(global.I_initialized);
+      expect(container.support('I')).is.ok;
+      expect(container.support('I')).to.include.keys('_init', 'doSomething');
+      expect(global.I_initialized).to.be.true;
     });
 
     it('should load DI includes provided as require paths', () => {
@@ -164,8 +164,8 @@ describe('Container', () => {
           dummyPage: './data/dummy_page',
         },
       });
-      assert.ok(container.support('dummyPage'));
-      container.support('dummyPage').should.include.keys('openDummyPage');
+      expect(container.support('dummyPage')).is.ok;
+      expect(container.support('dummyPage')).to.include.keys('openDummyPage');
     });
 
     it('should load DI and inject I into PO', () => {
@@ -174,10 +174,10 @@ describe('Container', () => {
           dummyPage: './data/dummy_page',
         },
       });
-      assert.ok(container.support('dummyPage'));
-      assert.ok(container.support('I'));
-      container.support('dummyPage').should.include.keys('openDummyPage');
-      container.support('dummyPage').getI().should.have.keys(Object.keys(container.support('I')));
+      expect(container.support('dummyPage')).is.ok;
+      expect(container.support('I')).is.ok;
+      expect(container.support('dummyPage')).to.include.keys('openDummyPage');
+      expect(container.support('dummyPage').getI()).to.have.keys(Object.keys(container.support('I')));
     });
 
     it('should load DI and inject custom I into PO', () => {
@@ -187,10 +187,10 @@ describe('Container', () => {
           I: './data/I',
         },
       });
-      assert.ok(container.support('dummyPage'));
-      assert.ok(container.support('I'));
-      container.support('dummyPage').should.include.keys('openDummyPage');
-      container.support('dummyPage').getI().should.include.keys(Object.keys(container.support('I')));
+      expect(container.support('dummyPage')).is.ok;
+      expect(container.support('I')).is.ok;
+      expect(container.support('dummyPage')).to.include.keys('openDummyPage');
+      expect(container.support('dummyPage').getI()).to.have.keys(Object.keys(container.support('I')));
     });
 
     it('should load DI includes provided as objects', () => {
@@ -201,8 +201,8 @@ describe('Container', () => {
           },
         },
       });
-      assert.ok(container.support('dummyPage'));
-      container.support('dummyPage').should.have.keys('openDummyPage');
+      expect(container.support('dummyPage')).is.ok;
+      expect(container.support('dummyPage')).to.include.keys('openDummyPage');
     });
 
     it('should load DI includes provided as objects', () => {
@@ -213,8 +213,8 @@ describe('Container', () => {
           },
         },
       });
-      assert.ok(container.support('dummyPage'));
-      container.support('dummyPage').should.have.keys('openDummyPage');
+      expect(container.support('dummyPage')).is.ok;
+      expect(container.support('dummyPage')).to.include.keys('openDummyPage');
     });
   });
 
@@ -231,19 +231,19 @@ describe('Container', () => {
           AnotherHelper: { method: () => 'executed' },
         },
       });
-      assert.ok(container.helpers('FileSystem'));
-      container.helpers('FileSystem').should.be.instanceOf(FileSystem);
+      expect(container.helpers('FileSystem')).is.ok;
+      expect(container.helpers('FileSystem')).is.instanceOf(FileSystem);
 
-      assert.ok(container.helpers('AnotherHelper'));
-      container.helpers('AnotherHelper').method().should.eql('executed');
+      expect(container.helpers('AnotherHelper')).is.ok;
+      expect(container.helpers('AnotherHelper').method()).is.eql('executed');
     });
 
     it('should be able to add new support object', () => {
       container.create({});
       container.append({ support: { userPage: { login: '#login' } } });
-      assert.ok(container.support('I'));
-      assert.ok(container.support('userPage'));
-      container.support('userPage').login.should.eql('#login');
+      expect(container.support('I')).is.ok;
+      expect(container.support('userPage')).is.ok;
+      expect(container.support('userPage').login).is.eql('#login');
     });
   });
 });

--- a/test/unit/data/dataTableArgument_test.js
+++ b/test/unit/data/dataTableArgument_test.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+const { expect } = require('chai');
 const DataTableArgument = require('../../../lib/data/dataTableArgument');
 
 describe('DataTableArgument', () => {
@@ -48,20 +48,20 @@ describe('DataTableArgument', () => {
     const dta = new DataTableArgument(gherkinDataTable);
     const raw = dta.raw();
     const expectedRaw = [['John', 'Doe'], ['Chuck', 'Norris']];
-    assert.deepEqual(raw, expectedRaw);
+    expect(raw).to.deep.equal(expectedRaw);
   });
 
   it('should return a 2D array containing each row without the header (first one)', () => {
     const dta = new DataTableArgument(gherkinDataTableWithHeader);
     const rows = dta.rows();
     const expectedRows = [['Chuck', 'Norris']];
-    assert.deepEqual(rows, expectedRows);
+    expect(rows).to.deep.equal(expectedRows);
   });
 
   it('should return an of object where properties is the header', () => {
     const dta = new DataTableArgument(gherkinDataTableWithHeader);
     const rows = dta.hashes();
     const expectedRows = [{ firstName: 'Chuck', lastName: 'Norris' }];
-    assert.deepEqual(rows, expectedRows);
+    expect(rows).to.deep.equal(expectedRows);
   });
 });

--- a/test/unit/data/table_test.js
+++ b/test/unit/data/table_test.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+const { expect } = require('chai');
 
 const DataTable = require('../../../lib/data/table');
 
@@ -6,8 +6,8 @@ describe('DataTable', () => {
   it('should take an array for creation', () => {
     const data = ['login', 'password'];
     const dataTable = new DataTable(data);
-    assert.deepEqual(dataTable.array, data);
-    assert.deepEqual(dataTable.rows, []);
+    expect(dataTable.array).to.deep.equal(data);
+    expect(dataTable.rows).to.deep.equal([]);
   });
 
   it('should allow arrays to be added', () => {
@@ -19,25 +19,25 @@ describe('DataTable', () => {
       login: 'jon',
       password: 'snow',
     };
-    assert.equal(dataTable.rows[0].data, JSON.stringify(expected));
+    expect(JSON.stringify(dataTable.rows[0].data)).to.equal(JSON.stringify(expected));
   });
 
   it('should not allow an empty array to be added', () => {
     const data = ['login', 'password'];
     const dataTable = new DataTable(data);
-    assert.throws(() => dataTable.add([]));
+    expect(() => dataTable.add([])).to.throw();
   });
 
   it('should not allow an array with more slots than the original to be added', () => {
     const data = ['login', 'password'];
     const dataTable = new DataTable(data);
-    assert.throws(() => dataTable.add(['Henrietta']));
+    expect(() => dataTable.add(['Henrietta'])).to.throw();
   });
 
   it('should not allow an array with less slots than the original to be added', () => {
     const data = ['login', 'password'];
     const dataTable = new DataTable(data);
-    assert.throws(() => dataTable.add(['Acid', 'Jazz', 'Singer']));
+    expect(() => dataTable.add(['Acid', 'Jazz', 'Singer'])).to.throw();
   });
 
   it('should filter an array', () => {
@@ -60,7 +60,7 @@ describe('DataTable', () => {
         password: 'lannister',
       },
     }];
-    assert.equal(JSON.stringify(dataTable.filter(row => row.password === 'lannister')), JSON.stringify(expected));
+    expect(JSON.stringify(dataTable.filter(row => row.password === 'lannister'))).to.equal(JSON.stringify(expected));
   });
 
   it('should filter an array with skips', () => {
@@ -83,6 +83,6 @@ describe('DataTable', () => {
         password: 'lannister',
       },
     }];
-    assert.equal(JSON.stringify(dataTable.filter(row => row.password === 'lannister')), JSON.stringify(expected));
+    expect(JSON.stringify(dataTable.filter(row => row.password === 'lannister'))).to.equal(JSON.stringify(expected));
   });
 });

--- a/test/unit/data/ui_test.js
+++ b/test/unit/data/ui_test.js
@@ -1,4 +1,4 @@
-const should = require('chai').should();
+const { expect } = require('chai');
 const Mocha = require('mocha/lib/mocha');
 const Suite = require('mocha/lib/suite');
 
@@ -31,7 +31,7 @@ describe('ui', () => {
       dataScenarioConfig.tag('@user');
 
       dataScenarioConfig.scenarios.forEach((scenario) => {
-        scenario.test.tags.should.include('@user');
+        expect(scenario.test.tags).to.include('@user');
       });
     });
 
@@ -40,7 +40,7 @@ describe('ui', () => {
 
       dataScenarioConfig.timeout(3);
 
-      dataScenarioConfig.scenarios.forEach(scenario => should.equal(3, scenario.test._timeout));
+      dataScenarioConfig.scenarios.forEach(scenario => expect(3).to.equal(scenario.test._timeout));
     });
 
     it('can add retries to all scenarios', () => {
@@ -48,7 +48,7 @@ describe('ui', () => {
 
       dataScenarioConfig.retry(3);
 
-      dataScenarioConfig.scenarios.forEach(scenario => should.equal(3, scenario.test._retries));
+      dataScenarioConfig.scenarios.forEach(scenario => expect(3).to.equal(scenario.test._retries));
     });
 
     it('can expect failure for all scenarios', () => {
@@ -56,7 +56,7 @@ describe('ui', () => {
 
       dataScenarioConfig.fails();
 
-      dataScenarioConfig.scenarios.forEach(scenario => should.exist(scenario.test.throws));
+      dataScenarioConfig.scenarios.forEach(scenario => expect(scenario.test.throws).to.exist);
     });
 
     it('can expect a specific error for all scenarios', () => {
@@ -66,7 +66,7 @@ describe('ui', () => {
 
       dataScenarioConfig.throws(err);
 
-      dataScenarioConfig.scenarios.forEach(scenario => should.equal(err, scenario.test.throws));
+      dataScenarioConfig.scenarios.forEach(scenario => expect(err).to.equal(scenario.test.throws));
     });
 
     it('can configure a helper for all scenarios', () => {
@@ -77,7 +77,7 @@ describe('ui', () => {
 
       dataScenarioConfig.config(helperName, helper);
 
-      dataScenarioConfig.scenarios.forEach(scenario => should.equal(helper, scenario.test.config[helperName]));
+      dataScenarioConfig.scenarios.forEach(scenario => expect(helper).to.equal(scenario.test.config[helperName]));
     });
 
     it("should shows object's toString() method in each scenario's name if the toString() method is overrided", () => {
@@ -87,13 +87,13 @@ describe('ui', () => {
         },
       ];
       const dataScenarioConfig = context.Data(data).Scenario('scenario', () => {});
-      should.equal('scenario | test case title', dataScenarioConfig.scenarios[0].test.title);
+      expect('scenario | test case title').to.equal(dataScenarioConfig.scenarios[0].test.title);
     });
 
     it("should shows JSON.stringify() in each scenario's name if the toString() method isn't overrided", () => {
       const data = [{ name: 'John Do' }];
       const dataScenarioConfig = context.Data(data).Scenario('scenario', () => {});
-      should.equal(`scenario | ${JSON.stringify(data[0])}`, dataScenarioConfig.scenarios[0].test.title);
+      expect(`scenario | ${JSON.stringify(data[0])}`).to.equal(dataScenarioConfig.scenarios[0].test.title);
     });
   });
 });

--- a/test/unit/helper/FileSystem_test.js
+++ b/test/unit/helper/FileSystem_test.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const { expect } = require('chai');
 
 const FileSystem = require('../../../lib/helper/FileSystem');
 
@@ -17,19 +18,19 @@ describe('FileSystem', () => {
   });
 
   it('should be initialized before tests', () => {
-    fs.dir.should.eql(global.codecept_dir);
+    expect(fs.dir).to.eql(global.codecept_dir);
   });
 
   it('should open dirs', () => {
     fs.amInPath('data');
-    fs.dir.should.eql(path.join(global.codecept_dir, '/data'));
+    expect(fs.dir).to.eql(path.join(global.codecept_dir, '/data'));
   });
 
   it('should see file', () => {
     fs.seeFile('data/fs_sample.txt');
     fs.amInPath('data');
     fs.seeFile('fs_sample.txt');
-    fs.grabFileNames().should.contain('fs_sample.txt');
+    expect(fs.grabFileNames()).to.include('fs_sample.txt');
     fs.seeFileNameMatching('sample');
   });
 

--- a/test/unit/helper/element_not_found_test.js
+++ b/test/unit/helper/element_not_found_test.js
@@ -1,4 +1,4 @@
-const expect = require('chai').expect;
+const { expect } = require('chai');
 
 const ElementNotFound = require('../../../lib/helper/errors/ElementNotFound');
 

--- a/test/unit/locator_test.js
+++ b/test/unit/locator_test.js
@@ -1,11 +1,8 @@
-const assert = require('assert');
-const chai = require('chai');
+const { expect } = require('chai');
 const Dom = require('xmldom').DOMParser;
 const xpath = require('xpath');
 
 const Locator = require('../../lib/locator');
-
-const expect = chai.expect;
 
 let doc;
 const xml = `<body>
@@ -189,15 +186,15 @@ describe('Locator', () => {
   });
 
   it('should throw an error when xpath with round brackets is nested', () => {
-    assert.throws(() => {
+    expect(() => {
       Locator.build('tr').find('(./td)[@id="id"]');
-    }, /round brackets/);
+    }, /round brackets/).to.be.thrown;
   });
 
   it('should throw an error when locator with specific position is nested', () => {
-    assert.throws(() => {
+    expect(() => {
       Locator.build('tr').withChild(Locator.build('td').first());
-    }, /round brackets/);
+    }, /round brackets/).to.be.thrown;
   });
 
   it('should not select element by deep nested siblings', () => {

--- a/test/unit/output_test.js
+++ b/test/unit/output_test.js
@@ -1,7 +1,5 @@
-const assert = require('assert');
 const chai = require('chai');
-
-const expect = chai.expect;
+const { expect } = require('chai');
 const sinonChai = require('sinon-chai');
 
 chai.use(sinonChai);
@@ -23,7 +21,7 @@ describe('Output', () => {
   it('should allow the output level to be set', () => {
     const expectedLevel = 2;
     output.level(expectedLevel);
-    assert.equal(output.level(), expectedLevel);
+    expect(output.level()).to.equal(expectedLevel);
   });
 
   it('should allow the process to be set', () => {
@@ -32,7 +30,7 @@ describe('Output', () => {
     };
 
     output.process(expectedProcess);
-    assert.equal(output.process(), `[${expectedProcess}]`);
+    expect(output.process()).to.equal(`[${expectedProcess}]`);
   });
 
   it('should allow debug messages when output level >= 2', () => {

--- a/test/unit/parser_test.js
+++ b/test/unit/parser_test.js
@@ -1,8 +1,5 @@
-const chai = require('chai');
-
+const { expect } = require('chai');
 const parser = require('../../lib/parser');
-
-const expect = chai.expect;
 
 /* eslint-disable no-unused-vars */
 class Obj {

--- a/test/unit/plugin/customLocator_test.js
+++ b/test/unit/plugin/customLocator_test.js
@@ -1,5 +1,4 @@
 const { expect } = require('chai');
-const assert = require('assert');
 const customLocatorPlugin = require('../../../lib/plugin/customLocator');
 const Locator = require('../../../lib/locator');
 
@@ -15,7 +14,7 @@ describe('customLocator', () => {
       showActual: true,
     });
     const l = new Locator('$user-id');
-    assert(l.isXPath());
+    expect(l.isXPath()).to.be.true;
     expect(l.toXPath()).to.eql('.//*[@data-qa=\'user-id\']');
     expect(l.toString()).to.eql('.//*[@data-qa=\'user-id\']');
   });
@@ -27,7 +26,7 @@ describe('customLocator', () => {
       showActual: false,
     });
     const l = new Locator('=no-user');
-    assert(l.isXPath());
+    expect(l.isXPath()).to.be.true;
     expect(l.toXPath()).to.eql('.//*[@data-test-id=\'no-user\']');
     expect(l.toString()).to.eql('=no-user');
   });
@@ -39,7 +38,7 @@ describe('customLocator', () => {
       showActual: false,
     });
     const l = new Locator('test=no-user');
-    assert(l.isXPath());
+    expect(l.isXPath()).to.be.true;
     expect(l.toXPath()).to.eql('.//*[@data-test-id=\'no-user\']');
     expect(l.toString()).to.eql('test=no-user');
   });
@@ -51,7 +50,7 @@ describe('customLocator', () => {
       strategy: 'css',
     });
     const l = new Locator('$user');
-    assert(l.isCSS());
+    expect(l.isCSS()).to.be.true;
     expect(l.simplify()).to.eql('[data-test=user]');
   });
 });

--- a/test/unit/plugin/retryFailedStep_test.js
+++ b/test/unit/plugin/retryFailedStep_test.js
@@ -1,3 +1,5 @@
+const { expect } = require('chai');
+
 const retryFailedStep = require('../../../lib/plugin/retryFailedStep');
 const within = require('../../../lib/within');
 const session = require('../../../lib/session');
@@ -73,7 +75,7 @@ describe('retryFailedStep', () => {
       recorder.catchWithoutStop((err) => err);
     }
 
-    counter.should.equal(1);
+    expect(counter).to.equal(1);
     // expects to retry only once
   });
 
@@ -95,7 +97,7 @@ describe('retryFailedStep', () => {
       recorder.catchWithoutStop((err) => err);
     }
 
-    counter.should.equal(1);
+    expect(counter).to.equal(1);
     // expects to retry only once
   });
 
@@ -117,7 +119,7 @@ describe('retryFailedStep', () => {
       recorder.catchWithoutStop((err) => err);
     }
 
-    counter.should.equal(1);
+    expect(counter).to.equal(1);
     // expects to retry only once
   });
 
@@ -140,6 +142,6 @@ describe('retryFailedStep', () => {
     }
 
     // expects to retry only once
-    counter.should.equal(2);
+    expect(counter).to.equal(2);
   });
 });

--- a/test/unit/plugin/screenshotOnFail_test.js
+++ b/test/unit/plugin/screenshotOnFail_test.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+const { expect } = require('chai');
 const sinon = require('sinon');
 
 const screenshotOnFail = require('../../../lib/plugin/screenshotOnFail');
@@ -24,34 +24,34 @@ describe('screenshotOnFail', () => {
     screenshotOnFail({});
     event.dispatcher.emit(event.test.failed, { title: 'Scenario with data driven | {"login":"admin","password":"123456"}' });
     await recorder.promise();
-    assert.ok(screenshotSaved.called);
-    assert.equal('Scenario_with_data_driven.failed.png', screenshotSaved.getCall(0).args[0]);
+    expect(screenshotSaved.called).is.ok;
+    expect('Scenario_with_data_driven.failed.png').is.equal(screenshotSaved.getCall(0).args[0]);
   });
 
   it('should create screenshot on fail', async () => {
     screenshotOnFail({});
     event.dispatcher.emit(event.test.failed, { title: 'test1' });
     await recorder.promise();
-    assert.ok(screenshotSaved.called);
-    assert.equal('test1.failed.png', screenshotSaved.getCall(0).args[0]);
+    expect(screenshotSaved.called).is.ok;
+    expect('test1.failed.png').is.equal(screenshotSaved.getCall(0).args[0]);
   });
 
   it('should create screenshot with unique name', async () => {
     screenshotOnFail({ uniqueScreenshotNames: true });
     event.dispatcher.emit(event.test.failed, { title: 'test1', uuid: 1 });
     await recorder.promise();
-    assert.ok(screenshotSaved.called);
-    assert.equal('test1_1.failed.png', screenshotSaved.getCall(0).args[0]);
+    expect(screenshotSaved.called).is.ok;
+    expect('test1_1.failed.png').is.equal(screenshotSaved.getCall(0).args[0]);
   });
 
   it('should create screenshot with unique name when uuid is null', async () => {
     screenshotOnFail({ uniqueScreenshotNames: true });
     event.dispatcher.emit(event.test.failed, { title: 'test1' });
     await recorder.promise();
-    assert.ok(screenshotSaved.called);
+    expect(screenshotSaved.called).is.ok;
     const fileName = screenshotSaved.getCall(0).args[0];
     const regexpFileName = /test1_[0-9]{10}.failed.png/;
-    assert.equal(fileName.match(regexpFileName).length, 1);
+    expect(fileName.match(regexpFileName).length).is.equal(1);
   });
 
   // TODO: write more tests for different options

--- a/test/unit/plugin/tryTo_test.js
+++ b/test/unit/plugin/tryTo_test.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+const { expect } = require('chai');
 const tryTo = require('../../../lib/plugin/tryTo')();
 const recorder = require('../../../lib/recorder');
 
@@ -9,7 +9,7 @@ describe('retryFailedStep', () => {
 
   it('should execute command on success', async () => {
     const ok = await tryTo(() => recorder.add(() => 5));
-    assert.equal(true, ok);
+    expect(true).is.equal(ok);
     return recorder.promise();
   });
 
@@ -17,7 +17,7 @@ describe('retryFailedStep', () => {
     const notOk = await tryTo(() => recorder.add(() => {
       throw new Error('Ups');
     }));
-    assert.equal(false, notOk);
+    expect(false).is.equal(notOk);
     return recorder.promise();
   });
 });

--- a/test/unit/recorder_test.js
+++ b/test/unit/recorder_test.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+const { expect } = require('chai');
 
 const recorder = require('../../lib/recorder');
 
@@ -6,7 +6,7 @@ describe('Recorder', () => {
   beforeEach(() => recorder.start());
 
   it('should create a promise', () => {
-    recorder.promise().should.be.instanceof(Promise);
+    expect(recorder.promise()).to.be.instanceof(Promise);
   });
 
   it('should execute error handler on error', (done) => {
@@ -27,7 +27,7 @@ describe('Recorder', () => {
       recorder.add(() => recorder.session.restore());
       recorder.add(() => order += 'b');
       return recorder.promise()
-        .then(() => assert.equal(order, 'acdb'));
+        .then(() => expect(order).is.equal('acdb'));
     });
   });
 
@@ -36,7 +36,7 @@ describe('Recorder', () => {
       let counter = 0;
       recorder.add(() => counter++);
       recorder.add(() => counter++);
-      recorder.add(() => counter.should.eql(2));
+      recorder.add(() => expect(counter).eql(2));
       return recorder.promise();
     });
 
@@ -46,7 +46,7 @@ describe('Recorder', () => {
       recorder.stop();
       recorder.add(() => counter++);
       return recorder.promise()
-        .then(() => counter.should.eql(1));
+        .then(() => expect(counter).eql(1));
     });
   });
 

--- a/test/unit/scenario_test.js
+++ b/test/unit/scenario_test.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+const { expect } = require('chai');
 const sinon = require('sinon');
 
 const scenario = require('../../lib/scenario');
@@ -25,7 +25,7 @@ describe('Scenario', () => {
 
   it('should wrap test function', () => {
     scenario.test(test).fn(() => {});
-    assert.ok(fn.called);
+    expect(fn.called).is.ok;
   });
 
   it('should work with async func', () => {
@@ -41,7 +41,7 @@ describe('Scenario', () => {
 
     scenario.setup();
     scenario.test(test).fn(() => null);
-    recorder.add('validation', () => assert.equal(counter, 4));
+    recorder.add('validation', () => expect(counter).to.eq(4));
     return recorder.promise();
   });
 
@@ -58,14 +58,14 @@ describe('Scenario', () => {
 
     it('should fire events', () => {
       scenario.test(test).fn(() => null);
-      assert.ok(started.called);
+      expect(started.called).is.ok;
       scenario.teardown();
       scenario.suiteTeardown();
       return recorder.promise()
-        .then(() => assert.ok(beforeSuite.called))
-        .then(() => assert.ok(afterSuite.called))
-        .then(() => assert.ok(before.called))
-        .then(() => assert.ok(after.called));
+        .then(() => expect(beforeSuite.called).is.ok)
+        .then(() => expect(afterSuite.called).is.ok)
+        .then(() => expect(before.called).is.ok)
+        .then(() => expect(after.called).is.ok);
     });
 
     it('should fire failed event on error', () => {
@@ -76,7 +76,7 @@ describe('Scenario', () => {
       };
       scenario.test(test).fn(() => {});
       return recorder.promise()
-        .then(() => assert.ok(failed.called))
+        .then(() => expect(failed.called).is.ok)
         .catch(() => null);
     });
 
@@ -86,7 +86,7 @@ describe('Scenario', () => {
       };
       scenario.test(test).fn(() => {});
       return recorder.promise()
-        .then(() => assert.ok(failed.called))
+        .then(() => expect(failed.called).is.ok)
         .catch(() => null);
     });
   });

--- a/test/unit/steps_test.js
+++ b/test/unit/steps_test.js
@@ -1,10 +1,9 @@
-const assert = require('assert');
 const sinon = require('sinon');
-const expect = require('expect');
+const { expect } = require('chai');
 const Step = require('../../lib/step');
 const { MetaStep } = require('../../lib/step');
 const event = require('../../lib/event');
-const secret = require('../../lib/secret').secret;
+const { secret } = require('../../lib/secret');
 
 let step;
 let action;
@@ -17,62 +16,62 @@ describe('Steps', () => {
     });
 
     it('has name', () => {
-      step.name.should.eql('doSomething');
+      expect(step.name).eql('doSomething');
     });
 
     it('should convert method names for output', () => {
-      step.humanize().should.eql('do something');
+      expect(step.humanize()).eql('do something');
     });
 
     it('should convert arguments for output', () => {
       step.args = ['word', 1];
-      step.humanizeArgs().should.eql('"word", 1');
+      expect(step.humanizeArgs()).eql('"word", 1');
 
       step.args = [['some', 'data'], 1];
-      step.humanizeArgs().should.eql('["some","data"], 1');
+      expect(step.humanizeArgs()).eql('["some","data"], 1');
 
       step.args = [{ css: '.class' }];
-      step.humanizeArgs().should.eql('{"css":".class"}');
+      expect(step.humanizeArgs()).eql('{"css":".class"}');
 
       let testUndefined;
       step.args = [testUndefined, 'undefined'];
-      step.humanizeArgs().should.eql(', "undefined"');
+      expect(step.humanizeArgs()).eql(', "undefined"');
 
       step.args = [secret('word'), 1];
-      step.humanizeArgs().should.eql('*****, 1');
+      expect(step.humanizeArgs()).eql('*****, 1');
     });
 
     it('should provide nice output', () => {
       step.args = [1, 'yo'];
-      step.toString().should.eql('I do something 1, "yo"');
+      expect(step.toString()).eql('I do something 1, "yo"');
     });
 
     it('should provide code output', () => {
       step.args = [1, 'yo'];
-      step.toCode().should.eql('I.doSomething(1, "yo")');
+      expect(step.toCode()).eql('I.doSomething(1, "yo")');
     });
 
     it('should set status for Step and MetaStep if exist', () => {
       const metaStep = new MetaStep({ doSomethingMS: action }, 'doSomethingMS');
       step.metaStep = metaStep;
       step.run();
-      expect(step.metaStep.status).toEqual('success');
+      expect(step.metaStep.status).eq('success');
     });
 
     it('should set status only for Step when MetaStep not exist', () => {
       step.run();
-      expect(step.metaStep).toBeFalsy();
+      expect(step.metaStep);
     });
 
     describe('#run', () => {
       afterEach(() => event.cleanDispatcher());
 
       it('should run step', () => {
-        assert.equal(step.status, 'pending');
+        expect(step.status).is.equal('pending');
         const res = step.run();
-        assert.equal(res, 'done');
-        assert(action.called);
-        assert.equal(step.status, 'success');
+        expect(res).is.equal('done');
+        expect(action.called);
+        expect(step.status).is.equal('success');
       });
     });
   });
@@ -88,27 +87,27 @@ describe('Steps', () => {
       ['Given', 'When', 'Then', 'And'].forEach(key => {
         it(`[${key}] #isBdd should return true if it BDD style`, () => {
           const metaStep = new MetaStep(key, 'I need to open Google');
-          expect(metaStep.isBDD()).toBe(true);
+          expect(metaStep.isBDD()).to.be.true;
         });
       });
     });
 
     it('#isWithin should return true if it Within step', () => {
       const metaStep = new MetaStep('Within', 'clickByName');
-      expect(metaStep.isWithin()).toBe(true);
+      expect(metaStep.isWithin()).to.be.true;
     });
 
     describe('#toString', () => {
       ['Given', 'When', 'Then', 'And'].forEach(key => {
         it(`[${key}] should correct print BDD step`, () => {
           const metaStep = new MetaStep(key, 'I need to open Google');
-          expect(metaStep.toString()).toContain(`${key} I need to open Google`);
+          expect(metaStep.toString()).to.include(`${key} I need to open Google`);
         });
       });
 
       it('should correct print step info for simple PageObject', () => {
         const metaStep = new MetaStep('MyPage', 'clickByName');
-        expect(metaStep.toString()).toContain('MyPage: clickByName');
+        expect(metaStep.toString()).to.include('MyPage: clickByName');
       });
 
       it('should correct print step with args', () => {
@@ -117,7 +116,7 @@ describe('Steps', () => {
         const msg2 = 'second message';
         const fn = (msg) => `result from callback = ${msg}`;
         metaStep.run.bind(metaStep, fn)(msg, msg2);
-        expect(metaStep.toString()).toEqual(`MyPage: clickByName "${msg}", "${msg2}"`);
+        expect(metaStep.toString()).eql(`MyPage: clickByName "${msg}", "${msg2}"`);
       });
     });
 
@@ -125,7 +124,7 @@ describe('Steps', () => {
       const context = { prop: 'prop' };
       const metaStep = new MetaStep('MyPage', 'clickByName');
       metaStep.setContext(context);
-      expect(metaStep.context).toEqual(context);
+      expect(metaStep.context).eql(context);
     });
 
     describe('#run', () => {
@@ -140,18 +139,18 @@ describe('Steps', () => {
 
       it('should return result from run callback function', () => {
         const fn = () => 'result from callback';
-        expect(metaStep.run(fn)).toEqual('result from callback');
+        expect(metaStep.run(fn)).eql('result from callback');
       });
 
       it('should return result when run is bound', () => {
         const fn = () => 'result from callback';
         const boundedRun = metaStep.run.bind(metaStep, fn);
-        expect(boundedRun()).toEqual('result from callback');
+        expect(boundedRun()).eql('result from callback');
       });
 
       it('should correct init args when run is bound', () => {
         const msg = 'arg message';
-        expect(boundedRun(msg)).toEqual(`result from callback = ${msg}`);
+        expect(boundedRun(msg)).eql(`result from callback = ${msg}`);
       });
 
       it('should init as metaStep in step', () => {
@@ -166,8 +165,8 @@ describe('Steps', () => {
           step2.run();
         });
         boundedRun();
-        expect(step1.metaStep).toEqual(metaStep);
-        expect(step2.metaStep).toEqual(metaStep);
+        expect(step1.metaStep).eql(metaStep);
+        expect(step2.metaStep).eql(metaStep);
       });
     });
   });

--- a/test/unit/ui_test.js
+++ b/test/unit/ui_test.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+const { expect } = require('chai');
 const Mocha = require('mocha/lib/mocha');
 const Suite = require('mocha/lib/suite');
 
@@ -20,7 +20,7 @@ describe('ui', () => {
     const constants = ['Before', 'Background', 'BeforeAll', 'After', 'AfterAll', 'Scenario', 'xScenario'];
 
     constants.forEach((c) => {
-      it(`context should contain ${c}`, () => assert.ok(context[c]));
+      it(`context should contain ${c}`, () => expect(context[c]).is.ok);
     });
   });
 
@@ -29,22 +29,22 @@ describe('ui', () => {
 
     it('Feature should return featureConfig', () => {
       suiteConfig = context.Feature('basic suite');
-      assert.ok(suiteConfig.suite);
+      expect(suiteConfig.suite).is.ok;
     });
 
     it('should contain title', () => {
       suiteConfig = context.Feature('basic suite');
-      assert.ok(suiteConfig.suite);
-      assert.equal(suiteConfig.suite.title, 'basic suite');
-      assert.equal(suiteConfig.suite.fullTitle(), 'basic suite:');
+      expect(suiteConfig.suite).is.ok;
+      expect(suiteConfig.suite.title).eq('basic suite');
+      expect(suiteConfig.suite.fullTitle()).eq('basic suite:');
     });
 
     it('should contain tags', () => {
       suiteConfig = context.Feature('basic suite');
-      assert.equal(0, suiteConfig.suite.tags.length);
+      expect(0).eq(suiteConfig.suite.tags.length);
 
       suiteConfig = context.Feature('basic suite @very @important');
-      assert.ok(suiteConfig.suite);
+      expect(suiteConfig.suite).is.ok;
 
       suiteConfig.suite.tags.should.include('@very');
       suiteConfig.suite.tags.should.include('@important');
@@ -60,92 +60,92 @@ describe('ui', () => {
     it('retries can be set', () => {
       suiteConfig = context.Feature('basic suite');
       suiteConfig.retry(3);
-      assert.equal(3, suiteConfig.suite.retries());
+      expect(3).eq(suiteConfig.suite.retries());
     });
 
     it('timeout can be set', () => {
       suiteConfig = context.Feature('basic suite');
-      assert.equal(0, suiteConfig.suite.timeout());
+      expect(0).eq(suiteConfig.suite.timeout());
       suiteConfig.timeout(3);
-      assert.equal(3, suiteConfig.suite.timeout());
+      expect(3).eq(suiteConfig.suite.timeout());
     });
 
     it('helpers can be configured', () => {
       suiteConfig = context.Feature('basic suite');
-      assert(!suiteConfig.suite.config);
+      expect(!suiteConfig.suite.config);
       suiteConfig.config('WebDriver', { browser: 'chrome' });
-      assert.equal('chrome', suiteConfig.suite.config.WebDriver.browser);
+      expect('chrome').eq(suiteConfig.suite.config.WebDriver.browser);
       suiteConfig.config({ browser: 'firefox' });
-      assert.equal('firefox', suiteConfig.suite.config[0].browser);
+      expect('firefox').eq(suiteConfig.suite.config[0].browser);
       suiteConfig.config('WebDriver', () => {
         return { browser: 'edge' };
       });
-      assert.equal('edge', suiteConfig.suite.config.WebDriver.browser);
+      expect('edge').eq(suiteConfig.suite.config.WebDriver.browser);
     });
 
     it('Feature can be skipped', () => {
       suiteConfig = context.Feature.skip('skipped suite');
-      assert.equal(suiteConfig.suite.pending, true, 'Skipped Feature must be contain pending === true');
-      assert.equal(suiteConfig.suite.opts.skipInfo.message, 'Skipped due to "skip" on Feature.');
-      assert.equal(suiteConfig.suite.opts.skipInfo.skipped, true, 'Skip should be set on skipInfo');
+      expect(suiteConfig.suite.pending).eq(true, 'Skipped Feature must be contain pending === true');
+      expect(suiteConfig.suite.opts.skipInfo.message).eq('Skipped due to "skip" on Feature.');
+      expect(suiteConfig.suite.opts.skipInfo.skipped).eq(true, 'Skip should be set on skipInfo');
     });
 
     it('Feature can be skipped via xFeature', () => {
       suiteConfig = context.xFeature('skipped suite');
-      assert.equal(suiteConfig.suite.pending, true, 'Skipped Feature must be contain pending === true');
-      assert.equal(suiteConfig.suite.opts.skipInfo.message, 'Skipped due to "skip" on Feature.');
-      assert.equal(suiteConfig.suite.opts.skipInfo.skipped, true, 'Skip should be set on skipInfo');
+      expect(suiteConfig.suite.pending).eq(true, 'Skipped Feature must be contain pending === true');
+      expect(suiteConfig.suite.opts.skipInfo.message).eq('Skipped due to "skip" on Feature.');
+      expect(suiteConfig.suite.opts.skipInfo.skipped).eq(true, 'Skip should be set on skipInfo');
     });
 
     it('Feature are not skipped by default', () => {
       suiteConfig = context.Feature('not skipped suite');
-      assert.equal(suiteConfig.suite.pending, false, 'Feature must not contain pending === true');
-      // assert.equal(suiteConfig.suite.opts, undefined, 'Features should have no skip info');
+      expect(suiteConfig.suite.pending).eq(false, 'Feature must not contain pending === true');
+      // expect(suiteConfig.suite.opts, undefined, 'Features should have no skip info');
     });
 
     it('Feature can be skipped', () => {
       suiteConfig = context.Feature.skip('skipped suite');
-      assert.equal(suiteConfig.suite.pending, true, 'Skipped Feature must be contain pending === true');
-      assert.equal(suiteConfig.suite.opts.skipInfo.message, 'Skipped due to "skip" on Feature.');
-      assert.equal(suiteConfig.suite.opts.skipInfo.skipped, true, 'Skip should be set on skipInfo');
+      expect(suiteConfig.suite.pending).eq(true, 'Skipped Feature must be contain pending === true');
+      expect(suiteConfig.suite.opts.skipInfo.message).eq('Skipped due to "skip" on Feature.');
+      expect(suiteConfig.suite.opts.skipInfo.skipped).eq(true, 'Skip should be set on skipInfo');
     });
 
     it('Feature can be skipped via xFeature', () => {
       suiteConfig = context.xFeature('skipped suite');
-      assert.equal(suiteConfig.suite.pending, true, 'Skipped Feature must be contain pending === true');
-      assert.equal(suiteConfig.suite.opts.skipInfo.message, 'Skipped due to "skip" on Feature.');
-      assert.equal(suiteConfig.suite.opts.skipInfo.skipped, true, 'Skip should be set on skipInfo');
+      expect(suiteConfig.suite.pending).eq(true, 'Skipped Feature must be contain pending === true');
+      expect(suiteConfig.suite.opts.skipInfo.message).eq('Skipped due to "skip" on Feature.');
+      expect(suiteConfig.suite.opts.skipInfo.skipped).eq(true, 'Skip should be set on skipInfo');
     });
 
     it('Feature are not skipped by default', () => {
       suiteConfig = context.Feature('not skipped suite');
-      assert.equal(suiteConfig.suite.pending, false, 'Feature must not contain pending === true');
-      // assert.equal(suiteConfig.suite.opts, undefined, 'Features should have no skip info');
+      expect(suiteConfig.suite.pending).eq(false, 'Feature must not contain pending === true');
+      // expect(suiteConfig.suite.opts, undefined, 'Features should have no skip info');
     });
 
     it('Feature can be skipped', () => {
       suiteConfig = context.Feature.skip('skipped suite');
-      assert.equal(suiteConfig.suite.pending, true, 'Skipped Feature must be contain pending === true');
-      assert.equal(suiteConfig.suite.opts.skipInfo.message, 'Skipped due to "skip" on Feature.');
-      assert.equal(suiteConfig.suite.opts.skipInfo.skipped, true, 'Skip should be set on skipInfo');
+      expect(suiteConfig.suite.pending,).eq(true, 'Skipped Feature must be contain pending === true');
+      expect(suiteConfig.suite.opts.skipInfo.message).eq('Skipped due to "skip" on Feature.');
+      expect(suiteConfig.suite.opts.skipInfo.skipped).eq(true, 'Skip should be set on skipInfo');
     });
 
     it('Feature can be skipped via xFeature', () => {
       suiteConfig = context.xFeature('skipped suite');
-      assert.equal(suiteConfig.suite.pending, true, 'Skipped Feature must be contain pending === true');
-      assert.equal(suiteConfig.suite.opts.skipInfo.message, 'Skipped due to "skip" on Feature.');
-      assert.equal(suiteConfig.suite.opts.skipInfo.skipped, true, 'Skip should be set on skipInfo');
+      expect(suiteConfig.suite.pending).eq(true, 'Skipped Feature must be contain pending === true');
+      expect(suiteConfig.suite.opts.skipInfo.message).eq('Skipped due to "skip" on Feature.');
+      expect(suiteConfig.suite.opts.skipInfo.skipped).eq(true, 'Skip should be set on skipInfo');
     });
 
     it('Feature are not skipped by default', () => {
       suiteConfig = context.Feature('not skipped suite');
-      assert.equal(suiteConfig.suite.pending, false, 'Feature must not contain pending === true');
-      assert.deepEqual(suiteConfig.suite.opts, {}, 'Features should have no skip info');
+      expect(suiteConfig.suite.pending).eq(false, 'Feature must not contain pending === true');
+      expect(suiteConfig.suite.opts).to.deep.eq({}, 'Features should have no skip info');
     });
 
     it('Feature should correctly pass options to suite context', () => {
       suiteConfig = context.Feature('not skipped suite', { key: 'value' });
-      assert.deepEqual(suiteConfig.suite.opts, { key: 'value' }, 'Features should have passed options');
+      expect(suiteConfig.suite.opts).to.deep.eq({ key: 'value' }, 'Features should have passed options');
     });
   });
 
@@ -154,15 +154,15 @@ describe('ui', () => {
 
     it('Scenario should return scenarioConfig', () => {
       scenarioConfig = context.Scenario('basic scenario');
-      assert.ok(scenarioConfig.test);
+      expect(scenarioConfig.test).is.ok;
     });
 
     it('should contain title', () => {
       context.Feature('suite');
       scenarioConfig = context.Scenario('scenario');
-      assert.equal(scenarioConfig.test.title, 'scenario');
-      assert.equal(scenarioConfig.test.fullTitle(), 'suite: scenario');
-      assert.equal(scenarioConfig.test.tags.length, 0);
+      expect(scenarioConfig.test.title).eq('scenario');
+      expect(scenarioConfig.test.fullTitle()).eq('suite: scenario');
+      expect(scenarioConfig.test.tags.length).eq(0);
     });
 
     it('should contain tags', () => {
@@ -181,36 +181,36 @@ describe('ui', () => {
     it('should dynamically inject dependencies', () => {
       scenarioConfig = context.Scenario('scenario');
       scenarioConfig.injectDependencies({ Data: 'data' });
-      assert.equal(scenarioConfig.test.inject.Data, 'data');
+      expect(scenarioConfig.test.inject.Data).eq('data');
     });
 
     describe('todo', () => {
       it('should inject skipInfo to opts', () => {
         scenarioConfig = context.Scenario.todo('scenario', () => { console.log('Scenario Body'); });
 
-        assert.equal(scenarioConfig.test.pending, true, 'Todo Scenario must be contain pending === true');
-        assert.equal(scenarioConfig.test.opts.skipInfo.message, 'Test not implemented!');
-        assert.equal(scenarioConfig.test.opts.skipInfo.description, "() => { console.log('Scenario Body'); }");
+        expect(scenarioConfig.test.pending).eq(true, 'Todo Scenario must be contain pending === true');
+        expect(scenarioConfig.test.opts.skipInfo.message).eq('Test not implemented!');
+        expect(scenarioConfig.test.opts.skipInfo.description).eq("() => { console.log('Scenario Body'); }");
       });
 
       it('should contain empty description in skipInfo and empty body', () => {
         scenarioConfig = context.Scenario.todo('scenario');
 
-        assert.equal(scenarioConfig.test.pending, true, 'Todo Scenario must be contain pending === true');
-        assert.equal(scenarioConfig.test.opts.skipInfo.description, '');
-        assert.equal(scenarioConfig.test.body, '');
+        expect(scenarioConfig.test.pending).eq(true, 'Todo Scenario must be contain pending === true');
+        expect(scenarioConfig.test.opts.skipInfo.description).eq('');
+        expect(scenarioConfig.test.body).eq('');
       });
 
       it('should inject custom opts to opts and without callback', () => {
         scenarioConfig = context.Scenario.todo('scenario', { customOpts: 'Custom Opts' });
 
-        assert.equal(scenarioConfig.test.opts.customOpts, 'Custom Opts');
+        expect(scenarioConfig.test.opts.customOpts).eq('Custom Opts');
       });
 
       it('should inject custom opts to opts and with callback', () => {
         scenarioConfig = context.Scenario.todo('scenario', { customOpts: 'Custom Opts' }, () => { console.log('Scenario Body'); });
 
-        assert.equal(scenarioConfig.test.opts.customOpts, 'Custom Opts');
+        expect(scenarioConfig.test.opts.customOpts).eq('Custom Opts');
       });
     });
   });

--- a/test/unit/utils_test.js
+++ b/test/unit/utils_test.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+const { expect } = require('chai');
 const os = require('os');
 const path = require('path');
 const sinon = require('sinon');
@@ -7,43 +7,43 @@ const utils = require('../../lib/utils');
 
 describe('utils', () => {
   describe('#fileExists', () => {
-    it('exists', () => assert(utils.fileExists(__filename)));
-    it('not exists', () => assert(!utils.fileExists('not_utils.js')));
+    it('exists', () => expect(utils.fileExists(__filename)));
+    it('not exists', () => expect(!utils.fileExists('not_utils.js')));
   });
   /* eslint-disable no-unused-vars */
   describe('#getParamNames', () => {
-    it('fn#1', () => utils.getParamNames((a, b) => {}).should.eql(['a', 'b']));
-    it('fn#2', () => utils.getParamNames((I, userPage) => { }).should.eql(['I', 'userPage']));
-    it('should handle single-param arrow functions with omitted parens', () => utils.getParamNames((I) => {}).should.eql(['I']));
-    it('should handle trailing comma', () => utils.getParamNames((
+    it('fn#1', () => expect(utils.getParamNames((a, b) => { })).eql(['a', 'b']));
+    it('fn#2', () => expect(utils.getParamNames((I, userPage) => { })).eql(['I', 'userPage']));
+    it('should handle single-param arrow functions with omitted parens', () => expect(utils.getParamNames((I) => { })).eql(['I']));
+    it('should handle trailing comma', () => expect(utils.getParamNames((
       I,
       trailing,
       comma,
-    ) => {}).should.eql(['I', 'trailing', 'comma']));
+    ) => { })).eql(['I', 'trailing', 'comma']));
   });
   /* eslint-enable no-unused-vars */
 
   describe('#methodsOfObject', () => {
     it('should get methods', () => {
-      utils.methodsOfObject({
+      expect(utils.methodsOfObject({
         a: 1,
-        hello: () => {},
-        world: () => {},
-      }).should.eql(['hello', 'world']);
+        hello: () => { },
+        world: () => { },
+      })).eql(['hello', 'world']);
     });
   });
 
   describe('#ucfirst', () => {
     it('should capitalize first letter', () => {
-      utils.ucfirst('hello').should.equal('Hello');
+      expect(utils.ucfirst('hello')).equal('Hello');
     });
   });
 
   describe('#beautify', () => {
     it('should beautify JS code', () => {
-      utils
+      expect(utils
         .beautify('module.exports = function(a, b) { a++; b = a; if (a == b) { return 2 }};')
-        .should.eql(`module.exports = function(a, b) {
+      ).eql(`module.exports = function(a, b) {
   a++;
   b = a;
   if (a == b) {
@@ -55,13 +55,13 @@ describe('utils', () => {
 
   describe('#xpathLocator', () => {
     it('combines xpaths', () => {
-      utils.xpathLocator.combine(['//a', '//button'])
-        .should.eql('//a | //button');
+      expect(utils.xpathLocator.combine(['//a', '//button'])
+      ).eql('//a | //button');
     });
 
     it('converts string to xpath literal', () => {
-      utils.xpathLocator.literal("can't find thing")
-        .should.eql('concat(\'can\',"\'",\'t find thing\')');
+      expect(utils.xpathLocator.literal("can't find thing")
+      ).eql('concat(\'can\',"\'",\'t find thing\')');
     });
   });
 
@@ -76,8 +76,8 @@ describe('utils', () => {
         },
       };
 
-      utils.replaceValueDeep(target.helpers, 'something', 1234).should.eql({ something: 1234 });
-      target.should.eql({
+      expect(utils.replaceValueDeep(target.helpers, 'something', 1234)).eql({ something: 1234 });
+      expect(target).eql({
         timeout: 1,
         helpers: {
           something: 1234,
@@ -94,7 +94,7 @@ describe('utils', () => {
       };
 
       utils.replaceValueDeep(target, 'unexisting', 1234);
-      target.should.eql({
+      expect(target).eql({
         timeout: 1,
         helpers: {
           something: 2,
@@ -111,7 +111,7 @@ describe('utils', () => {
       };
 
       utils.replaceValueDeep(target, 'timeout', 1234);
-      target.should.eql({
+      expect(target).eql({
         timeout: 1234,
         helpers: {
           something: 2,
@@ -139,7 +139,7 @@ describe('utils', () => {
       };
 
       utils.replaceValueDeep(target, 'timeout', 1234);
-      target.should.eql({
+      expect(target).eql({
         zeroValue: {
           timeout: 1234,
         },
@@ -167,13 +167,13 @@ describe('utils', () => {
         }, {
           a: 3,
         },
-        123,
-        0,
+          123,
+          0,
         [{ a: 1 }, 123]],
       };
 
       utils.replaceValueDeep(target, 'a', 1234);
-      target.should.eql({
+      expect(target).eql({
         timeout: 1,
         something: [{
           a: 1234,
@@ -181,8 +181,8 @@ describe('utils', () => {
         }, {
           a: 1234,
         },
-        123,
-        0,
+          123,
+          0,
         [{ a: 1234 }, 123]],
       });
     });
@@ -198,7 +198,7 @@ describe('utils', () => {
       };
 
       utils.replaceValueDeep(target, 'otherthing', 1234);
-      target.should.eql({
+      expect(target).eql({
         timeout: 1,
         helpers: {
           something: {
@@ -223,7 +223,7 @@ describe('utils', () => {
       };
 
       utils.replaceValueDeep(target.helpers, 'WebDriver', { timeouts: 1234 });
-      target.should.eql({
+      expect(target).eql({
         timeout: 1,
         helpers: {
           WebDriver: {
@@ -240,51 +240,51 @@ describe('utils', () => {
 
   describe('#getNormalizedKeyAttributeValue', () => {
     it('should normalize key (alias) to key attribute value', () => {
-      utils.getNormalizedKeyAttributeValue('Arrow down').should.equal('ArrowDown');
-      utils.getNormalizedKeyAttributeValue('RIGHT_ARROW').should.equal('ArrowRight');
-      utils.getNormalizedKeyAttributeValue('leftarrow').should.equal('ArrowLeft');
-      utils.getNormalizedKeyAttributeValue('Up arrow').should.equal('ArrowUp');
+      expect(utils.getNormalizedKeyAttributeValue('Arrow down')).equal('ArrowDown');
+      expect(utils.getNormalizedKeyAttributeValue('RIGHT_ARROW')).equal('ArrowRight');
+      expect(utils.getNormalizedKeyAttributeValue('leftarrow')).equal('ArrowLeft');
+      expect(utils.getNormalizedKeyAttributeValue('Up arrow')).equal('ArrowUp');
 
-      utils.getNormalizedKeyAttributeValue('Left Alt').should.equal('AltLeft');
-      utils.getNormalizedKeyAttributeValue('RIGHT_ALT').should.equal('AltRight');
-      utils.getNormalizedKeyAttributeValue('alt').should.equal('Alt');
+      expect(utils.getNormalizedKeyAttributeValue('Left Alt')).equal('AltLeft');
+      expect(utils.getNormalizedKeyAttributeValue('RIGHT_ALT')).equal('AltRight');
+      expect(utils.getNormalizedKeyAttributeValue('alt')).equal('Alt');
 
-      utils.getNormalizedKeyAttributeValue('oPTION left').should.equal('AltLeft');
-      utils.getNormalizedKeyAttributeValue('ALTGR').should.equal('AltGraph');
-      utils.getNormalizedKeyAttributeValue('alt graph').should.equal('AltGraph');
+      expect(utils.getNormalizedKeyAttributeValue('oPTION left')).equal('AltLeft');
+      expect(utils.getNormalizedKeyAttributeValue('ALTGR')).equal('AltGraph');
+      expect(utils.getNormalizedKeyAttributeValue('alt graph')).equal('AltGraph');
 
-      utils.getNormalizedKeyAttributeValue('Control Left').should.equal('ControlLeft');
-      utils.getNormalizedKeyAttributeValue('RIGHT_CTRL').should.equal('ControlRight');
-      utils.getNormalizedKeyAttributeValue('Ctrl').should.equal('Control');
+      expect(utils.getNormalizedKeyAttributeValue('Control Left')).equal('ControlLeft');
+      expect(utils.getNormalizedKeyAttributeValue('RIGHT_CTRL')).equal('ControlRight');
+      expect(utils.getNormalizedKeyAttributeValue('Ctrl')).equal('Control');
 
-      utils.getNormalizedKeyAttributeValue('Cmd').should.equal('Meta');
-      utils.getNormalizedKeyAttributeValue('LeftCommand').should.equal('MetaLeft');
-      utils.getNormalizedKeyAttributeValue('os right').should.equal('MetaRight');
-      utils.getNormalizedKeyAttributeValue('SUPER').should.equal('Meta');
+      expect(utils.getNormalizedKeyAttributeValue('Cmd')).equal('Meta');
+      expect(utils.getNormalizedKeyAttributeValue('LeftCommand')).equal('MetaLeft');
+      expect(utils.getNormalizedKeyAttributeValue('os right')).equal('MetaRight');
+      expect(utils.getNormalizedKeyAttributeValue('SUPER')).equal('Meta');
 
-      utils.getNormalizedKeyAttributeValue('NumpadComma').should.equal('Comma');
-      utils.getNormalizedKeyAttributeValue('Separator').should.equal('Comma');
+      expect(utils.getNormalizedKeyAttributeValue('NumpadComma')).equal('Comma');
+      expect(utils.getNormalizedKeyAttributeValue('Separator')).equal('Comma');
 
-      utils.getNormalizedKeyAttributeValue('Add').should.equal('NumpadAdd');
-      utils.getNormalizedKeyAttributeValue('Decimal').should.equal('NumpadDecimal');
-      utils.getNormalizedKeyAttributeValue('Divide').should.equal('NumpadDivide');
-      utils.getNormalizedKeyAttributeValue('Multiply').should.equal('NumpadMultiply');
-      utils.getNormalizedKeyAttributeValue('Subtract').should.equal('NumpadSubtract');
+      expect(utils.getNormalizedKeyAttributeValue('Add')).equal('NumpadAdd');
+      expect(utils.getNormalizedKeyAttributeValue('Decimal')).equal('NumpadDecimal');
+      expect(utils.getNormalizedKeyAttributeValue('Divide')).equal('NumpadDivide');
+      expect(utils.getNormalizedKeyAttributeValue('Multiply')).equal('NumpadMultiply');
+      expect(utils.getNormalizedKeyAttributeValue('Subtract')).equal('NumpadSubtract');
     });
 
     it('should normalize modifier key based on operating system', () => {
       sinon.stub(os, 'platform').returns('notdarwin');
-      utils.getNormalizedKeyAttributeValue('CmdOrCtrl').should.equal('Control');
-      utils.getNormalizedKeyAttributeValue('COMMANDORCONTROL').should.equal('Control');
-      utils.getNormalizedKeyAttributeValue('ControlOrCommand').should.equal('Control');
-      utils.getNormalizedKeyAttributeValue('left ctrl or command').should.equal('ControlLeft');
+      expect(utils.getNormalizedKeyAttributeValue('CmdOrCtrl')).equal('Control');
+      expect(utils.getNormalizedKeyAttributeValue('COMMANDORCONTROL')).equal('Control');
+      expect(utils.getNormalizedKeyAttributeValue('ControlOrCommand')).equal('Control');
+      expect(utils.getNormalizedKeyAttributeValue('left ctrl or command')).equal('ControlLeft');
       os.platform.restore();
 
       sinon.stub(os, 'platform').returns('darwin');
-      utils.getNormalizedKeyAttributeValue('CtrlOrCmd').should.equal('Meta');
-      utils.getNormalizedKeyAttributeValue('CONTROLORCOMMAND').should.equal('Meta');
-      utils.getNormalizedKeyAttributeValue('CommandOrControl').should.equal('Meta');
-      utils.getNormalizedKeyAttributeValue('right command or ctrl').should.equal('MetaRight');
+      expect(utils.getNormalizedKeyAttributeValue('CtrlOrCmd')).equal('Meta');
+      expect(utils.getNormalizedKeyAttributeValue('CONTROLORCOMMAND')).equal('Meta');
+      expect(utils.getNormalizedKeyAttributeValue('CommandOrControl')).equal('Meta');
+      expect(utils.getNormalizedKeyAttributeValue('right command or ctrl')).equal('MetaRight');
       os.platform.restore();
     });
   });
@@ -308,7 +308,7 @@ describe('utils', () => {
 
     it('returns the joined filename for filename only', () => {
       const _path = utils.screenshotOutputFolder('screenshot1.failed.png');
-      _path.should.eql(
+      expect(_path).eql(
         '/Users/someuser/workbase/project1/test_output/screenshot1.failed.png'.replace(
           /\//g,
           path.sep,
@@ -324,14 +324,14 @@ describe('utils', () => {
         ),
       );
       if (os.platform() === 'win32') {
-        _path.should.eql(
+        expect(_path).eql(
           path.resolve(
             global.codecept_dir,
             '/Users/someuser/workbase/project1/test_output/screenshot1.failed.png',
           ),
         );
       } else {
-        _path.should.eql(
+        expect(_path).eql(
           '/Users/someuser/workbase/project1/test_output/screenshot1.failed.png',
         );
       }


### PR DESCRIPTION
## Motivation/Description of the PR
- Move all unit tests to 'expect' assert library
- Resolves #2451

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [x] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
