### PR TITLE
Set return type of `plugins` and `helpers` to any

### DIFF
--- a/lib/container.js
+++ b/lib/container.js
@@ -51,6 +51,7 @@ class Container {
    *
    * @api
    * @param {string} [name]
+   * @returns { * }
    */
   static plugins(name) {
     if (!name) {
@@ -78,6 +79,7 @@ class Container {
    *
    * @api
    * @param {string} [name]
+   * @returns { * }
    */
   static helpers(name) {
     if (!name) {


### PR DESCRIPTION
## Motivation/Description of the PR
This will allow using code `codeceptjs.container.plugins('allure')` in `.ts` files without cast to `unknown`

Applicable helpers:

- None

Applicable plugins:

- None

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code
- [x] 🦖 : Typing improve

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
