### PR TITLE
update @codeceptjs/configure dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "dtslint": "dtslint typings --localTs './node_modules/typescript/lib'"
   },
   "dependencies": {
-    "@codeceptjs/configure": "^0.4.1",
+    "@codeceptjs/configure": "^0.6.2",
     "@codeceptjs/helper": "^1.0.1",
     "acorn": "^7.1.0",
     "allure-js-commons": "^1.3.2",


### PR DESCRIPTION
## Motivation/Description of the PR
Upgrade dependency to remove unnecessary webdriverio@5 istalling.
see `@codeceptjs/configure` PR https://github.com/codeceptjs/configure/pull/12

not sure, should be PR to `master` done, or `3.x` only

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
