### PR TITLE
fix(retryFailedStep): regexp based ignored steps

### DIFF
--- a/lib/plugin/retryFailedStep.js
+++ b/lib/plugin/retryFailedStep.js
@@ -100,8 +100,9 @@ module.exports = (config) => {
     // if a step is ignored - return
     for (const ignored of config.ignoredSteps) {
       if (step.name === ignored) return;
-      if (ignored instanceof RegExp && step.name.match(ignored)) return;
-      if (ignored.indexOf('*') && step.name.startsWith(ignored.slice(0, -1))) return;
+      if (ignored instanceof RegExp) {
+        if (step.name.match(ignored)) return;
+      } else if (ignored.indexOf('*') && step.name.startsWith(ignored.slice(0, -1))) return;
     }
     enableRetry = true; // enable retry for a step
   });

--- a/test/unit/plugin/retryFailedStep_test.js
+++ b/test/unit/plugin/retryFailedStep_test.js
@@ -123,6 +123,28 @@ describe('retryFailedStep', () => {
     // expects to retry only once
   });
 
+  it('should add custom regexp steps to ignore', async () => {
+    retryFailedStep({ retries: 2, minTimeout: 1, ignoredSteps: [/somethingNew/] });
+    event.dispatcher.emit(event.test.before, {});
+
+    let counter = 0;
+    event.dispatcher.emit(event.step.started, { name: 'somethingNew' });
+    try {
+      recorder.add(() => {
+        counter++;
+        if (counter < 3) {
+          throw new Error();
+        }
+      }, undefined, undefined, true);
+      await recorder.promise();
+    } catch (e) {
+      recorder.catchWithoutStop((err) => err);
+    }
+
+    expect(counter).to.equal(1);
+    // expects to retry only once
+  });
+
   it('should not retry session', async () => {
     retryFailedStep({ retries: 1, minTimeout: 1 });
     event.dispatcher.emit(event.test.before, {});


### PR DESCRIPTION
## Motivation
This contribution avoids an exception in `retryFailedStep` caused by regular expressions in `ignoredSteps`

```js
{
  retryFailedStep: {
    enabled: true,
    defaultIgnoredSteps: [/haveMail/],
  }
}
```

```
TypeError: ignored.indexOf is not a function
at EventEmitter.event.dispatcher.on (/appsuite-ui/ui/node_modules/codeceptjs/lib/plugin/retryFailedStep.js:105:19)
at EventEmitter.emit (events.js:203:15)
at EventEmitter.emit (domain.js:448:20)
at Object.emit (/appsuite-ui/ui/node_modules/codeceptjs/lib/event.js:117:28)
at recorder.add (/appsuite-ui/ui/node_modules/codeceptjs/lib/actor.js:89:13)
at process._tickCallback (internal/process/next_tick.js:68:7)
```

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [x] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [x] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
