### PR TITLE
Fix error suppression for failed gherkin step

### DIFF
--- a/lib/interfaces/gherkin.js
+++ b/lib/interfaces/gherkin.js
@@ -53,7 +53,7 @@ module.exports = (text) => {
       } catch (err) {
         step.status = 'failed';
         step.err = err;
-        return err;
+        throw err;
       } finally {
         step.endTime = Date.now();
         event.dispatcher.removeListener(event.step.before, setMetaStep);


### PR DESCRIPTION
## Motivation/Description of the PR
- Accidently broke gherkin when trying to catch error in https://github.com/codeceptjs/CodeceptJS/pull/2678. Meant to throw error after evaluating it. Currently if gherkin step encounters an error, it will return and other steps within the gherkin step wont run.

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [x] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
