### PR TITLE
fix --suites flag for run workers

### DIFF
--- a/lib/workers.js
+++ b/lib/workers.js
@@ -253,10 +253,12 @@ class Workers extends EventEmitter {
    * @param {Number} numberOfWorkers
    */
   createGroupsOfSuites(numberOfWorkers) {
+    const files = this.codecept.testFiles;
     const groups = populateGroups(numberOfWorkers);
 
     const mocha = Container.mocha();
-
+    mocha.files = files;
+    mocha.loadFiles();
     mocha.suite.suites.forEach((suite) => {
       const i = indexOfSmallestElement(groups);
       suite.tests.forEach((test) => {

--- a/test/runner/run_workers_test.js
+++ b/test/runner/run_workers_test.js
@@ -59,6 +59,20 @@ describe('CodeceptJS Workers Runner', function () {
     });
   });
 
+  it('should use suites', function (done) {
+    if (!semver.satisfies(process.version, '>=11.7.0')) this.skip('not for node version');
+    exec(`${codecept_run} 2 --suites`, (err, stdout) => {
+      expect(stdout).toContain('CodeceptJS'); // feature
+      expect(stdout).toContain('Running tests in 2 workers'); // feature
+      expect(stdout).toContain('glob current dir');
+      expect(stdout).toContain('From worker @1_grep print message 1');
+      expect(stdout).toContain('From worker @2_grep print message 2');
+      expect(stdout).not.toContain('this is running inside worker');
+      expect(err.code).toEqual(1);
+      done();
+    });
+  });
+
   it('should show failures when suite is failing', function (done) {
     if (!semver.satisfies(process.version, '>=11.7.0')) this.skip('not for node version');
     exec(`${codecept_run} 2 --grep "Workers Failing"`, (err, stdout) => {


### PR DESCRIPTION
## Motivation/Description of the PR
- The suites flag for workers is not working, wrote runner test to prove it
- Resolves #issueId (if applicable).

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [x] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
