### PR TITLE
feat: add status, start/end time, and matchline for bddStep event

### DIFF
--- a/lib/interfaces/gherkin.js
+++ b/lib/interfaces/gherkin.js
@@ -28,7 +28,6 @@ module.exports = (text) => {
 
   const runSteps = async (steps) => {
     for (const step of steps) {
-      event.emit(event.bddStep.before, step);
       const metaStep = new Step.MetaStep(null, step.text);
       metaStep.actor = step.keyword.trim();
       const setMetaStep = (step) => {
@@ -44,10 +43,19 @@ module.exports = (text) => {
         if (step.argument.type === 'DataTable') metaStep.comment = `\n${transformTable(step.argument)}`;
         if (step.argument.content) metaStep.comment = `\n${step.argument.content}`;
       }
+      step.startTime = Date.now();
+      step.match = fn.line;
+      event.emit(event.bddStep.before, step);
       event.dispatcher.on(event.step.before, setMetaStep);
       try {
         await fn(...fn.params);
+        step.status = 'passed';
+      } catch (err) {
+        step.status = 'failed';
+        step.err = err;
+        return err;
       } finally {
+        step.endTime = Date.now();
         event.dispatcher.removeListener(event.step.before, setMetaStep);
       }
       event.emit(event.bddStep.after, step);


### PR DESCRIPTION
## Motivation/Description of the PR
I wanted to enhance bddStep reporting a bit more as a follow up to PR #2343 
Just as @wojtkowiak reported initially when there are no helper methods fired in a bdd step, it is hard to extract relevant information. Emitting an event was a good step forward. However, I have add some more properties - status, start/end time, error,  and step match location for enhanced reporting when the event is fired.

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [x] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
