### PR TITLE
fix(playwright): #2422 - fix grabCssPropertyFromAll method

### DIFF
--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -1590,8 +1590,7 @@ class Playwright extends Helper {
   async grabCssPropertyFromAll(locator, cssProperty) {
     const els = await this._locate(locator);
     this.debug(`Matched ${els.length} elements`);
-    const res = await Promise.all(els.map(el => el.$eval('xpath=.', el => JSON.parse(JSON.stringify(getComputedStyle(el))), el)));
-    const cssValues = res.map(props => props[toCamelCase(cssProperty)]);
+    const cssValues = await Promise.all(els.map(el => el.$eval('xpath=.', (el, cssProperty) => getComputedStyle(el).getPropertyValue(cssProperty), cssProperty)));
 
     return cssValues;
   }


### PR DESCRIPTION
## Motivation/Description of the PR
- The main problem was in Firefox and the `JSON.stringify` method since the `grabCssPropertyFromAll` method uses `JSON.parse` and `JSON.stringify` to deep clone the object and returns serialized data. Unfortunately, this approach doesn't work in Firefox and loses all significant data. Moreover, I've optimized and improved the method by removing the deep clone step and updating the get property step by the `getPropertyValue` method to avoid converting CSS property into a camel case.

- Tested in Chromium, WebKit, and Firefox

test case:
```js
Scenario('should get background color @debug', async ({ I }) => {
    I.amOnPage("https://github.com/")
    const bgColor = await I.grabCssPropertyFrom("button.btn-mktg-fluid", "background-color")
    I.say(bgColor)
});
```

- Resolves #2422

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [x] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
