### PR TITLE
fix(autocomplete): no autocomplete for custom helper

### DIFF
--- a/lib/command/definitions.js
+++ b/lib/command/definitions.js
@@ -5,16 +5,17 @@ const { getConfig, getTestRoot } = require('./utils');
 const Codecept = require('../codecept');
 const container = require('../container');
 const output = require('../output');
+const actingHelpers = [...require('../../lib/plugin/standardActingHelpers'), 'REST'];
 
 const template = ({
-  helperNames, supportObject, importPaths, translations, hasCustomStepsFile,
+  helperNames, supportObject, importPaths, translations, hasCustomStepsFile, hasCustomHelper, customHelpers,
 }) => `/// <reference types='codeceptjs' />
 ${importPaths.join('\n')}
 
 declare namespace CodeceptJS {
   interface SupportObject ${convertMapToType(supportObject)}
   ${helperNames.length > 0 ? `interface Methods extends ${helperNames.join(', ')} {}` : ''}
-  interface I extends ${hasCustomStepsFile ? 'ReturnType<steps_file>' : 'WithTranslation<Methods>'} {}
+  interface I extends ${hasCustomStepsFile && hasCustomStepsFile ? `${['ReturnType<steps_file>', ...customHelpers].join(', ')}` : hasCustomStepsFile ? 'ReturnType<steps_file>' : 'WithTranslation<Methods>'} {}
   namespace Translation {
     interface Actions ${JSON.stringify(translations.vocabulary.actions, null, 2)}
   }
@@ -22,6 +23,7 @@ declare namespace CodeceptJS {
 `;
 
 const helperNames = [];
+const customHelpers = [];
 
 module.exports = function (genPath, options) {
   const configFile = options.config || genPath;
@@ -34,6 +36,7 @@ module.exports = function (genPath, options) {
   /** @type {Object<string, string>} */
   const supportPaths = {};
   let hasCustomStepsFile = false;
+  let hasCustomerHelper = false;
 
   const targetFolderPath = options.output && getTestRoot(options.output) || testsPath;
 
@@ -43,18 +46,26 @@ module.exports = function (genPath, options) {
   const helpers = container.helpers();
   const translations = container.translation();
   for (const name in helpers) {
-    const require = codecept.config.helpers[name].require;
-    if (require) {
-      helperPaths[name] = require;
-      helperNames.push(name);
-    } else {
-      helperNames.push(name);
+      const require = codecept.config.helpers[name].require;
+      if (require) {
+        helperPaths[name] = require;
+        helperNames.push(name);
+      } else {
+        helperNames.push(name);
+      }
+
+    if (!actingHelpers.includes(name)) {
+      customHelpers.push(`WithTranslation<${name}>`);
     }
   }
 
   const supportObject = new Map();
   supportObject.set('I', 'I');
-  supportObject.set('current', 'any');
+
+  if (customHelpers.length > 0) {
+    hasCustomerHelper = true;
+  }
+
   for (const name in codecept.config.include) {
     const includePath = codecept.config.include[name];
     if (name === 'I' || name === translations.I) {
@@ -72,6 +83,8 @@ module.exports = function (genPath, options) {
     importPaths: getImportString(testsPath, targetFolderPath, supportPaths, helperPaths),
     translations,
     hasCustomStepsFile,
+    hasCustomerHelper,
+    customHelpers
   });
 
   fs.writeFileSync(path.join(targetFolderPath, 'steps.d.ts'), definitionsTemplate);

--- a/lib/command/definitions.js
+++ b/lib/command/definitions.js
@@ -61,6 +61,7 @@ module.exports = function (genPath, options) {
 
   const supportObject = new Map();
   supportObject.set('I', 'I');
+  supportObject.set('current', 'any');
 
   if (customHelpers.length > 0) {
     hasCustomerHelper = true;


### PR DESCRIPTION
## Motivation/Description of the PR
- This PR aims to resolve the issue that there is no autocomplete for custom helper.

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
