### PR TITLE
improve recorder a little: don't retry hooks

### DIFF
--- a/lib/listener/helpers.js
+++ b/lib/listener/helpers.js
@@ -23,7 +23,7 @@ module.exports = function () {
     if (store.dryRun) return;
     Object.keys(helpers).forEach((key) => {
       if (!helpers[key][hook]) return;
-      recorder.add(`hook ${key}.${hook}()`, () => helpers[key][hook](param), force);
+      recorder.add(`hook ${key}.${hook}()`, () => helpers[key][hook](param), force, false);
     });
   };
 

--- a/lib/recorder.js
+++ b/lib/recorder.js
@@ -154,17 +154,20 @@ module.exports = {
    * @param {string|function} taskName
    * @param {function} [fn]
    * @param {boolean} [force=false]
-   * @param {boolean} [retry=true] -
+   * @param {boolean} [retry]
+   *     undefined: `add(fn)` -> `false` and `add('step',fn)` -> `true`
    *     true: it will retries if `retryOpts` set.
    *     false: ignore `retryOpts` and won't retry.
    * @return {Promise<*> | undefined}
    * @inner
    */
-  add(taskName, fn = undefined, force = false, retry = true) {
+  add(taskName, fn = undefined, force = false, retry = undefined) {
     if (typeof taskName === 'function') {
       fn = taskName;
       taskName = fn.toString();
+      if (retry === undefined) retry = false;
     }
+    if (retry === undefined) retry = true;
     if (!running && !force) {
       return;
     }

--- a/test/rest/REST_test.js
+++ b/test/rest/REST_test.js
@@ -183,7 +183,7 @@ describe('REST - Form upload', () => {
 
   describe('upload file', () => {
     it('should show error when file size exceedes the permit', async () => {
-      let form = new FormData();
+      const form = new FormData();
       form.append('file', fs.createReadStream(testFile));
 
       try {
@@ -194,7 +194,7 @@ describe('REST - Form upload', () => {
     });
 
     it('should not show error when file size doesnt exceedes the permit', async () => {
-      let form = new FormData();
+      const form = new FormData();
       form.append('file', fs.createReadStream(testFile));
 
       try {

--- a/test/unit/plugin/retryFailedStep_test.js
+++ b/test/unit/plugin/retryFailedStep_test.js
@@ -30,7 +30,7 @@ describe('retryFailedStep', () => {
       if (counter < 3) {
         throw new Error();
       }
-    });
+    }, undefined, undefined, true);
     return recorder.promise();
   });
   it('should not retry within', async () => {
@@ -44,7 +44,7 @@ describe('retryFailedStep', () => {
         recorder.add(() => {
           counter++;
           throw new Error();
-        });
+        }, undefined, undefined, true);
       });
       await recorder.promise();
     } catch (e) {
@@ -67,7 +67,7 @@ describe('retryFailedStep', () => {
         if (counter < 3) {
           throw new Error();
         }
-      });
+      }, undefined, undefined, true);
       await recorder.promise();
     } catch (e) {
       recorder.catchWithoutStop((err) => err);
@@ -89,7 +89,7 @@ describe('retryFailedStep', () => {
         if (counter < 3) {
           throw new Error();
         }
-      });
+      }, undefined, undefined, true);
       await recorder.promise();
     } catch (e) {
       recorder.catchWithoutStop((err) => err);
@@ -111,7 +111,7 @@ describe('retryFailedStep', () => {
         if (counter < 3) {
           throw new Error();
         }
-      });
+      }, undefined, undefined, true);
       await recorder.promise();
     } catch (e) {
       recorder.catchWithoutStop((err) => err);
@@ -132,7 +132,7 @@ describe('retryFailedStep', () => {
         recorder.add(() => {
           counter++;
           throw new Error();
-        });
+        }, undefined, undefined, true);
       });
       await recorder.promise();
     } catch (e) {

--- a/test/unit/recorder_test.js
+++ b/test/unit/recorder_test.js
@@ -59,7 +59,7 @@ describe('Recorder', () => {
         if (counter < 3) {
           throw new Error('ups');
         }
-      });
+      }, undefined, undefined, true);
       return recorder.promise();
     });
 
@@ -74,7 +74,7 @@ describe('Recorder', () => {
         if (counter < 3) {
           throw new Error(errorText);
         }
-      });
+      }, undefined, undefined, true);
       return recorder.promise();
     });
   });


### PR DESCRIPTION
## Motivation/Description of the PR
- during debugging I recognised retries on hooks

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [x] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
