### PR TITLE
Add ability to use an array of feature files

### DIFF
--- a/docs/bdd.md
+++ b/docs/bdd.md
@@ -343,12 +343,23 @@ Tag should be placed before *Scenario:* or before *Feature:* keyword. In the las
 ## Configuration
 
 * `gherkin`
-  * `features` - path to feature files
+  * `features` - path to feature files, or an array of feature file paths
   * `steps` - array of files with step definitions
 
 ```js
 "gherkin": {
   "features": "./features/*.feature",
+  "steps": [
+    "./step_definitions/steps.js"
+  ]
+}
+```
+```js
+"gherkin": {
+  "features": [
+      "./features/*.feature",
+      "./features/api_features/*.feature"
+    ],
   "steps": [
     "./step_definitions/steps.js"
   ]

--- a/lib/codecept.js
+++ b/lib/codecept.js
@@ -131,7 +131,15 @@ class Codecept {
     if (!pattern) {
       patterns = [];
       if (this.config.tests && !this.opts.features) patterns.push(this.config.tests);
-      if (this.config.gherkin.features && !this.opts.tests) patterns.push(this.config.gherkin.features);
+      if (this.config.gherkin.features && !this.opts.tests) {
+        if (Array.isArray(this.config.gherkin.features)) {
+          this.config.gherkin.features.forEach(feature => {
+            patterns.push(feature);
+          });
+        } else {
+          patterns.push(this.config.gherkin.features);
+        }
+      }
     }
 
     for (pattern of patterns) {


### PR DESCRIPTION
## Motivation/Description of the PR
- This Pr is designed to allow people to add different paths for their feature files. This way there can be better organization for frontend vs api features or old vs new, etc etc. This is for gherkin.

Applicable helpers:

- [x ] WebDriver
- [x] Puppeteer
- [x ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [x] Protractor
- [] TestCafe
- [x] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [x] :rocket: New functionality
- [ ] :bug: Bug fix
- [x] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
