### PR TITLE
(fix): complain on TS2339: Property 'current' does not exist on type 'SupportObject'

### DIFF
--- a/lib/command/definitions.js
+++ b/lib/command/definitions.js
@@ -54,6 +54,7 @@ module.exports = function (genPath, options) {
 
   const supportObject = new Map();
   supportObject.set('I', 'I');
+  supportObject.set('current', 'any');
   for (const name in codecept.config.include) {
     const includePath = codecept.config.include[name];
     if (name === 'I' || name === translations.I) {


### PR DESCRIPTION
## Motivation/Description of the PR
- Not sure if it is the proper fix for this issue `fix TS2339: Property 'current' does not exist on type 'SupportObject'.` but at least this worked, no more complain.

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
