### PR TITLE
Option to Run the Failed scripts only & to run selected scripts  

### DIFF
--- a/bin/codecept.js
+++ b/bin/codecept.js
@@ -95,6 +95,7 @@ program.command('run [test]')
   .option('--features', 'run only *.feature files and skip tests')
   .option('--tests', 'run only JS test files and skip features')
   .option('-p, --plugins <k=v,k2=v2,...>', 'enable plugins, comma-separated')
+  .option('--failed','to run the failed tests')
 
   // mocha options
   .option('--colors', 'force enabling of colors')
@@ -133,6 +134,7 @@ program.command('run-workers <workers>')
   .option('-p, --plugins <k=v,k2=v2,...>', 'enable plugins, comma-separated')
   .option('-O, --reporter-options <k=v,k2=v2,...>', 'reporter-specific options')
   .option('-R, --reporter <name>', 'specify the reporter to use')
+  .option('--failed','to run the failed tests')
   .action(require('../lib/command/run-workers'));
 
 program.command('run-multiple [suites...]')

--- a/bin/codecept.js
+++ b/bin/codecept.js
@@ -95,7 +95,7 @@ program.command('run [test]')
   .option('--features', 'run only *.feature files and skip tests')
   .option('--tests', 'run only JS test files and skip features')
   .option('-p, --plugins <k=v,k2=v2,...>', 'enable plugins, comma-separated')
-  .option('--failed','to run the failed tests')
+  .option('--rerun-tests','to run the selected / failed tests from last execution')
 
   // mocha options
   .option('--colors', 'force enabling of colors')
@@ -134,7 +134,7 @@ program.command('run-workers <workers>')
   .option('-p, --plugins <k=v,k2=v2,...>', 'enable plugins, comma-separated')
   .option('-O, --reporter-options <k=v,k2=v2,...>', 'reporter-specific options')
   .option('-R, --reporter <name>', 'specify the reporter to use')
-  .option('--failed','to run the failed tests')
+  .option('--rerun-tests','to run the selected / failed tests from last execution')
   .action(require('../lib/command/run-workers'));
 
 program.command('run-multiple [suites...]')

--- a/lib/codecept.js
+++ b/lib/codecept.js
@@ -125,14 +125,17 @@ class Codecept {
    * @param {string} [pattern]
    */
   loadTests(pattern){
+    let flag = 0;
+    let invalidTest = [];
     const options = {
       cwd: global.codecept_dir,
     };
-    if(this.opts.failed){
-      print('Re-running The Failed Scripts ..');
+    if(this.opts.rerunTests){
+      print('Re-running The Selected/Failed Scripts ..');
       const failedTestRerun = new FailedTestsRerun();
       failedTestRerun.checkForFailedTestsExist(this.opts);
       this.testFiles= JSON.parse(fs.readFileSync('failedCases.json', 'utf8'));
+      failedTestRerun.checkForFileExistence(this.testFiles);
     }
     else {
       let patterns = [pattern];

--- a/lib/codecept.js
+++ b/lib/codecept.js
@@ -129,7 +129,7 @@ class Codecept {
       cwd: global.codecept_dir,
     };
     if(this.opts.failed){
-      print('Running The Tests in Failed Re-Run Mode ..');
+      print('Re-running The Failed Scripts ..');
       const failedTestRerun = new FailedTestsRerun();
       failedTestRerun.checkForFailedTestsExist(this.opts);
       this.testFiles= JSON.parse(fs.readFileSync('failedCases.json', 'utf8'));

--- a/lib/codecept.js
+++ b/lib/codecept.js
@@ -1,4 +1,5 @@
 const { existsSync, readFileSync } = require('fs');
+const fs = require('fs');
 const glob = require('glob');
 const fsPath = require('path');
 const { resolve } = require('path');
@@ -7,7 +8,8 @@ const container = require('./container');
 const Config = require('./config');
 const event = require('./event');
 const runHook = require('./hooks');
-const output = require('./output');
+const {output,print} = require('./output');
+const FailedTestsRerun = require('./rerunFailed');
 
 /**
  * CodeceptJS runner
@@ -122,25 +124,32 @@ class Codecept {
    *
    * @param {string} [pattern]
    */
-  loadTests(pattern) {
+  loadTests(pattern){
     const options = {
       cwd: global.codecept_dir,
     };
-
-    let patterns = [pattern];
-    if (!pattern) {
-      patterns = [];
-      if (this.config.tests && !this.opts.features) patterns.push(this.config.tests);
-      if (this.config.gherkin.features && !this.opts.tests) patterns.push(this.config.gherkin.features);
+    if(this.opts.failed){
+      print('Running The Tests in Failed Re-Run Mode ..');
+      const failedTestRerun = new FailedTestsRerun();
+      const optionForCheck = failedTestRerun.getOptions();
+      failedTestRerun.checkForFailedTestsExist(optionForCheck);
+      this.testFiles= JSON.parse(fs.readFileSync('failedCases.json', 'utf8'));
     }
-
-    for (pattern of patterns) {
-      glob.sync(pattern, options).forEach((file) => {
-        if (!fsPath.isAbsolute(file)) {
-          file = fsPath.join(global.codecept_dir, file);
-        }
-        this.testFiles.push(fsPath.resolve(file));
-      });
+    else {
+      let patterns = [pattern];
+      if (!pattern) {
+        patterns = [];
+        if (this.config.tests && !this.opts.features) patterns.push(this.config.tests);
+        if (this.config.gherkin.features && !this.opts.tests) patterns.push(this.config.gherkin.features);
+      }
+      for (pattern of patterns) {
+        glob.sync(pattern, options).forEach((file) => {
+          if (!fsPath.isAbsolute(file)) {
+            file = fsPath.join(global.codecept_dir, file);
+          }
+          this.testFiles.push(fsPath.resolve(file));
+        });
+      }
     }
   }
 

--- a/lib/codecept.js
+++ b/lib/codecept.js
@@ -131,8 +131,7 @@ class Codecept {
     if(this.opts.failed){
       print('Running The Tests in Failed Re-Run Mode ..');
       const failedTestRerun = new FailedTestsRerun();
-      const optionForCheck = failedTestRerun.getOptions();
-      failedTestRerun.checkForFailedTestsExist(optionForCheck);
+      failedTestRerun.checkForFailedTestsExist(this.opts);
       this.testFiles= JSON.parse(fs.readFileSync('failedCases.json', 'utf8'));
     }
     else {

--- a/lib/command/run-workers.js
+++ b/lib/command/run-workers.js
@@ -25,8 +25,6 @@ module.exports = async function (workerCount, options) {
     options,
   };
 
-  failedTestRerun.setOptions(options);
-
   const numberOfWorkers = parseInt(workerCount, 10);
 
   output.print(`CodeceptJS v${require('../codecept').version()}`);

--- a/lib/command/run-workers.js
+++ b/lib/command/run-workers.js
@@ -4,6 +4,8 @@ const { tryOrDefault } = require('../utils');
 const output = require('../output');
 const event = require('../event');
 const Workers = require('../workers');
+const FailedTestRerun = require('./../rerunFailed');
+const failedTestRerun = new FailedTestRerun();
 
 module.exports = async function (workerCount, options) {
   satisfyNodeVersion(
@@ -22,6 +24,8 @@ module.exports = async function (workerCount, options) {
     testConfig,
     options,
   };
+
+  failedTestRerun.setOptions(options);
 
   const numberOfWorkers = parseInt(workerCount, 10);
 

--- a/lib/command/run.js
+++ b/lib/command/run.js
@@ -3,9 +3,9 @@ const {
 } = require('./utils');
 const Config = require('../config');
 const Codecept = require('../codecept');
-const FailedTestRerun = require('./../rerunFailed');
+const FailedTestRerun = require('../rerunFailed');
+
 const failedTestRerun = new FailedTestRerun();
-const {stringify} = require('flatted')
 
 module.exports = async function (test, options) {
   // registering options globally to use in config

--- a/lib/command/run.js
+++ b/lib/command/run.js
@@ -3,6 +3,9 @@ const {
 } = require('./utils');
 const Config = require('../config');
 const Codecept = require('../codecept');
+const FailedTestRerun = require('./../rerunFailed');
+const failedTestRerun = new FailedTestRerun();
+const {stringify} = require('flatted')
 
 module.exports = async function (test, options) {
   // registering options globally to use in config
@@ -19,6 +22,8 @@ module.exports = async function (test, options) {
   createOutputDir(config, testRoot);
 
   const codecept = new Codecept(config, options);
+  failedTestRerun.setOptions(options);
+
 
   try {
     codecept.init(testRoot);

--- a/lib/command/run.js
+++ b/lib/command/run.js
@@ -22,7 +22,6 @@ module.exports = async function (test, options) {
   createOutputDir(config, testRoot);
 
   const codecept = new Codecept(config, options);
-  failedTestRerun.setOptions(options);
   try {
     codecept.init(testRoot);
     await codecept.bootstrap();

--- a/lib/command/run.js
+++ b/lib/command/run.js
@@ -23,8 +23,6 @@ module.exports = async function (test, options) {
 
   const codecept = new Codecept(config, options);
   failedTestRerun.setOptions(options);
-
-
   try {
     codecept.init(testRoot);
     await codecept.bootstrap();

--- a/lib/listener/exit.js
+++ b/lib/listener/exit.js
@@ -2,12 +2,18 @@ const event = require('../event');
 
 module.exports = function () {
   let failedTests = [];
+  let failedTestName = [];
+  let passedTest = [];
+  const FailedTestRerun = require('./../rerunFailed');
+  const failedTestRerun = new FailedTestRerun();
 
   event.dispatcher.on(event.test.failed, (testOrSuite) => {
     // NOTE When an error happens in one of the hooks (BeforeAll/BeforeEach...) the event object
     // is a suite and not a test
     const id = testOrSuite.id || (testOrSuite.ctx && testOrSuite.ctx.test.id) || 'empty';
+    const name = testOrSuite.file;
     failedTests.push(id);
+    failedTestName.push(name);
   });
 
   // if test was successful after retries
@@ -15,12 +21,22 @@ module.exports = function () {
     // NOTE When an error happens in one of the hooks (BeforeAll/BeforeEach...) the event object
     // is a suite and not a test
     const id = testOrSuite.id || (testOrSuite.ctx && testOrSuite.ctx.test.id) || 'empty';
+    const name = testOrSuite.file;
     failedTests = failedTests.filter(failed => id !== failed);
+    failedTestRerun.removePassedTests(name);
   });
 
   event.dispatcher.on(event.all.result, () => {
     if (failedTests.length) {
       process.exitCode = 1;
+    }
+  });
+
+  event.dispatcher.on(event.all.after, () => {
+
+    // Writes the Failed Test Names In The JSON File For Rerun
+    if(failedTests.length > 0) {
+      failedTestRerun.writeFailedTests(failedTestName);
     }
   });
 

--- a/lib/listener/exit.js
+++ b/lib/listener/exit.js
@@ -33,11 +33,9 @@ module.exports = function () {
   });
 
   event.dispatcher.on(event.all.after, () => {
-
     // Writes the Failed Test Names In The JSON File For Rerun
-    if(failedTests.length > 0) {
-      failedTestRerun.writeFailedTests(failedTestName);
-    }
+    failedTestRerun.writeFailedTests(failedTestName);
+    failedTestRerun.checkAndRemoveFailedCasesFile(failedTestName)
   });
 
   process.on('beforeExit', (code) => {

--- a/lib/listener/steps.js
+++ b/lib/listener/steps.js
@@ -3,6 +3,7 @@ const store = require('../store');
 
 let currentTest;
 let currentHook;
+let failedTests = new Array(0);
 
 /**
  * Register steps inside tests
@@ -33,6 +34,12 @@ module.exports = function () {
   });
 
   event.dispatcher.on(event.test.failed, () => {
+    //Getting Failes Test Scrips To Add in JSON File for Rerun
+    // @ts-ignore
+    let failedTestName = currentTest.file;
+    failedTests.push(failedTestName);
+
+
     const cutSteps = function (current) {
       const failureIndex = current.steps.findIndex(el => el.status === 'failed');
       // To be sure that failed test will be failed in report

--- a/lib/listener/steps.js
+++ b/lib/listener/steps.js
@@ -34,7 +34,7 @@ module.exports = function () {
   });
 
   event.dispatcher.on(event.test.failed, () => {
-    //Getting Failes Test Scrips To Add in JSON File for Rerun
+    //Getting Failed Test Scrips To Add in JSON File for Rerun
     // @ts-ignore
     let failedTestName = currentTest.file;
     failedTests.push(failedTestName);

--- a/lib/rerunFailed.js
+++ b/lib/rerunFailed.js
@@ -1,6 +1,5 @@
 const fs = require('fs');
 const { print } = require('codeceptjs/lib/output');
-let optionsForCheck;
 
 class FailedTestsRerun {
 
@@ -10,7 +9,7 @@ class FailedTestsRerun {
    * @param options
    */
   checkForFailedTestsExist(options) {
-    if (options.failed) {
+    if (options.rerunTests) {
       if (!fs.existsSync('failedCases.json')) {
         print('There Are No Failed Tests In Previous Execution');
         process.exit()
@@ -26,6 +25,29 @@ class FailedTestsRerun {
   }
 
   /**
+   * Checks If The Valid Files are Passed in Failed Cases Json File
+   *@param testFiles
+   */
+  checkForFileExistence(testFiles){
+    let invalidTest = [];
+    let flag = 0;
+    for(let i = 0;i < testFiles.length;i++) {
+      let path = testFiles[i];
+      if(!fs.existsSync(path)){
+        invalidTest.push(path);
+        flag++;
+      }
+    }
+    if(flag > 0){
+      print("\nInvalid File(s) Found :" + '\n' );
+      for(let j = 0; j< invalidTest.length;j++){
+        print(invalidTest[j]);
+      }
+      process.exit();
+    }
+  }
+
+  /**
    * Returns The Content In JSON File For File/Content existence Check
    * @return {string[]}
    */
@@ -34,7 +56,7 @@ class FailedTestsRerun {
   }
 
   /**
-   * Returns The Failed Tests
+   * Returns The Failed/Selected Tests
    * @return {any}
    */
   getFailedTests() {

--- a/lib/rerunFailed.js
+++ b/lib/rerunFailed.js
@@ -2,7 +2,6 @@ const fs = require('fs');
 const { print } = require('codeceptjs/lib/output');
 
 class FailedTestsRerun {
-
   /**
    * Initial Check To Find the Existence Of Failed Cases JSON File
    * and Content
@@ -12,9 +11,8 @@ class FailedTestsRerun {
     if (options.rerunTests) {
       if (!fs.existsSync('failedCases.json')) {
         print('There Are No Failed Tests In Previous Execution');
-        process.exit()
-      }
-      else{
+        process.exit();
+      } else {
         const failedTests = this.getFailedTestContent();
         if (failedTests.length === 0 || failedTests.toString() === '') {
           print('There Are No Files Present In the Failed Cases Json File');
@@ -28,19 +26,20 @@ class FailedTestsRerun {
    * Checks If The Valid Files are Passed in Failed Cases Json File
    *@param testFiles
    */
-  checkForFileExistence(testFiles){
-    let invalidTest = [];
+  checkForFileExistence(testFiles) {
+    const invalidTest = [];
     let flag = 0;
-    for(let i = 0;i < testFiles.length;i++) {
-      let path = testFiles[i];
-      if(!fs.existsSync(path)){
+    for (let i = 0; i < testFiles.length; i++) {
+      const path = testFiles[i];
+      if (!fs.existsSync(path)) {
         invalidTest.push(path);
         flag++;
       }
     }
-    if(flag > 0){
-      print("\nInvalid File(s) Found :" + '\n' );
-      for(let j = 0; j< invalidTest.length;j++){
+    if (flag > 0) {
+      // eslint-disable-next-line no-useless-concat
+      print('\nInvalid File(s) Found :' + '\n');
+      for (let j = 0; j < invalidTest.length; j++) {
         print(invalidTest[j]);
       }
       process.exit();
@@ -51,8 +50,8 @@ class FailedTestsRerun {
    * Returns The Content In JSON File For File/Content existence Check
    * @return {string[]}
    */
-  getFailedTestContent(){
-    return fs.readFileSync('failedCases.json', {encoding: 'utf8'}).split(',');
+  getFailedTestContent() {
+    return fs.readFileSync('failedCases.json', { encoding: 'utf8' }).split(',');
   }
 
   /**
@@ -61,19 +60,18 @@ class FailedTestsRerun {
    */
   getFailedTests() {
     return JSON.parse(fs.readFileSync('failedCases.json', 'utf8'));
-   }
+  }
 
   /**
    * Writes The Failed Tests in The Failed Cases JSON File Post Execution
     * @param failedTests
    */
   writeFailedTests(failedTests) {
-    if(failedTests.length > 0 )
-      // @ts-ignore
-    fs.writeFileSync('failedCases.json', JSON.stringify(failedTests),function (err) {
-      if (err)
-        return print(err);
-    });
+    if (failedTests.length > 0) {
+      fs.writeFileSync('failedCases.json', JSON.stringify(failedTests), (err) => {
+        if (err) { return print(err); }
+      });
+    }
   }
 
   /**
@@ -82,8 +80,8 @@ class FailedTestsRerun {
    * @param passedTest
    */
   removePassedTests(passedTest) {
-    if(fs.existsSync('failedCases.json')){
-      let currentFile = JSON.parse(fs.readFileSync('failedCases.json', 'utf8'));
+    if (fs.existsSync('failedCases.json')) {
+      const currentFile = JSON.parse(fs.readFileSync('failedCases.json', 'utf8'));
       currentFile.forEach((t) => {
         if (currentFile.includes(passedTest)) {
           const index = currentFile.indexOf(t);
@@ -92,8 +90,8 @@ class FailedTestsRerun {
           }
         }
       });
-        fs.writeFile('failedCases.json', JSON.stringify(currentFile), function (err) {
-          if (err) throw err
+      fs.writeFile('failedCases.json', JSON.stringify(currentFile), (err) => {
+        if (err) throw err;
       });
     }
   }
@@ -102,15 +100,13 @@ class FailedTestsRerun {
    * To Remove The Failed Cases JSON file if No Tests Are There
    * @param failedTests
    */
-  checkAndRemoveFailedCasesFile(failedTests){
-    if(failedTests.length < 1) {
+  checkAndRemoveFailedCasesFile(failedTests) {
+    if (failedTests.length < 1) {
       if (fs.existsSync('failedCases.json')) {
         fs.unlinkSync('failedCases.json');
       }
     }
   }
-
-
 }
 
 module.exports = FailedTestsRerun;

--- a/lib/rerunFailed.js
+++ b/lib/rerunFailed.js
@@ -47,7 +47,8 @@ class FailedTestsRerun {
    */
   writeFailedTests(failedTests) {
     if(failedTests.length > 0 )
-    fs.writeFile('failedCases.json', JSON.stringify(failedTests),function (err) {
+      // @ts-ignore
+    fs.writeFileSync('failedCases.json', JSON.stringify(failedTests),function (err) {
       if (err)
         return print(err);
     });

--- a/lib/rerunFailed.js
+++ b/lib/rerunFailed.js
@@ -5,14 +5,6 @@ let optionsForCheck;
 class FailedTestsRerun {
 
   /**
-   * Sets The Options When The Run is Initiated
-   * @param options
-   */
-  setOptions(options) {
-    optionsForCheck = options;
-  }
-
-  /**
    * Initial Check To Find the Existence Of Failed Cases JSON File
    * and Content
    * @param options
@@ -54,6 +46,7 @@ class FailedTestsRerun {
     * @param failedTests
    */
   writeFailedTests(failedTests) {
+    if(failedTests.length > 0 )
     fs.writeFile('failedCases.json', JSON.stringify(failedTests),function (err) {
       if (err)
         return print(err);
@@ -66,7 +59,7 @@ class FailedTestsRerun {
    * @param passedTest
    */
   removePassedTests(passedTest) {
-    if (optionsForCheck.failed ) {
+    if(fs.existsSync('failedCases.json')){
       let currentFile = JSON.parse(fs.readFileSync('failedCases.json', 'utf8'));
       currentFile.forEach((t) => {
         if (currentFile.includes(passedTest)) {
@@ -76,18 +69,25 @@ class FailedTestsRerun {
           }
         }
       });
-      if(currentFile.length === 0 ){
-        fs.unlink('failedCases.json',err => {
-          if(err) throw err;
-        });
-      }
-      else{
-        fs.writeFile('failedCases.json', currentFile, function (err) {
+        fs.writeFile('failedCases.json', JSON.stringify(currentFile), function (err) {
           if (err) throw err
-        });
+      });
+    }
+  }
+
+  /**
+   * To Remove The Failed Cases JSON file if No Tests Are There
+   * @param failedTests
+   */
+  checkAndRemoveFailedCasesFile(failedTests){
+    if(failedTests.length < 1) {
+      if (fs.existsSync('failedCases.json')) {
+        fs.unlinkSync('failedCases.json');
       }
     }
   }
+
+
 }
 
 module.exports = FailedTestsRerun;

--- a/lib/rerunFailed.js
+++ b/lib/rerunFailed.js
@@ -1,0 +1,71 @@
+const fs = require('fs');
+const { print } = require('codeceptjs/lib/output');
+let optionsForCheck;
+
+class FailedTestsRerun {
+
+  setOptions(options) {
+    optionsForCheck = options;
+  }
+
+  getOptions(){
+    return optionsForCheck;
+  }
+
+  checkForFailedTestsExist(options) {
+    if (options.failed) {
+      if (!fs.existsSync('failedCases.json')) {
+        print('There Are No Failed Tests In Previous Execution');
+        process.exit()
+      }
+      else{
+        const failedTests = this.getFailedTestContent();
+        if (failedTests.length === 0 || failedTests.toString() === '') {
+          print('There Are No Files Present In the Failed Tests File');
+          process.exit();
+        }
+      }
+    }
+  }
+
+  getFailedTestContent(){
+    return fs.readFileSync('failedCases.json', {encoding: 'utf8'}).split(',');
+  }
+
+  getFailedTests() {
+    return JSON.parse(fs.readFileSync('failedCases.json', 'utf8'));
+   }
+
+  writeFailedTests(failedTests) {
+    fs.writeFile('failedCases.json', JSON.stringify(failedTests),function (err) {
+      if (err)
+        return print(err);
+    });
+  }
+
+  removePassedTests(passedTest) {
+    if (optionsForCheck.failed ) {
+      let currentFile = JSON.parse(fs.readFileSync('failedCases.json', 'utf8'));
+      currentFile.forEach((t) => {
+        if (currentFile.includes(passedTest)) {
+          const index = currentFile.indexOf(t);
+          if (index > -1) {
+            currentFile.splice(index, 1);
+          }
+        }
+      });
+      if(currentFile.length === 0 ){
+        fs.unlink('failedCases.json',err => {
+          if(err) throw err;
+        });
+      }
+      else{
+        fs.writeFile('failedCases.json', currentFile, function (err) {
+          if (err) throw err
+        });
+      }
+    }
+  }
+}
+
+module.exports = FailedTestsRerun;

--- a/lib/rerunFailed.js
+++ b/lib/rerunFailed.js
@@ -4,14 +4,19 @@ let optionsForCheck;
 
 class FailedTestsRerun {
 
+  /**
+   * Sets The Options When The Run is Initiated
+   * @param options
+   */
   setOptions(options) {
     optionsForCheck = options;
   }
 
-  getOptions(){
-    return optionsForCheck;
-  }
-
+  /**
+   * Initial Check To Find the Existence Of Failed Cases JSON File
+   * and Content
+   * @param options
+   */
   checkForFailedTestsExist(options) {
     if (options.failed) {
       if (!fs.existsSync('failedCases.json')) {
@@ -21,21 +26,33 @@ class FailedTestsRerun {
       else{
         const failedTests = this.getFailedTestContent();
         if (failedTests.length === 0 || failedTests.toString() === '') {
-          print('There Are No Files Present In the Failed Tests File');
+          print('There Are No Files Present In the Failed Cases Json File');
           process.exit();
         }
       }
     }
   }
 
+  /**
+   * Returns The Content In JSON File For File/Content existence Check
+   * @return {string[]}
+   */
   getFailedTestContent(){
     return fs.readFileSync('failedCases.json', {encoding: 'utf8'}).split(',');
   }
 
+  /**
+   * Returns The Failed Tests
+   * @return {any}
+   */
   getFailedTests() {
     return JSON.parse(fs.readFileSync('failedCases.json', 'utf8'));
    }
 
+  /**
+   * Writes The Failed Tests in The Failed Cases JSON File Post Execution
+    * @param failedTests
+   */
   writeFailedTests(failedTests) {
     fs.writeFile('failedCases.json', JSON.stringify(failedTests),function (err) {
       if (err)
@@ -43,6 +60,11 @@ class FailedTestsRerun {
     });
   }
 
+  /**
+   * Removes The Passed Test From The Failed Cases JSON During the Execution
+   * Deletes the File When All Tests Are Passed
+   * @param passedTest
+   */
   removePassedTests(passedTest) {
     if (optionsForCheck.failed ) {
       let currentFile = JSON.parse(fs.readFileSync('failedCases.json', 'utf8'));

--- a/lib/workers.js
+++ b/lib/workers.js
@@ -17,11 +17,12 @@ const runHook = require('./hooks');
 const WorkerStorage = require('./workerStorage');
 
 const FailedTestRerun = require('./rerunFailed');
+
 const failedTestRerun = new FailedTestRerun();
 
-let testsArrObj = [];
-let failedTests = [];
-let passedTests = [];
+const testsArrObj = [];
+const failedTests = [];
+const passedTests = [];
 
 const pathToWorker = path.join(__dirname, 'command', 'workers', 'runTests.js');
 
@@ -333,12 +334,14 @@ class Workers extends EventEmitter {
           break;
         case event.test.failed:
           this._updateFinishedTests(repackTest(message.data));
+          // eslint-disable-next-line no-case-declarations
           const failTest = testsArrObj.filter(t => t.id === message.data.id);
           failedTests.push(failTest[0].file);
           this.emit(event.test.failed, repackTest(message.data));
           break;
         case event.test.passed:
           this._updateFinishedTests(repackTest(message.data));
+          // eslint-disable-next-line no-case-declarations
           const passTest = testsArrObj.filter(t => t.id === message.data.id);
           passedTests.push(passTest[0].file);
           this.emit(event.test.passed, repackTest(message.data));

--- a/lib/workers.js
+++ b/lib/workers.js
@@ -63,7 +63,6 @@ const createWorker = (workerObject) => {
     },
   });
   worker.on('error', err => output.error(`Worker Error: ${err.stack}`));
-
   WorkerStorage.addWorker(worker);
   return worker;
 };
@@ -342,7 +341,6 @@ class Workers extends EventEmitter {
           this._updateFinishedTests(repackTest(message.data));
           const passTest = testsArrObj.filter(t => t.id === message.data.id);
           passedTests.push(passTest[0].file);
-          failedTestRerun.removePassedTests(passedTests);
           this.emit(event.test.passed, repackTest(message.data));
           break;
         case event.test.skipped:

--- a/lib/workers.js
+++ b/lib/workers.js
@@ -16,6 +16,13 @@ const recorder = require('./recorder');
 const runHook = require('./hooks');
 const WorkerStorage = require('./workerStorage');
 
+const FailedTestRerun = require('./rerunFailed');
+const failedTestRerun = new FailedTestRerun();
+
+let testsArrObj = [];
+let failedTests = [];
+let passedTests = [];
+
 const pathToWorker = path.join(__dirname, 'command', 'workers', 'runTests.js');
 
 const initializeCodecept = (configPath, options = {}) => {
@@ -241,6 +248,7 @@ class Workers extends EventEmitter {
     mocha.suite.eachTest((test) => {
       const i = groupCounter % groups.length;
       if (test) {
+        testsArrObj.push(test);
         const { id } = test;
         groups[i].push(id);
         groupCounter++;
@@ -263,6 +271,7 @@ class Workers extends EventEmitter {
       const i = indexOfSmallestElement(groups);
       suite.tests.forEach((test) => {
         if (test) {
+          testsArrObj.push(test);
           const { id } = test;
           groups[i].push(id);
         }
@@ -325,10 +334,15 @@ class Workers extends EventEmitter {
           break;
         case event.test.failed:
           this._updateFinishedTests(repackTest(message.data));
+          const failTest = testsArrObj.filter(t => t.id === message.data.id);
+          failedTests.push(failTest[0].file);
           this.emit(event.test.failed, repackTest(message.data));
           break;
         case event.test.passed:
           this._updateFinishedTests(repackTest(message.data));
+          const passTest = testsArrObj.filter(t => t.id === message.data.id);
+          passedTests.push(passTest[0].file);
+          failedTestRerun.removePassedTests(passedTests);
           this.emit(event.test.passed, repackTest(message.data));
           break;
         case event.test.skipped:
@@ -340,6 +354,7 @@ class Workers extends EventEmitter {
           this.emit(event.test.after, repackTest(message.data));
           break;
         case event.all.after:
+          failedTestRerun.writeFailedTests(failedTests);
           this._appendStats(message.data); break;
       }
     });


### PR DESCRIPTION
## Motivation/Description of the PR

Currently Codecept don't have the option to rerun the failed scripts and to run the script with different pattern. This option of --rerun-tests will make it easier to run the failed tests alone and selected tests.

Applicable helpers:

- 

- [ ✓ ]  WebDriver

- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [✓ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [✓ ] Lint checking (Run `npm run lint`)
- [ ✓] Local tests are passed (Run `npm test`)
