### PR TITLE
Fix interactive shell bug

### DIFF
--- a/lib/command/interactive.js
+++ b/lib/command/interactive.js
@@ -4,7 +4,7 @@ const Codecept = require('../codecept');
 const event = require('../event');
 const output = require('../output');
 
-module.exports = function (path, options) {
+module.exports = async function (path, options) {
   // Backward compatibility for --profile
   process.profile = options.profile;
   process.env.profile = options.profile;
@@ -14,11 +14,8 @@ module.exports = function (path, options) {
   const codecept = new Codecept(config, options);
   codecept.init(testsPath);
 
-  codecept.runBootstrap((err) => {
-    if (err) {
-      output.error(`Error while running bootstrap file :${err}`);
-      return;
-    }
+  try {
+    await codecept.bootstrap();
 
     if (options.verbose) output.level(3);
 
@@ -36,5 +33,7 @@ module.exports = function (path, options) {
     recorder.add(() => event.emit(event.suite.after, {}));
     recorder.add(() => event.emit(event.all.result, {}));
     recorder.add(() => codecept.teardown());
-  });
+  } catch (err) {
+    output.error(`Error while running bootstrap file :${err}`);
+  }
 };


### PR DESCRIPTION
## Motivation/Description of the PR
- It looks like `runBootstrap` was updated to a promise-based `bootstrap` in #2385 
    - see https://github.com/codeceptjs/CodeceptJS/commit/03c5c910272b8a2cd2aefe29d279c35511c97856#diff-0d969c34cdd37d1e94a88372a2bf51abb40fb512da7a4d92ae118b2ca6bd6bfeL112-R108
- This fix updates the old code to use the new `bootstrap` promise.
- Resolves #2711

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
