### PR TITLE
fix: catch error in after test

### DIFF
--- a/lib/listener/helpers.js
+++ b/lib/listener/helpers.js
@@ -61,6 +61,7 @@ module.exports = function () {
 
   event.dispatcher.on(event.test.after, () => {
     runAsyncHelpersHook('_after', {}, true);
+    recorder.catchWithoutStop(e => error(e));
   });
 
   event.dispatcher.on(event.step.before, (step) => {

--- a/lib/listener/helpers.js
+++ b/lib/listener/helpers.js
@@ -45,6 +45,7 @@ module.exports = function () {
   event.dispatcher.on(event.test.before, (test) => {
     // schedule config to revert changes
     runAsyncHelpersHook('_before', test, true);
+    recorder.catchWithoutStop(e => error(e));
   });
 
   event.dispatcher.on(event.test.passed, (test) => {


### PR DESCRIPTION
## Motivation/Description of the PR
In case of error in _after function, for example, browser is closed during test, tests executions is stopped, but error is not logged.
It lead to tests are failed, but exit code is returned 0.

example:
```
sspjs % yarn test:e2e && echo 'ok'
yarn run v1.21.1
$ codeceptjs run -c ./specs/e2e/codecept.conf.js --reporter mochawesome


  Banner initialization methods
    ✓ 'test name' (800ms)
(node:71219) UnhandledPromiseRejectionWarning: no such window: no such window: window was already closed
  (Session info: chrome=87.0.4280.88)
    at Object.getErrorFromResponseBody (<there is path>/node_modules/webdriver/build/utils.js:94:12)
    at WebDriverRequest._request (<there is path>/node_modules/webdriver/build/request.js:133:31)
    at processTicksAndRejections (internal/process/task_queues.js:94:5)
    at Browser.wrapCommandFn (<there is path>/node_modules/@wdio/utils/build/shim.js:58:29)
    at Browser.wrapCommandFn (<there is path>/node_modules/@wdio/utils/build/shim.js:58:29)
    at WebDriver._after (<there is path>/node_modules/codeceptjs/lib/helper/WebDriver.js:560:7)
(node:71219) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:71219) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
✨  Done in 10.09s.
ok
```

How to reproduce:
1. run codeceptjs tests
2. close browser (or browser connection) in middle of tests
3. see for exit code

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`) - linting will be fixed in https://github.com/codeceptjs/CodeceptJS/pull/2707
- [x] Local tests are passed (Run `npm test`)

**UPD**
added the same for before to fix https://github.com/codeceptjs/CodeceptJS/issues/1181