### PR TITLE
feat: mask the payload with sensitive info in console logs

### DIFF
--- a/docs/helpers/REST.md
+++ b/docs/helpers/REST.md
@@ -101,6 +101,9 @@ Sends PATCH request to API.
 
 ```js
 I.sendPatchRequest('/api/users.json', { "email": "user@user.com" });
+
+// To mask the payload in logs
+I.sendPatchRequest('/api/users.json', secret({ "email": "user@user.com" }));
 ```
 
 #### Parameters
@@ -115,6 +118,9 @@ Sends POST request to API.
 
 ```js
 I.sendPostRequest('/api/users.json', { "email": "user@user.com" });
+
+// To mask the payload in logs
+I.sendPostRequest('/api/users.json', secret({ "email": "user@user.com" }));
 ```
 
 #### Parameters
@@ -129,6 +135,9 @@ Sends PUT request to API.
 
 ```js
 I.sendPutRequest('/api/users.json', { "email": "user@user.com" });
+
+// To mask the payload in logs
+I.sendPutRequest('/api/users.json', secret({ "email": "user@user.com" }));
 ```
 
 #### Parameters

--- a/lib/helper/REST.js
+++ b/lib/helper/REST.js
@@ -85,7 +85,7 @@ class REST extends Helper {
 
     if (request.data instanceof Secret) {
       _debugRequest.data = '*****';
-      request.data = { ...request.data.toString() };
+      request.data = typeof request.data === 'object' ? { ...request.data.toString() } : request.data.toString();
     }
 
     if ((typeof request.data) === 'string') {

--- a/lib/helper/REST.js
+++ b/lib/helper/REST.js
@@ -1,4 +1,5 @@
 const axios = require('axios').default;
+const Secret = require('../secret');
 
 const Helper = require('../helper');
 
@@ -75,10 +76,16 @@ class REST extends Helper {
    * @param {*} request
    */
   async _executeRequest(request) {
+    const _debugRequest = { ...request };
     axios.defaults.timeout = request.timeout || this.options.timeout;
 
     if (this.headers && this.headers.auth) {
       request.auth = this.headers.auth;
+    }
+
+    if (request.data instanceof Secret) {
+      _debugRequest.data = '*****';
+      request.data = { ...request.data.toString() };
     }
 
     if ((typeof request.data) === 'string') {
@@ -91,7 +98,7 @@ class REST extends Helper {
       await this.config.onRequest(request);
     }
 
-    this.debugSection('Request', JSON.stringify(request));
+    this.debugSection('Request', JSON.stringify(_debugRequest));
 
     let response;
     try {
@@ -149,6 +156,10 @@ class REST extends Helper {
    *
    * ```js
    * I.sendPostRequest('/api/users.json', { "email": "user@user.com" });
+   *
+   * // To mask the payload in logs
+   * I.sendPostRequest('/api/users.json', secret({ "email": "user@user.com" }));
+   *
    * ```
    *
    * @param {*} url
@@ -176,6 +187,10 @@ class REST extends Helper {
    *
    * ```js
    * I.sendPatchRequest('/api/users.json', { "email": "user@user.com" });
+   *
+   * // To mask the payload in logs
+   * I.sendPatchRequest('/api/users.json', secret({ "email": "user@user.com" }));
+   *
    * ```
    *
    * @param {string} url
@@ -203,6 +218,10 @@ class REST extends Helper {
    *
    * ```js
    * I.sendPutRequest('/api/users.json', { "email": "user@user.com" });
+   *
+   * // To mask the payload in logs
+   * I.sendPutRequest('/api/users.json', secret({ "email": "user@user.com" }));
+   *
    * ```
    *
    * @param {string} url


### PR DESCRIPTION
## Motivation/Description of the PR
- Sometimes the payload of API tests for POST/PUT contain sensitive info and you don’t want those info are showing in console logs when running tests with `--verbose`. So taking the advantage of Secret class, now we can mask the payload and you're feeling good to see no sensitive info are showing in console logs.

```
...
      I send post request "customers/login", *****, {"x-component":"google"}
      › [Request] {"baseURL":"https://thisisatest/customers/login","method":"POST","data":"*****","headers":{"x-component":"google"}}
...
```


Applicable helpers:
- [x] REST

## Type of change

- [ ] :fire: Breaking changes
- [x] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [x] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
