### PR TITLE
Fix context error

### DIFF
--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -301,6 +301,10 @@ class Playwright extends Helper {
     }
   }
 
+  async _beforeStep() {
+    await this._setPage(this.page);
+  }
+
   async _before() {
     recorder.retry({
       retries: 5,

--- a/test/helper/Playwright_test.js
+++ b/test/helper/Playwright_test.js
@@ -172,6 +172,7 @@ describe('Playwright', function () {
     it('should be able to assert after post request', () => I.openNewTab()
       .then(() => I.amOnPage('/info'))
       .then(() => I.click('input[type=submit]'))
+      .then(() => I._beforeStep())
       .then(() => I.see('Welcome to test app!')));
 
     it('should assert when there is no ability to switch to next tab', () => I.amOnPage('/')

--- a/test/helper/Playwright_test.js
+++ b/test/helper/Playwright_test.js
@@ -169,6 +169,11 @@ describe('Playwright', function () {
       .then(() => I.grabNumberOfOpenTabs())
       .then(numPages => assert.equal(numPages, 2)));
 
+    it('should be able to assert after post request', () => I.openNewTab()
+      .then(() => I.amOnPage('/info'))
+      .then(() => I.click('input[type=submit]'))
+      .then(() => I.see('Welcome to test app!')));
+
     it('should assert when there is no ability to switch to next tab', () => I.amOnPage('/')
       .then(() => I.click('More info'))
       .then(() => I.wait(1)) // Wait is required because the url is change by previous statement (maybe related to #914)


### PR DESCRIPTION
## Motivation/Description of the PR

When clicking a submit button in a post request form after opening a new tab, I encountered this error.

```
     Execution context was destroyed, most likely because of a navigation.
      at Connection.sendMessageToServer (node_modules/playwright/lib/client/connection.js:69:15)
      at Proxy.<anonymous> (node_modules/playwright/lib/client/channelOwner.js:54:53)
      at ElementHandle.getProperty (node_modules/playwright/lib/client/jsHandle.js:39:44)
      at Playwright.proceedSee (lib/helper/Playwright.js:2489:25)
```

![image](https://user-images.githubusercontent.com/17092259/99979843-eacf8d80-2dea-11eb-8a29-c425da75bd2b.png)

This PR will fix this issue.

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [x] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [x] Tests have been added
- [x] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
