### PR TITLE
allow .ts config files

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -120,14 +120,17 @@ class Config {
 module.exports = Config;
 
 function loadConfigFile(configFile) {
+  const extensionName = path.extname(configFile);
+
   // .conf.js config file
-  if (path.extname(configFile) === '.js') {
+  if (extensionName === '.js' || extensionName === '.ts') {
     return Config.create(require(configFile).config);
   }
 
   // json config provided
-  if (path.extname(configFile) === '.json') {
+  if (extensionName === '.json') {
     return Config.create(JSON.parse(fs.readFileSync(configFile, 'utf8')));
   }
+
   throw new Error(`Config file ${configFile} can't be loaded`);
 }


### PR DESCRIPTION
## Motivation/Description of the PR
current implementation does not allow using of `.ts` files as an config files.

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [x] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`) - there are some problems in definitions.js
- [ ] Local tests are passed (Run `npm test`)
