### PR TITLE
(fix): Incorrect work with Playwright helper

### DIFF
--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -244,7 +244,10 @@ class Playwright extends Helper {
   }
 
   _getOptionsForBrowser(config) {
-    return config[config.browser] || {};
+    return config[config.browser] ? {
+      ...config[config.browser],
+      wsEndpoint: config[config.browser].browserWSEndpoint,
+    } : {};
   }
 
   _setConfig(config) {
@@ -546,10 +549,7 @@ class Playwright extends Helper {
   async _startBrowser() {
     if (this.isRemoteBrowser) {
       try {
-        this.browser = await playwright[this.options.browser].connect({
-          ...this.playwrightOptions,
-          wsEndpoint: this.playwrightOptions.browserWSEndpoint
-        });
+        this.browser = await playwright[this.options.browser].connect(this.playwrightOptions);
       } catch (err) {
         if (err.toString().indexOf('ECONNREFUSED')) {
           throw new RemoteBrowserConnectionRefused(err);

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -546,7 +546,10 @@ class Playwright extends Helper {
   async _startBrowser() {
     if (this.isRemoteBrowser) {
       try {
-        this.browser = await playwright[this.options.browser].connect(this.playwrightOptions);
+        this.browser = await playwright[this.options.browser].connect({
+          ...this.playwrightOptions,
+          wsEndpoint: this.playwrightOptions.browserWSEndpoint
+        });
       } catch (err) {
         if (err.toString().indexOf('ECONNREFUSED')) {
           throw new RemoteBrowserConnectionRefused(err);
@@ -580,11 +583,7 @@ class Playwright extends Helper {
     this.context = null;
     popupStore.clear();
 
-    if (this.isRemoteBrowser) {
-      await this.browser.disconnect();
-    } else {
-      await this.browser.close();
-    }
+    await this.browser.close();
   }
 
   async _evaluateHandeInContext(...args) {


### PR DESCRIPTION
## Motivation/Description of the PR

In our team we use remote execution e2e tests with Moon and Playwright. When I setup config from documentation: https://codecept.io/helpers/Playwright/#configuration I got error with connection. Playwright not connect to remote browser.

I went inside `lib/helper/Playwright.js` and viewd Playwright documentation on link https://playwright.dev/ I was found that Playwright use other option for connect to remote browser: `wsEndpoint`.
https://github.com/codeceptjs/CodeceptJS/blob/a72aa750003734f926cd55c14bd6dfeeea6ea104/lib/helper/Playwright.js#L549

After fix it I got next error with disconnect from remote browser:
https://github.com/codeceptjs/CodeceptJS/blob/a72aa750003734f926cd55c14bd6dfeeea6ea104/lib/helper/Playwright.js#L584
In Playwright doc for all of versions I culdn't find this option (function). I found only `close` option (function).

This PR fix incorrect connection to remote browser with Playwright and fix incorrect close connect with remote browser.

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [x] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [x] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
