### PR TITLE
trigger on onChange event for uploading file 

### DIFF
--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -1301,6 +1301,9 @@ class Puppeteer extends Helper {
     const els = await findFields.call(this, locator);
     assertElementExists(els, 'Field');
     await els[0].uploadFile(file);
+    await this._evaluateHandeInContext((element) => {
+      element.dispatchEvent(new Event('change', { bubbles: true }));
+    }, els[0]);
     return this._waitForAction();
   }
 


### PR DESCRIPTION
## Motivation/Description of the PR
This PR aimed to resolve the fact that on uploading file on attachFile, we didn't trigger the onChange effect, 
which may be important in lot of cases. Now, when we attachFile on an input, there is a trigger of the onChange event on the input, and a callback function can be called (for example to change the UI of the button type=['file'] or the app in general, on onChange event, when the file is uploaded).

Applicable helpers:

- [ ] WebDriver
- [X] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [X] :fire: Breaking changes
- [ ] :rocket: New functionality
- [X] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
