### PR TITLE
fix: allure report for multi sessions

### DIFF
--- a/lib/plugin/allure.js
+++ b/lib/plugin/allure.js
@@ -261,13 +261,9 @@ module.exports = (config) => {
     if (isHookSteps === false) {
       startMetaStep(step.metaStep);
       if (currentStep !== step) {
-        // The reason we need to do this cause
-        // the step actor contains this and hence
-        // the allure reporter could not parse and
-        // generate the report
-        if (step.actor.includes('\u001b[36m')) {
-          step.actor = step.actor.replace('\u001b[36m', '').replace('\u001b[39m', '');
-        }
+        // In multi-session scenarios, actors' names will be highlighted with ANSI
+        // escape sequences which are invalid XML values
+        step.actor = step.actor.replace(ansiRegExp(), '');
         reporter.startStep(step.toString());
         currentStep = step;
       }


### PR DESCRIPTION
## Motivation/Description of the PR
When working with the allure plugin and multiple sessions, codeceptjs will throw an error. The name of the actor will be highlighted using [ANSI color codes](https://en.wikipedia.org/wiki/ANSI_escape_code#Colors) that represent invalid characters for the allure XML report.

The following test will fail
```typescript
Feature('sample-test')

Scenario('test something', ({ I }) => {
    I.amOnPage('https://github.com')
    session('Second Actor', () => {
        I.amOnPage('https://github.com')
    })
})
```
with this error:
```console
Error processing suite.after event:
Error: charData should not contain characters not allowed in XML
```

There already was some logic in place to replace the ANSI code for the color cyan, not however, for the other possible colors.

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [X] Playwright

Applicable plugins:

- [X] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [X] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [X] Lint checking (Run `npm run lint`)
- [X] Local tests are passed (Run `npm test`)
