### PR TITLE
Fix: Fail "helper.saveScreenshot is not a function" on stepByStepReport plugin

### DIFF
--- a/lib/plugin/autoDelay.js
+++ b/lib/plugin/autoDelay.js
@@ -3,7 +3,7 @@ const store = require('../store');
 const recorder = require('../recorder');
 const event = require('../event');
 const log = require('../output').log;
-const supportedHelpers = require('./standardActingHelpers');
+const supportedHelpers = require('./standardActingHelpers').slice();
 
 const methodsToDelay = [
   'click',


### PR DESCRIPTION
## Motivation/Description of the PR
Description of this PR, which problem it solves

In the changes to remove the REST helper from list supoortedHelpers, we added this bug :'(

In the autoDelay.js file, the supoortedHelpers variable is declared by reference.

If a variable by reference is changed, all other plug-ins will have their values ​​changed as well, so by adding REST helper to the autoDelay.js file, the plugin, stepByStepReport.js will have 'REST' as well.

In this PR we changed the declaration of the variable to be by value, so we changed the list only in this plugin.

The fail "helper.saveScreenshot is not a function" occur when we use simultaneous:

helpers [REST, WebDriver]
plugins [autoDelay, stepByStepReport]
Original message fail: <Can't save step screenshot: TypeError: helper.saveScreenshot is not a function> undefined.

Related #2508, #2513, #2527, #2546

Applicable helpers:

- [x] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [x] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [x] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [x] screenshotOnFail
- [ ] selenoid
- [x] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [x] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [x] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
