### PR TITLE
feature(config): add ability to run ts config file

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -77,7 +77,12 @@ class Config {
       return loadConfigFile(jsonConfig);
     }
 
-    throw new Error(`Can not load config from ${jsConfig} or ${jsonConfig}\nCodeceptJS is not initialized in this dir. Execute 'codeceptjs init' to start`);
+    const tsConfig = path.join(configFile, 'codecept.conf.ts');
+    if (isFile(tsConfig)) {
+      return loadConfigFile(tsConfig);
+    }
+
+    throw new Error(`Can not load config from ${jsConfig} or ${jsonConfig} or ${tsConfig}\nCodeceptJS is not initialized in this dir. Execute 'codeceptjs init' to start`);
   }
 
   /**


### PR DESCRIPTION
## Motivation/Description of the PR
- I've added the ability to run the `codecept.conf.ts` config file with the command `npx codeceptjs run`

#### Before these changes:
Output after running the `npx codeceptjs run` command with the `codecept.conf.ts` config file:
```bash
Error: Can not load config from /Users/Ivan/Desktop/codecept.conf.js or  /Users/Ivan/Desktop/codecept.json
CodeceptJS is not initialized in this dir. Execute 'codeceptjs init' to start
```

#### After these changes:
Output after running the `npx codeceptjs run` command with the `codecept.conf.ts` config file:
```bash
CodeceptJS v3.0.4
Using test root "/Users/Ivan/Desktop"

Call functionality --
...
```

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [x] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
