### PR TITLE
Emit test.after on workers

### DIFF
--- a/lib/workers.js
+++ b/lib/workers.js
@@ -335,6 +335,9 @@ class Workers extends EventEmitter {
           this.emit(event.test.skipped, repackTest(message.data));
           break;
         case event.test.finished: this.emit(event.test.finished, repackTest(message.data)); break;
+        case event.test.after:
+          this.emit(event.test.after, repackTest(message.data));
+          break;
         case event.all.after:
           this._appendStats(message.data); break;
       }


### PR DESCRIPTION
## Motivation/Description of the PR
- When a test fails, ex: an assertion, running in parallel, the error is never visible

## Type of change

- [x] :rocket: New functionality

## Checklist:

- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
