### PR TITLE
Add emit hook.failed

### DIFF
--- a/lib/workers.js
+++ b/lib/workers.js
@@ -335,6 +335,9 @@ class Workers extends EventEmitter {
           this.emit(event.test.skipped, repackTest(message.data));
           break;
         case event.test.finished: this.emit(event.test.finished, repackTest(message.data)); break;
+        case event.test.after:
+          this.emit(event.test.after, repackTest(message.data));
+          break;
         case event.all.after:
           this._appendStats(message.data); break;
       }

--- a/lib/workers.js
+++ b/lib/workers.js
@@ -320,6 +320,7 @@ class Workers extends EventEmitter {
       output.process(message.workerIndex);
       switch (message.event) {
         case event.hook.failed:
+          this.emit(event.hook.failed, repackTest(message.data));
           this.errors.push(message.data.err);
           break;
         case event.test.failed:


### PR DESCRIPTION
## Motivation/Description of the PR
- When a test fails, ex: on a `BeforeSuite`, running in parallel, there is no way to map to a specific test

## Type of change

- [x] :rocket: New functionality

## Checklist:

- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
