### PR TITLE
fix(playwright): use _getContext for _locate

### DIFF
--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -837,7 +837,7 @@ class Playwright extends Helper {
    *
    */
   async _locate(locator) {
-    return findElements(await this.context, locator);
+    return findElements(await this._getContext(), locator);
   }
 
   /**

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -837,7 +837,8 @@ class Playwright extends Helper {
    *
    */
   async _locate(locator) {
-    return findElements(await this._getContext(), locator);
+    const matcher = this.context || await this._getContext();
+    return findElements(matcher, locator);
   }
 
   /**

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -837,7 +837,7 @@ class Playwright extends Helper {
    *
    */
   async _locate(locator) {
-    const matcher = this.context || await this._getContext();
+    const matcher = await this.context || await this._getContext();
     return findElements(matcher, locator);
   }
 

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -837,8 +837,8 @@ class Playwright extends Helper {
    *
    */
   async _locate(locator) {
-    const matcher = await this.context || await this._getContext();
-    return findElements(matcher, locator);
+    const context = await this.context || await this._getContext();
+    return findElements(context, locator);
   }
 
   /**


### PR DESCRIPTION
## Motivation/Description of the PR
Related to this fix
https://github.com/codeceptjs/CodeceptJS/pull/2667

Occasionally, we also see this error:
```
  Cannot read property '$$' of null
      at findElements (node_modules/codeceptjs/lib/helper/Playwright.js:2151:18)
      at Playwright._locate (node_modules/codeceptjs/lib/helper/Playwright.js:840:12)
      at async Playwright._withinBegin (node_modules/codeceptjs/lib/helper/Playwright.js:611:17)
```

Seems like we should be using `this._getContext()` here as well. Still not quite sure how `this.context` is `null` in these cases.

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [x] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [x] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
