### PR TITLE
refactor puppeteer a bit

### DIFF
--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -2120,7 +2120,7 @@ class Puppeteer extends Helper {
       if (locator >= 0 && locator < childFrames.length) {
         this.context = childFrames[locator];
       } else {
-        throw new Error('Element #invalidIframeSelector was not found by text|CSS|XPath');
+        throw new Error('Frame was not found by number.');
       }
       return;
     }

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -1139,15 +1139,15 @@ class Puppeteer extends Helper {
   /**
    * {{> seeCheckboxIsChecked }}
    */
-  async seeCheckboxIsChecked(field) {
-    return proceedIsChecked.call(this, 'assert', field);
+  async seeCheckboxIsChecked(field, context = null) {
+    return proceedIsChecked.call(this, 'assert', field, context);
   }
 
   /**
    * {{> dontSeeCheckboxIsChecked }}
    */
-  async dontSeeCheckboxIsChecked(field) {
-    return proceedIsChecked.call(this, 'negate', field);
+  async dontSeeCheckboxIsChecked(field, context = null) {
+    return proceedIsChecked.call(this, 'negate', field, context);
   }
 
   /**
@@ -2332,13 +2332,13 @@ async function findCheckable(locator, context) {
   return findElements.call(this, matcher, locator);
 }
 
-async function proceedIsChecked(assertType, option) {
-  let els = await findCheckable.call(this, option);
-  assertElementExists(els, option, 'Checkable');
+async function proceedIsChecked(assertType, locator, context) {
+  let els = await this._locateCheckable(locator, context);
+  assertElementExists(els, locator, 'Checkable');
   els = await Promise.all(els.map(el => el.getProperty('checked')));
   els = await Promise.all(els.map(el => el.jsonValue()));
   const selected = els.reduce((prev, cur) => prev || cur);
-  return truth(`checkable ${option}`, 'to be checked')[assertType](selected);
+  return truth(`checkable ${locator}`, 'to be checked')[assertType](selected);
 }
 
 async function findFields(locator) {

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -247,16 +247,6 @@ class Puppeteer extends Helper {
 
   async _before() {
     this.sessionPages = {};
-    recorder.retry({
-      retries: 5,
-      when: err => {
-        if (!err || typeof (err.message) !== 'string') {
-          return false;
-        }
-        // ignore context errors
-        return err.message.includes('context');
-      },
-    });
     if (this.options.restart && !this.options.manualStart) return this._startBrowser();
     if (!this.isRunning && !this.options.manualStart) return this._startBrowser();
     return this.browser;

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -988,7 +988,8 @@ class Puppeteer extends Helper {
    * {{ react }}
    */
   async forceClick(locator, context = null) {
-    const els = await findClickable.call(this, await this._getMatcher(context), locator);
+    const matcher = await getMatcher.call(this, context);
+    const els = await findClickable.call(this, matcher, locator);
     if (context) {
       assertElementExists(els, locator, 'Clickable element', `was not found inside element ${new Locator(context).toString()}`);
     } else {

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -431,7 +431,7 @@ class Puppeteer extends Helper {
     this.page = page;
     if (!page) return;
     page.setDefaultNavigationTimeout(this.options.getPageTimeout);
-    this.context = await this.page.$('body');
+    this.context = page.mainFrame();
     if (this.config.browser === 'chrome') {
       await page.bringToFront();
     }
@@ -546,15 +546,8 @@ class Puppeteer extends Helper {
   }
 
   async _evaluateHandeInContext(...args) {
-    let context = await this._getContext();
-
-    if (context.constructor.name === 'Frame') {
-      // Currently there is no evalateHandle for the Frame object
-      // https://github.com/GoogleChrome/puppeteer/issues/1051
-      context = await context.executionContext();
-    }
-
-    return context.evaluateHandle(...args);
+    // not needed any more but kept for backwards compatibility
+    return this._getContext().evaluateHandle(...args);
   }
 
   async _withinBegin(locator) {
@@ -583,7 +576,7 @@ class Puppeteer extends Helper {
 
   async _withinEnd() {
     this.withinLocator = null;
-    this.context = await this.page.mainFrame().$('body');
+    this.context = this.page.mainFrame();
   }
 
   _extractDataFromPerformanceTiming(timing, ...dataNames) {
@@ -795,7 +788,7 @@ class Puppeteer extends Helper {
    * {{ react }}
    */
   async _locate(locator) {
-    const matcher = await this.context || await this._getContext();
+    const matcher = this._getContext();
     return findElements(matcher, locator);
   }
 
@@ -808,7 +801,7 @@ class Puppeteer extends Helper {
    * ```
    */
   async _locateCheckable(locator, providedContext = null) {
-    const context = providedContext || await this._getContext();
+    const context = providedContext || this._getContext();
     const els = await findCheckable.call(this, locator, context);
     assertElementExists(els[0], locator, 'Checkbox or radio');
     return els[0];
@@ -822,7 +815,7 @@ class Puppeteer extends Helper {
    * ```
    */
   async _locateClickable(locator) {
-    const context = await this._getContext();
+    const context = this._getContext();
     return findClickable.call(this, context, locator);
   }
 
@@ -1240,9 +1233,9 @@ class Puppeteer extends Helper {
     const tag = await el.getProperty('tagName').then(el => el.jsonValue());
     const editable = await el.getProperty('contenteditable').then(el => el.jsonValue());
     if (tag === 'INPUT' || tag === 'TEXTAREA') {
-      await this._evaluateHandeInContext(el => el.value = '', el);
+      await this._getContext().evaluateHandle(el => el.value = '', el);
     } else if (editable) {
-      await this._evaluateHandeInContext(el => el.innerHTML = '', el);
+      await this._getContext().evaluateHandle(el => el.innerHTML = '', el);
     }
     await el.type(value.toString(), { delay: this.options.pressKeyDelay });
     return this._waitForAction();
@@ -1315,15 +1308,15 @@ class Puppeteer extends Helper {
       const opt = xpathLocator.literal(option[key]);
       let optEl = await findElements.call(this, el, { xpath: Locator.select.byVisibleText(opt) });
       if (optEl.length) {
-        this._evaluateHandeInContext(el => el.selected = true, optEl[0]);
+        this._getContext().evaluateHandle(el => el.selected = true, optEl[0]);
         continue;
       }
       optEl = await findElements.call(this, el, { xpath: Locator.select.byValue(opt) });
       if (optEl.length) {
-        this._evaluateHandeInContext(el => el.selected = true, optEl[0]);
+        this._getContext().evaluateHandle(el => el.selected = true, optEl[0]);
       }
     }
-    await this._evaluateHandeInContext((element) => {
+    await this._getContext().evaluateHandle((element) => {
       element.dispatchEvent(new Event('input', { bubbles: true }));
       element.dispatchEvent(new Event('change', { bubbles: true }));
     }, el);
@@ -1517,7 +1510,7 @@ class Puppeteer extends Helper {
    * If a function returns a Promise It will wait for it resolution.
    */
   async executeScript(...args) {
-    const context = await this._getContext();
+    const context = this._getContext();
     return context.evaluate.apply(context, args);
   }
 
@@ -1741,7 +1734,7 @@ class Puppeteer extends Helper {
     const els = await this._locate(locator);
     const array = [];
     for (let index = 0; index < els.length; index++) {
-      const a = await this._evaluateHandeInContext((el, attr) => el[attr] || el.getAttribute(attr), els[index], attr);
+      const a = await this._getContext().evaluateHandle((el, attr) => el[attr] || el.getAttribute(attr), els[index], attr);
       array.push(await a.jsonValue());
     }
     return array;
@@ -1818,9 +1811,8 @@ class Puppeteer extends Helper {
   async waitForEnabled(locator, sec) {
     const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout;
     locator = new Locator(locator, 'css');
-    await this.context;
     let waiter;
-    const context = await this._getContext();
+    const context = this._getContext();
     if (locator.isCSS()) {
       const enabledFn = function (locator) {
         const els = document.querySelectorAll(locator);
@@ -1848,9 +1840,8 @@ class Puppeteer extends Helper {
   async waitForValue(field, value, sec) {
     const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout;
     const locator = new Locator(field, 'css');
-    await this.context;
     let waiter;
-    const context = await this._getContext();
+    const context = this._getContext();
     if (locator.isCSS()) {
       const valueFn = function (locator, value) {
         const els = document.querySelectorAll(locator);
@@ -1880,9 +1871,8 @@ class Puppeteer extends Helper {
   async waitNumberOfVisibleElements(locator, num, sec) {
     const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout;
     locator = new Locator(locator, 'css');
-    await this.context;
     let waiter;
-    const context = await this._getContext();
+    const context = this._getContext();
     if (locator.isCSS()) {
       const visibleFn = function (locator, num) {
         const els = document.querySelectorAll(locator);
@@ -1927,9 +1917,8 @@ class Puppeteer extends Helper {
   async waitForElement(locator, sec) {
     const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout;
     locator = new Locator(locator, 'css');
-
     let waiter;
-    const context = await this._getContext();
+    const context = this._getContext();
     if (locator.isCSS()) {
       waiter = context.waitForSelector(locator.simplify(), { timeout: waitTimeout });
     } else {
@@ -1948,9 +1937,8 @@ class Puppeteer extends Helper {
   async waitForVisible(locator, sec) {
     const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout;
     locator = new Locator(locator, 'css');
-    await this.context;
     let waiter;
-    const context = await this._getContext();
+    const context = this._getContext();
     if (locator.isCSS()) {
       waiter = context.waitForSelector(locator.simplify(), { timeout: waitTimeout, visible: true });
     } else {
@@ -1967,9 +1955,8 @@ class Puppeteer extends Helper {
   async waitForInvisible(locator, sec) {
     const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout;
     locator = new Locator(locator, 'css');
-    await this.context;
     let waiter;
-    const context = await this._getContext();
+    const context = this._getContext();
     if (locator.isCSS()) {
       waiter = context.waitForSelector(locator.simplify(), { timeout: waitTimeout, hidden: true });
     } else {
@@ -1987,7 +1974,7 @@ class Puppeteer extends Helper {
     const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout;
     locator = new Locator(locator, 'css');
     let waiter;
-    const context = await this._getContext();
+    const context = this._getContext();
     if (locator.isCSS()) {
       waiter = context.waitForSelector(locator.simplify(), { timeout: waitTimeout, hidden: true });
     } else {
@@ -1998,11 +1985,11 @@ class Puppeteer extends Helper {
     });
   }
 
-  async _getContext() {
+  _getContext() {
     if (this.context && this.context.constructor.name === 'Frame') {
       return this.context;
     }
-    return this.page;
+    return this.page.mainFrame();
   }
 
   /**
@@ -2055,7 +2042,7 @@ class Puppeteer extends Helper {
     const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout;
     let waiter;
 
-    const contextObject = await this._getContext();
+    const contextObject = this._getContext();
 
     if (context) {
       const locator = new Locator(context, 'css');
@@ -2138,7 +2125,7 @@ class Puppeteer extends Helper {
       return;
     }
     if (!locator) {
-      this.context = await this.page.mainFrame().$('body');
+      this.context = this.page.mainFrame();
       return;
     }
 
@@ -2167,7 +2154,7 @@ class Puppeteer extends Helper {
       }
     }
     const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout;
-    const context = await this._getContext();
+    const context = this._getContext();
     return context.waitForFunction(fn, { timeout: waitTimeout }, ...args);
   }
 
@@ -2193,7 +2180,7 @@ class Puppeteer extends Helper {
   async waitUntil(fn, sec = null) {
     console.log('This method will remove in CodeceptJS 1.4; use `waitForFunction` instead!');
     const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout;
-    const context = await this._getContext();
+    const context = this._getContext();
     return context.waitForFunction(fn, { timeout: waitTimeout });
   }
 
@@ -2212,7 +2199,7 @@ class Puppeteer extends Helper {
     locator = new Locator(locator, 'css');
 
     let waiter;
-    const context = await this._getContext();
+    const context = this._getContext();
     if (locator.isCSS()) {
       const visibleFn = function (locator) {
         return document.querySelector(locator) === null;
@@ -2264,7 +2251,7 @@ async function getMatcher(context, returnAll = false) {
     }
     return els[0];
   }
-  return await this.context || await this._getContext();
+  return this.context || this._getContext();
 }
 
 async function findElements(matcher, locator) {
@@ -2522,10 +2509,8 @@ function $XPath(element, selector) {
 async function targetCreatedHandler(page) {
   if (!page) return;
   this.withinLocator = null;
-  page.on('load', () => {
-    page.$('body')
-      .catch(() => null)
-      .then(context => this.context = context);
+  page.on('domcontentloaded', () => {
+    this.context = page;
   });
   page.on('console', (msg) => {
     this.debugSection(`Browser:${ucfirst(msg.type())}`, (msg._text || '') + msg.args().join(' '));

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -795,7 +795,8 @@ class Puppeteer extends Helper {
    * {{ react }}
    */
   async _locate(locator) {
-    return findElements(await this.context, locator);
+    const matcher = await this.context || await this._getContext();
+    return findElements(matcher, locator);
   }
 
   /**
@@ -987,14 +988,7 @@ class Puppeteer extends Helper {
    * {{ react }}
    */
   async forceClick(locator, context = null) {
-    let matcher = await this.context;
-    if (context) {
-      const els = await this._locate(context);
-      assertElementExists(els, context);
-      matcher = els[0];
-    }
-
-    const els = await findClickable.call(this, matcher, locator);
+    const els = await findClickable.call(this, await this._getMatcher(context), locator);
     if (context) {
       assertElementExists(els, locator, 'Clickable element', `was not found inside element ${new Locator(context).toString()}`);
     } else {
@@ -1522,10 +1516,7 @@ class Puppeteer extends Helper {
    * If a function returns a Promise It will wait for it resolution.
    */
   async executeScript(...args) {
-    let context = this.page;
-    if (this.context && this.context.constructor.name === 'Frame') {
-      context = this.context; // switching to iframe context
-    }
+    const context = await this._getContext();
     return context.evaluate.apply(context, args);
   }
 
@@ -2263,6 +2254,18 @@ class Puppeteer extends Helper {
 
 module.exports = Puppeteer;
 
+async function getMatcher(context, returnAll = false) {
+  if (context) {
+    const els = await this._locate(context);
+    assertElementExists(els, context);
+    if (returnAll) {
+      return els;
+    }
+    return els[0];
+  }
+  return await this.context || await this._getContext();
+}
+
 async function findElements(matcher, locator) {
   if (locator.react) return findReact(matcher, locator);
   locator = new Locator(locator, 'css');
@@ -2271,12 +2274,7 @@ async function findElements(matcher, locator) {
 }
 
 async function proceedClick(locator, context = null, options = {}) {
-  let matcher = await this.context;
-  if (context) {
-    const els = await this._locate(context);
-    assertElementExists(els, context);
-    matcher = els[0];
-  }
+  const matcher = await getMatcher.call(this, context);
   const els = await findClickable.call(this, matcher, locator);
   if (context) {
     assertElementExists(els, locator, 'Clickable element', `was not found inside element ${new Locator(context).toString()}`);
@@ -2318,25 +2316,18 @@ async function findClickable(matcher, locator) {
 
 async function proceedSee(assertType, text, context, strict = false) {
   let description;
-  let allText;
-  if (!context) {
-    let el = await this.context;
-
+  const els = [await getMatcher.call(this, context, true)].flat(1);
+  if (context) {
+    description = `element ${new Locator(context).toString()}`;
+  } else {
+    description = 'web application';
+    const el = els[0];
     if (el && !el.getProperty) {
       // Fallback to body
-      el = await this.context.$('body');
+      els[0] = await el.$('body');
     }
-
-    allText = [await el.getProperty('innerText').then(p => p.jsonValue())];
-    description = 'web application';
-  } else {
-    const locator = new Locator(context, 'css');
-    description = `element ${locator.toString()}`;
-    const els = await this._locate(locator);
-    assertElementExists(els, locator.toString());
-    allText = await Promise.all(els.map(el => el.getProperty('innerText').then(p => p.jsonValue())));
   }
-
+  const allText = await Promise.all(els.map(el => el.getProperty('innerText').then(p => p.jsonValue())));
   if (strict) {
     return allText.map(elText => equals(description)[assertType](text, elText));
   }
@@ -2344,27 +2335,23 @@ async function proceedSee(assertType, text, context, strict = false) {
 }
 
 async function findCheckable(locator, context) {
-  let contextEl = await this.context;
-  if (typeof context === 'string') {
-    contextEl = await findElements.call(this, contextEl, (new Locator(context, 'css')).simplify());
-    contextEl = contextEl[0];
-  }
+  const matcher = await getMatcher.call(this, context);
 
   const matchedLocator = new Locator(locator);
   if (!matchedLocator.isFuzzy()) {
-    return findElements.call(this, contextEl, matchedLocator.simplify());
+    return findElements.call(this, matcher, matchedLocator.simplify());
   }
 
   const literal = xpathLocator.literal(locator);
-  let els = await findElements.call(this, contextEl, Locator.checkable.byText(literal));
+  let els = await findElements.call(this, matcher, Locator.checkable.byText(literal));
   if (els.length) {
     return els;
   }
-  els = await findElements.call(this, contextEl, Locator.checkable.byName(literal));
+  els = await findElements.call(this, matcher, Locator.checkable.byName(literal));
   if (els.length) {
     return els;
   }
-  return findElements.call(this, contextEl, locator);
+  return findElements.call(this, matcher, locator);
 }
 
 async function proceedIsChecked(assertType, option) {

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "@pollyjs/core": "^2.6.3",
     "@types/inquirer": "^0.0.35",
     "@types/node": "^8.10.61",
+    "@types/promise-retry": "^1.1.3",
     "@wdio/sauce-service": "^5.22.5",
     "@wdio/selenium-standalone-service": "^5.16.10",
     "@wdio/utils": "^5.23.0",

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "puppeteer": "^4.0.0",
     "qrcode-terminal": "^0.12.0",
     "rosie": "^1.6.0",
-    "runok": "^0.9.2",
+    "runok": "^0.9.3",
     "sinon": "^9.0.2",
     "sinon-chai": "^3.5.0",
     "testcafe": "^1.8.6",


### PR DESCRIPTION
## Motivation/Description of the PR
- I saw PR #2667 and had a look at the Puppeteer Code.
- I currently use a sophisticated implicit retry helper to avoid problems like `Cannot read property '$$' of null` or `Cannot read property '$x' of null` and I want to get rid of it.
- I tested it a little with out testsuite and it looks all right.

Applicable helpers:

- [ ] WebDriver
- [x] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [x] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [x] Documentation has been added (Run `npm run docs`) -> (no changes for puppeteer)
- [x] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
- [x] Local unit-tests are passed (Run `npm test:unit`)
