### PR TITLE
style: optional params for config get function

### DIFF
--- a/docs/helpers/Playwright.md
+++ b/docs/helpers/Playwright.md
@@ -99,7 +99,7 @@ This helper should be configured in codecept.json or codecept.conf.js
      Playwright: {
        url: "http://localhost",
        chromium: {
-         browserWSEndpoint: "ws://localhost:9222/devtools/browser/c5aa6160-b5bc-4d53-bb49-6ecb36cd2e0a"
+         browserWSEndpoint: { wsEndpoint: 'ws://localhost:9222/devtools/browser/c5aa6160-b5bc-4d53-bb49-6ecb36cd2e0a' } 
        }
      }
    }
@@ -1894,7 +1894,7 @@ I.waitUrlEquals('http://127.0.0.1:8000/info');
 
 [2]: https://github.com/microsoft/playwright/blob/master/docs/api.md#pagewaitfornavigationoptions
 
-[3]: https://chromedevtools.github.io/devtools-protocol/#how-do-i-access-the-browser-target
+[3]: https://playwright.dev/docs/api/class-browsertype#browsertypeconnectparams
 
 [4]: https://github.com/microsoft/playwright/blob/v0.11.0/docs/api.md#working-with-chrome-extensions
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -87,8 +87,8 @@ class Config {
 
   /**
    * Get current config.
-   * @param {string} key
-   * @param {*} val
+   * @param {string} [key]
+   * @param {*} [val]
    * @return {*}
    */
   static get(key, val) {


### PR DESCRIPTION
## Motivation/Description of the PR

![Screen Shot 2021-02-24 at 11 43 08 AM](https://user-images.githubusercontent.com/7845001/108997506-f5c2e400-769f-11eb-9baf-f3cb346a30e1.png)

- Make the params optional for config get function. -> https://codecept.io/hooks/#config
`let config = require('codeceptjs').config.get();`

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [x] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
