### PR TITLE
Fix attachments usage for `mocha-junit-reporter`

### DIFF
--- a/docs/reports.md
+++ b/docs/reports.md
@@ -360,9 +360,9 @@ Configure mocha-multi with reports that you want:
       "mocha-junit-reporter": {
         "stdout": "./output/console.log",
         "options": {
-          "mochaFile": "./output/result.xml"
-        },
-        "attachments": true //add screenshot for a failed test
+          "mochaFile": "./output/result.xml",
+          "attachments": true //add screenshot for a failed test
+        }
       }
     }
   }

--- a/lib/plugin/screenshotOnFail.js
+++ b/lib/plugin/screenshotOnFail.js
@@ -99,8 +99,7 @@ module.exports = function (config) {
         await helper.saveScreenshot(fileName, options.fullPageScreenshots);
 
         test.artifacts.screenshot = path.join(global.output_dir, fileName);
-
-        if (Container.mocha().options.reporterOptions['mocha-junit-reporter'] && Container.mocha().options.reporterOptions['mocha-junit-reporter'].attachments) {
+        if (Container.mocha().options.reporterOptions['mocha-junit-reporter'] && Container.mocha().options.reporterOptions['mocha-junit-reporter'].options.attachments) {
           test.attachments = [path.join(global.output_dir, fileName)];
         }
 


### PR DESCRIPTION
## Motivation/Description of the PR

This PR will fix the issue in #1502 regarding double setting of the `attachments` setting (described in https://github.com/codeceptjs/CodeceptJS/issues/1502#issuecomment-494112578)

The current implementation checks for the `attachments` option in the
wrong location, which requires the user to set `attachments:true` in two
places, the current location and within the `options` object.

This changes the check and docs to only use the `options` object which is
what `mocha-junit-report` is actually looking for.

Applicable helpers:

Does not directly effect helpers

Applicable plugins:

- [X] screenshotOnFail
- [X] mocha-junit-reporter

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [X] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [X] Documentation has been added (Run `npm run docs`)
- [X] Lint checking (Run `npm run lint`)
- [X] Local tests are passed (Run `npm test`)

