### PR TITLE
Fixed error with waitForFunction not working with number values

### DIFF
--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -1865,7 +1865,7 @@ class Puppeteer extends Helper {
         if (!els || els.length === 0) {
           return false;
         }
-        return Array.prototype.filter.call(els, el => (el.value || '').indexOf(value) !== -1).length > 0;
+        return Array.prototype.filter.call(els, el => (el.value.toString() || '').indexOf(value) !== -1).length > 0;
       };
       waiter = context.waitForFunction(valueFn, { timeout: waitTimeout }, locator.value, value);
     } else {


### PR DESCRIPTION
## Motivation/Description of the PR

I've just updated to angular 11 in my project, and had the waitForValue function start failing for input values which are of type Number. The query selector was returning the Number value, which didn't have the indexOf function so was throwing errors. 

Applicable helpers:

- [x] Puppeteer

## Type of change

- [x] :bug: Bug fix

## Checklist:

- [ ] Tests have been added -> Unsure how to add a test that resolves to a number like I'm seeing in angular.
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
