### PR TITLE
feat: propagate more events for custom parallel script

### DIFF
--- a/lib/workers.js
+++ b/lib/workers.js
@@ -318,10 +318,20 @@ class Workers extends EventEmitter {
   _listenWorkerEvents(worker) {
     worker.on('message', (message) => {
       output.process(message.workerIndex);
+
       switch (message.event) {
+        case event.suite.before:
+          this.emit(event.suite.before, repackTest(message.data));
+          break;
         case event.hook.failed:
           this.emit(event.hook.failed, repackTest(message.data));
           this.errors.push(message.data.err);
+          break;
+        case event.test.before:
+          this.emit(event.test.before, repackTest(message.data));
+          break;
+        case event.test.started:
+          this.emit(event.test.started, repackTest(message.data));
           break;
         case event.test.failed:
           this._updateFinishedTests(repackTest(message.data));
@@ -335,7 +345,9 @@ class Workers extends EventEmitter {
           this._updateFinishedTests(repackTest(message.data));
           this.emit(event.test.skipped, repackTest(message.data));
           break;
-        case event.test.finished: this.emit(event.test.finished, repackTest(message.data)); break;
+        case event.test.finished:
+          this.emit(event.test.finished, repackTest(message.data));
+          break;
         case event.test.after:
           this.emit(event.test.after, repackTest(message.data));
           break;


### PR DESCRIPTION
## Motivation/Description of the PR

This PR adds more events to be propagated to who ever uses the custom script for parallel execution

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [x] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
