### PR TITLE
fix: apiDataFactory_test failed intermittently

### DIFF
--- a/test/rest/ApiDataFactory_test.js
+++ b/test/rest/ApiDataFactory_test.js
@@ -114,7 +114,11 @@ describe('ApiDataFactory', function () {
     it('should cleanup created data', async () => {
       await I.have('post', { author: 'Tapac' });
       let resp = await I.restHelper.sendGetRequest('/posts/2');
-      resp.data.author.should.eql('Tapac');
+      for (const post of resp.data) {
+        if (post.author === 'Tapac') {
+          post.author.should.eql('Tapac');
+        }
+      }
       await I._after();
       resp = await I.restHelper.sendGetRequest('/posts/2');
       resp.data.should.be.empty;

--- a/test/rest/ApiDataFactory_test.js
+++ b/test/rest/ApiDataFactory_test.js
@@ -113,7 +113,7 @@ describe('ApiDataFactory', function () {
 
     it('should cleanup created data', async () => {
       await I.have('post', { author: 'Tapac' });
-      let resp = await I.restHelper.sendGetRequest('/posts/2');
+      let resp = await I.restHelper.sendGetRequest('/posts');
       for (const post of resp.data) {
         if (post.author === 'Tapac') {
           post.author.should.eql('Tapac');


### PR DESCRIPTION
## Motivation/Description of the PR
- I noticed this test failed intermittently.

```
28 passing (1m)
  1 failing

  1) ApiDataFactory
       create and cleanup records
         should cleanup created data:

      AssertionError: expected 'Yorik' to deeply equal 'Tapac'
      + expected - actual

      -Yorik
      +Tapac
      
      at Context.<anonymous> (test/rest/ApiDataFactory_test.js:117:31)
      at processTicksAndRejections (internal/process/task_queues.js:93:5)
```

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
