### PR TITLE
feat: Ensure skipped data driven tests have a skip entry per data entry

### DIFF
--- a/lib/data/context.js
+++ b/lib/data/context.js
@@ -47,8 +47,17 @@ module.exports = function (context) {
     };
   };
 
-  context.xData = function () {
-    return { Scenario: context.xScenario };
+  context.xData = function (dataTable) {
+    const data = detectDataType(dataTable);
+    return {
+      Scenario: (title) => {
+        data.forEach((dataRow) => {
+          const dataTitle = replaceTitle(title, dataRow);
+          context.xScenario(dataTitle);
+        });
+        return new DataScenarioConfig([]);
+      },
+    };
   };
 };
 

--- a/test/data/sandbox/codecept.skip_ddt.json
+++ b/test/data/sandbox/codecept.skip_ddt.json
@@ -1,0 +1,11 @@
+{
+  "tests": "./*_test.skip_ddt.js",
+  "timeout": 10000,
+  "output": "./output",
+  "helpers": {
+  },
+  "include": {},
+  "bootstrap": false,
+  "mocha": {},
+  "name": "sandbox"
+}

--- a/test/data/sandbox/ddt_test.skip_ddt.js
+++ b/test/data/sandbox/ddt_test.skip_ddt.js
@@ -1,0 +1,8 @@
+Feature('SkipDDT');
+
+xData(function* () {
+  yield { user: 'bob' };
+  yield { user: 'anne' };
+}).Scenario('Should add skip entry for each item', ({ current }) => {
+  console.log(`I am ${current.user}`);
+});

--- a/test/runner/interface_test.js
+++ b/test/runner/interface_test.js
@@ -149,6 +149,19 @@ describe('CodeceptJS Interface', () => {
     });
   });
 
+  it('should provide skipped test for each entry of data', (done) => {
+    exec(config_run_config('codecept.skip_ddt.json'), (err, stdout) => {
+      const output = stdout.replace(/in [0-9]ms/g, '').replace(/\r/g, '');
+      expect(output).toContain('S Should add skip entry for each item | {"user":"bob"}');
+      expect(output).toContain('S Should add skip entry for each item | {"user":"anne"}');
+      expect(output).toContain('OK');
+      expect(output).toContain('0 passed');
+      expect(output).toContain('2 skipped');
+      expect(err).toBeFalsy();
+      done();
+    });
+  });
+
   it('should execute expected promise chain', (done) => {
     exec(`${codecept_run} --verbose`, (err, stdout) => {
       const lines = stdout.match(/\S.+/g);


### PR DESCRIPTION
## Motivation/Description of the PR
- Quality of life fix that instead of having one skipped test for data driven scenarios when using xData you get a skipped test for each entry in the data table.

Old behavior:
![image](https://user-images.githubusercontent.com/9056958/100241717-e959ae80-2f2b-11eb-9fd1-c76a924d9dad.png)


 New behavior, as proved in runner test:
![image](https://user-images.githubusercontent.com/9056958/100241753-f5de0700-2f2b-11eb-92eb-1d429b5d1323.png)


Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [x] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
