### PR TITLE
fix(Playwright): handle null context in proceedClick

### DIFF
--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -2152,7 +2152,7 @@ async function findElements(matcher, locator) {
 }
 
 async function proceedClick(locator, context = null, options = {}) {
-  let matcher = await this.context;
+  let matcher = await this._getContext();
   if (context) {
     const els = await this._locate(context);
     assertElementExists(els, context);


### PR DESCRIPTION
## Motivation/Description of the PR

We have a test that opens a link in a new tab, switches to that tab and tries to click a button. Some example code:
```javascript
I.click(locate('.some-button'));
I.switchToNextTab();
I.waitForElement('Get Started');
I.retry(5).forceClick('Get Started');
```

 and we get this error intermittently (maybe 50% of our runs):
```
     Cannot read property '$$' of null
      at Playwright.findElements (node_modules/codeceptjs/lib/helper/Playwright.js:2152:18)
      at Playwright.findClickable (node_modules/codeceptjs/lib/helper/Playwright.js:2186:47)
      at Playwright.proceedClick (node_modules/codeceptjs/lib/helper/Playwright.js:2162:35)
```

After some spelunking, we discovered that sometimes `this.context` gets set to `null`. No clue how that's happening as `_setPage` is meant to set the context and gets called when switching tabs. However, most methods in the file are using `this._getContext()` but I'm not sure what the semantic difference between it and `this.context` is. 

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [x] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
