### PR TITLE
fix(typings): value of the fillField method for all helpers

### DIFF
--- a/docs/helpers/Appium.md
+++ b/docs/helpers/Appium.md
@@ -911,7 +911,7 @@ I.fillField({css: 'form#login input[name=username]'}, 'John');
 #### Parameters
 
 -   `field` **([string][4] \| [object][6])** located by label|name|CSS|XPath|strict locator.
--   `value` **[string][4]** text value to fill.
+-   `value` **([string][4] \| [object][6])** text value to fill.
 
 ### grabTextFromAll
 

--- a/docs/helpers/Nightmare.md
+++ b/docs/helpers/Nightmare.md
@@ -415,7 +415,7 @@ I.fillField({css: 'form#login input[name=username]'}, 'John');
 #### Parameters
 
 -   `field` **([string][3] | [object][4])** located by label|name|CSS|XPath|strict locator.
--   `value` **[string][3]** text value to fill.
+-   `value` **([string][3] | [object][4])** text value to fill.
 
 ### grabAttributeFrom
 

--- a/docs/helpers/Playwright.md
+++ b/docs/helpers/Playwright.md
@@ -634,7 +634,7 @@ I.fillField({css: 'form#login input[name=username]'}, 'John');
 #### Parameters
 
 -   `field` **([string][7] | [object][5])** located by label|name|CSS|XPath|strict locator.
--   `value` **[string][7]** text value to fill.
+-   `value` **([string][7] | [object][5])** text value to fill.
 
 ### forceClick
 

--- a/docs/helpers/Protractor.md
+++ b/docs/helpers/Protractor.md
@@ -563,7 +563,7 @@ I.fillField({css: 'form#login input[name=username]'}, 'John');
 #### Parameters
 
 -   `field` **([string][9] | [object][10])** located by label|name|CSS|XPath|strict locator.
--   `value` **[string][9]** text value to fill.
+-   `value` **([string][9] | [object][10])** text value to fill.
 
 ### grabAttributeFrom
 

--- a/docs/helpers/Puppeteer.md
+++ b/docs/helpers/Puppeteer.md
@@ -690,7 +690,7 @@ I.fillField({css: 'form#login input[name=username]'}, 'John');
 #### Parameters
 
 -   `field` **([string][8] | [object][6])** located by label|name|CSS|XPath|strict locator.
--   `value` **[string][8]** text value to fill.
+-   `value` **([string][8] | [object][6])** text value to fill.
 
 
 This action supports [React locators](https://codecept.io/react#locators)

--- a/docs/helpers/TestCafe.md
+++ b/docs/helpers/TestCafe.md
@@ -399,7 +399,7 @@ I.fillField({css: 'form#login input[name=username]'}, 'John');
 #### Parameters
 
 -   `field` **([string][4] | [object][5])** located by label|name|CSS|XPath|strict locator.
--   `value` **[string][4]** text value to fill.
+-   `value` **([string][4] | [object][5])** text value to fill.
 
 ### grabAttributeFrom
 

--- a/docs/helpers/WebDriver.md
+++ b/docs/helpers/WebDriver.md
@@ -868,7 +868,7 @@ I.fillField({css: 'form#login input[name=username]'}, 'John');
 #### Parameters
 
 -   `field` **([string][19] | [object][18])** located by label|name|CSS|XPath|strict locator.
--   `value` **[string][19]** text value to fill.
+-   `value` **([string][19] | [object][18])** text value to fill.
 
 
 This action supports [React locators](https://codecept.io/react#locators)

--- a/docs/webapi/fillField.mustache
+++ b/docs/webapi/fillField.mustache
@@ -12,4 +12,4 @@ I.fillField('form#login input[name=username]', 'John');
 I.fillField({css: 'form#login input[name=username]'}, 'John');
 ```
 @param {CodeceptJS.LocatorOrString} field located by label|name|CSS|XPath|strict locator.
-@param {string} value text value to fill.
+@param {CodeceptJS.StringOrSecret} value text value to fill.

--- a/runok.js
+++ b/runok.js
@@ -160,6 +160,7 @@ Our community prepared some valuable recipes for setting up CI systems with Code
           cfg.replace(/LocatorOrString\?/g, '(string | object)?');
           cfg.replace(/CodeceptJS.LocatorOrString/g, 'string | object');
           cfg.replace(/LocatorOrString/g, 'string | object');
+          cfg.replace(/CodeceptJS.StringOrSecret/g, 'string | object');
         }
       });
     }
@@ -196,6 +197,7 @@ Our community prepared some valuable recipes for setting up CI systems with Code
         cfg.replace(/LocatorOrString\?/g, '(string | object)?');
         cfg.replace(/CodeceptJS.LocatorOrString/g, 'string | object');
         cfg.replace(/LocatorOrString/g, 'string | object');
+        cfg.replace(/CodeceptJS.StringOrSecret/g, 'string | object');
       });
 
       await npx(`documentation build docs/build/${file} -o docs/helpers/${name}.md -f md --shallow --markdown-toc=false --sort-order=alpha`);

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -55,6 +55,7 @@ declare namespace CodeceptJS {
     | { react: string };
 
   type LocatorOrString = string | ILocator | Locator;
+  type StringOrSecret = string | CodeceptJS.Secret;
 
   interface HookCallback { (args: SupportObject): void; }
   interface Scenario extends IScenario { only: IScenario, skip: IScenario, todo: IScenario}


### PR DESCRIPTION
## Motivation/Description of the PR
- Currently, the `fillField` method takes a value as a `string` only, but it could be a `secret` too. So, I've fixed that to make it work with both of them.
- Resolves #2767

Applicable helpers:

- [x] WebDriver
- [x] Puppeteer
- [x] Nightmare
- [ ] REST
- [ ] FileHelper
- [x] Appium
- [x] Protractor
- [x] TestCafe
- [x] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [x] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [x] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [x] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
