### PR TITLE
Fix/align run workers output

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -44,7 +44,7 @@ module.exports = {
    */
   process(process) {
     if (process === null) return outputProcess = '';
-    if (process) outputProcess = String(process).length === 1 ? `[0${process}]` : `[${process}]`
+    if (process) outputProcess = String(process).length === 1 ? `[0${process}]` : `[${process}]`;
     return outputProcess;
   },
 

--- a/lib/output.js
+++ b/lib/output.js
@@ -44,7 +44,7 @@ module.exports = {
    */
   process(process) {
     if (process === null) return outputProcess = '';
-    if (process) outputProcess = `[${process}]`;
+    if (process) outputProcess = String(process).length === 1 ? `[0${process}]` : `[${process}]`
     return outputProcess;
   },
 


### PR DESCRIPTION
This is a feature request and a fix at the same time to align the run-workers output into a more readable alignment. Currently the output of run-workers when using more than 9 workers is staggered like so:

```
[21] testing feature @tag1 @tag2 --
[23]   ✔ scenario test in 14435ms
[23] feature two @tag3 @tag1 --
[4]   ✔ scenario testing in 36477ms
[4] feature tests @tag1 --
[8]   ✔ more tests at the scenario level in 37890ms
[24]   ✔ another test in 10440ms
[7]   ✔ this is a test in 41545ms
[8] feature file heading --
[30]   ✔ successful test in 6920ms
```

This PR would update that same output to be:
```
[21] testing feature @tag1 @tag2 --
[23]   ✔ scenario test in 14435ms
[23] feature two @tag3 @tag1 --
[04]   ✔ scenario testing in 36477ms
[04] feature tests @tag1 --
[08]   ✔ more tests at the scenario level in 37890ms
[24]   ✔ another test in 10440ms
[07]   ✔ this is a test in 41545ms
[08] feature file heading --
[30]   ✔ successful test in 6920ms
```

This primarily serves to align the checkmark and x's for pass / fail to line up so it's easier to parse through at a glance. This is just a pet peeve of mine that's been bugging me for a while.

Applicable helpers:

- [x] N/A
- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [x] N/A
- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [x] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added - N/A
- [ ] Documentation has been added (Run `npm run docs`) - N/A
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
