### PR TITLE
♨️ Hot fix (recorder): don't mess retries order any more

### DIFF
--- a/lib/actor.js
+++ b/lib/actor.js
@@ -35,8 +35,6 @@ class Actor {
   retry(opts) {
     if (opts === undefined) opts = 1;
     recorder.retry(opts);
-    // adding an empty promise to clear retries
-    recorder.add(() => null);
     // remove retry once the step passed
     recorder.add(() => event.dispatcher.once(event.step.finished, () => recorder.retries.pop()));
     return this;

--- a/lib/recorder.js
+++ b/lib/recorder.js
@@ -178,11 +178,9 @@ module.exports = {
         return Promise.resolve(res).then(fn);
       }
 
+      const retryRules = this.retries.slice().reverse();
       return promiseRetry(Object.assign(defaultRetryOptions, retryOpts), (retry, number) => {
         if (number > 1) log(`${currentQueue()}Retrying... Attempt #${number}`);
-
-        const retryRules = this.retries.slice().reverse();
-
         return Promise.resolve(res).then(fn).catch((err) => {
           for (const retryObj of retryRules) {
             if (!retryObj.when) return retry(err);

--- a/lib/recorder.js
+++ b/lib/recorder.js
@@ -181,7 +181,7 @@ module.exports = {
       return promiseRetry(Object.assign(defaultRetryOptions, retryOpts), (retry, number) => {
         if (number > 1) log(`${currentQueue()}Retrying... Attempt #${number}`);
 
-        const retryRules = this.retries.reverse();
+        const retryRules = this.retries.slice().reverse();
 
         return Promise.resolve(res).then(fn).catch((err) => {
           for (const retryObj of retryRules) {

--- a/test/unit/plugin/retryFailedStep_test.js
+++ b/test/unit/plugin/retryFailedStep_test.js
@@ -142,4 +142,21 @@ describe('retryFailedStep', () => {
     // expects to retry only once
     counter.should.equal(2);
   });
+
+  it('should not turn around the chain of retries', () => {
+    recorder.retry({ retries: 2, when: (err) => { return err.message === 'someerror'; }, identifier: 'test' });
+    recorder.retry({ retries: 2, when: (err) => { return err.message === 'othererror'; } });
+
+    const getRetryIndex = () => recorder.retries.indexOf(recorder.retries.find(retry => retry.identifier));
+    let initalIndex;
+
+    recorder.add(() => {
+      initalIndex = getRetryIndex();
+    }, undefined, undefined, true);
+
+    recorder.add(() => {
+      initalIndex.should.equal(getRetryIndex());
+    }, undefined, undefined, true);
+    return recorder.promise();
+  });
 });


### PR DESCRIPTION
## Motivation/Description of the PR
- the retries order was turned around each time a promise was recorded
- this was a problem because `retryOpts` are extracted from the last element in the array
- have a look at the code and attach a debugger, while running a test with special `retriy()`-options


Applicable helpers:

- [x] WebDriver
- [x] Puppeteer
- [x] Nightmare
- [x] REST
- [x] FileHelper
- [x] Appium
- [x] Protractor
- [x] TestCafe
- [x] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [x] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [x] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
