### PR TITLE
doc: Fix Pupeteer documentation for waitFroResponse

### DIFF
--- a/docs/helpers/Puppeteer.md
+++ b/docs/helpers/Puppeteer.md
@@ -1879,11 +1879,11 @@ I.waitForRequest(request => request.url() === 'http://example.com' && request.me
 
 ### waitForResponse
 
-Waits for a network response.
+Waits for a network request.
 
 ```js
 I.waitForResponse('http://example.com/resource');
-I.waitForResponse(response => response.url() === 'http://example.com' && response.request().method() === 'GET');
+I.waitForResponse(request => request.url() === 'http://example.com' && request.method() === 'GET');
 ```
 
 #### Parameters

--- a/docs/helpers/Puppeteer.md
+++ b/docs/helpers/Puppeteer.md
@@ -1879,11 +1879,11 @@ I.waitForRequest(request => request.url() === 'http://example.com' && request.me
 
 ### waitForResponse
 
-Waits for a network request.
+Waits for a network response.
 
 ```js
 I.waitForResponse('http://example.com/resource');
-I.waitForResponse(request => request.url() === 'http://example.com' && request.method() === 'GET');
+I.waitForResponse(response => response.url() === 'http://example.com' && response.request().method() === 'GET');
 ```
 
 #### Parameters

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -2107,11 +2107,11 @@ class Puppeteer extends Helper {
   }
 
   /**
-   * Waits for a network request.
+   * Waits for a network response.
    *
    * ```js
    * I.waitForResponse('http://example.com/resource');
-   * I.waitForResponse(request => request.url() === 'http://example.com' && request.method() === 'GET');
+   * I.waitForResponse(response => response.url() === 'http://example.com' && response.request().method() === 'GET');
    * ```
    *
    * @param {string|function} urlOrPredicate


### PR DESCRIPTION
The predicate method accepts the `response` object and not `request`

## Motivation/Description of the PR

Simple doc update. I believe it is a simple copy&paste mistake.

Applicable helpers:

- [ ] WebDriver
- [x] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [x] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [x] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
