### PR TITLE
fix: catch init failures during run

### DIFF
--- a/lib/command/run.js
+++ b/lib/command/run.js
@@ -19,9 +19,9 @@ module.exports = async function (test, options) {
   createOutputDir(config, testRoot);
 
   const codecept = new Codecept(config, options);
-  codecept.init(testRoot);
 
   try {
+    codecept.init(testRoot);
     await codecept.bootstrap();
     codecept.loadTests();
     await codecept.run(test);

--- a/test/data/sandbox/codecept.multiple.initFailure.json
+++ b/test/data/sandbox/codecept.multiple.initFailure.json
@@ -1,0 +1,23 @@
+{
+  "tests": "./*_test.multiple.js",
+  "timeout": 10000,
+  "output": "./output",
+  "helpers": {
+    "FakeDriver": {
+      "require": "./support/failureHelper"
+    }
+  },
+
+  "multiple": {
+    "default": {
+      "browsers": [
+        "chrome",
+        { "browser": "firefox"}
+      ]
+    }
+  },
+  "include": {},
+  "bootstrap": false,
+  "mocha": {},
+  "name": "multiple-init-failure"
+}

--- a/test/data/sandbox/support/failureHelper.js
+++ b/test/data/sandbox/support/failureHelper.js
@@ -1,0 +1,10 @@
+/* eslint-disable no-unused-vars */
+// const Helper = require('../../lib/helper');
+
+class FailureHelper extends Helper {
+  constructor() {
+    throw new Error('Failed on FailureHelper');
+  }
+}
+
+module.exports = FailureHelper;

--- a/test/runner/run_multiple_test.js
+++ b/test/runner/run_multiple_test.js
@@ -1,4 +1,5 @@
 const assert = require('assert');
+const expect = require('expect');
 const path = require('path');
 const exec = require('child_process').exec;
 
@@ -168,6 +169,16 @@ describe('CodeceptJS Multiple Runner', function () {
       stdout.should.not.include('Checkout examples process');
       stdout.should.not.include('Checkout string');
       assert(!err);
+      done();
+    });
+  });
+
+  it('should exit with non-zero code for failures during init process', (done) => {
+    process.chdir(codecept_dir);
+    exec(`${runner} run-multiple --config codecept.multiple.initFailure.json default --all`, (err, stdout) => {
+      expect(err).not.toBeFalsy();
+      expect(err.code).toBe(1);
+      expect(stdout).toContain('Failed on FailureHelper');
       done();
     });
   });


### PR DESCRIPTION
## Motivation/Description of the PR

When running run-multiple and there's an error during initialization (such as an exception when loading helpers for example), codeceptjs would return a 0 exit code, because the error becomes an unhandled promise rejection.

With this change, the error is handled by run.js, and the process returns a non 0 exit code.

## Type of change

- [x] :bug: Bug fix

## Checklist:

- [x] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
