### PR TITLE
feat: propagate non test cycle events to main thread

### DIFF
--- a/docs/parallel.md
+++ b/docs/parallel.md
@@ -178,7 +178,7 @@ customWorkers.on(event.all.result, () => {
 });
 ```
 
-### Example: Emitting messages to the parent worker
+### Emitting messages to the parent worker
 
 Child workers can send non test events to the main worker. This is useful if you want to pass along information not related to the tests event cycles itself such as `event.test.success`.
 

--- a/docs/parallel.md
+++ b/docs/parallel.md
@@ -178,6 +178,22 @@ customWorkers.on(event.all.result, () => {
 });
 ```
 
+### Example: Emitting messages to the parent worker
+
+Child workers can send non test events to the main worker. This is useful if you want to pass along information not related to the tests event cycles itself such as `event.test.success`.
+
+```js
+
+// listen for any non test related events
+workers.on('message', (data) => {
+  console.log(data)
+});
+
+workers.on(event.all.result, (status, completedTests, workerStats) => {
+  // logic
+});
+```
+
 ## Sharing Data Between Workers
 
 NodeJS Workers can communicate between each other via messaging system. It may happen that you want to pass some data from one of workers to other. For instance, you may want to share user credentials accross all tests. Data will be appended to a container.

--- a/docs/parallel.md
+++ b/docs/parallel.md
@@ -183,7 +183,7 @@ customWorkers.on(event.all.result, () => {
 Child workers can send non test events to the main process. This is useful if you want to pass along information not related to the tests event cycles itself such as `event.test.success`.
 
 ```js
-
+// inside main process
 // listen for any non test related events
 workers.on('message', (data) => {
   console.log(data)

--- a/docs/parallel.md
+++ b/docs/parallel.md
@@ -180,7 +180,7 @@ customWorkers.on(event.all.result, () => {
 
 ### Emitting messages to the parent worker
 
-Child workers can send non test events to the main worker. This is useful if you want to pass along information not related to the tests event cycles itself such as `event.test.success`.
+Child workers can send non test events to the main process. This is useful if you want to pass along information not related to the tests event cycles itself such as `event.test.success`.
 
 ```js
 

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -129,7 +129,7 @@ const { createValueEngine, createDisabledEngine } = require('./extras/Playwright
  *      Playwright: {
  *        url: "http://localhost",
  *        chromium: {
- *          browserWSEndpoint: { wsEndpoint: 'ws://localhost:9222/devtools/browser/c5aa6160-b5bc-4d53-bb49-6ecb36cd2e0a' } 
+ *          browserWSEndpoint: { wsEndpoint: 'ws://localhost:9222/devtools/browser/c5aa6160-b5bc-4d53-bb49-6ecb36cd2e0a' }
  *        }
  *      }
  *    }

--- a/lib/workers.js
+++ b/lib/workers.js
@@ -319,6 +319,11 @@ class Workers extends EventEmitter {
     worker.on('message', (message) => {
       output.process(message.workerIndex);
 
+      // deal with events that are not test cycle related
+      if (!message.event) {
+        return this.emit('message', message);
+      }
+
       switch (message.event) {
         case event.suite.before:
           this.emit(event.suite.before, repackTest(message.data));

--- a/test/data/sandbox/codecept.non-test-events-worker.js
+++ b/test/data/sandbox/codecept.non-test-events-worker.js
@@ -1,0 +1,21 @@
+exports.config = {
+  tests: './non-test-events-worker/*.js',
+  timeout: 10000,
+  output: './output',
+  helpers: {
+    FileSystem: {},
+    Workers: {
+      require: './workers_helper',
+    },
+  },
+  include: {},
+  bootstrap: (done) => {
+    process.stdout.write('bootstrap b1+');
+    setTimeout(() => {
+      process.stdout.write('b2');
+      done();
+    }, 1000);
+  },
+  mocha: {},
+  name: 'sandbox',
+};

--- a/test/data/sandbox/non-test-events-worker/non_test_event.worker.js
+++ b/test/data/sandbox/non-test-events-worker/non_test_event.worker.js
@@ -1,0 +1,13 @@
+const { isMainThread, parentPort } = require('worker_threads');
+
+Feature('Should propagate non test events');
+
+Scenario('From worker propagate message 1', ({ I }) => {
+  if (!isMainThread) parentPort.postMessage('message 1');
+  I.seeThisIsWorker();
+});
+
+Scenario('From worker propagate message 2', ({ I }) => {
+  if (!isMainThread) parentPort.postMessage('message 2');
+  I.seeThisIsWorker();
+});

--- a/test/unit/worker_test.js
+++ b/test/unit/worker_test.js
@@ -220,4 +220,37 @@ describe('Workers', () => {
       done();
     });
   });
+
+  it('should propagate non test events', (done) => {
+    if (!semver.satisfies(process.version, '>=11.7.0')) this.skip('not for node version');
+    const messages = [];
+
+    const createTestGroups = () => {
+      const files = [
+        [path.join(codecept_dir, '/non-test-events-worker/non_test_event.worker.js')],
+      ];
+
+      return files;
+    };
+
+    const workerConfig = {
+      by: createTestGroups,
+      testConfig: './test/data/sandbox/codecept.non-test-events-worker.js',
+    };
+
+    workers = new Workers(2, workerConfig);
+
+    workers.run();
+
+    workers.on('message', (data) => {
+      messages.push(data);
+    });
+
+    workers.on(event.all.result, () => {
+      expect(messages.length).equal(2);
+      expect(messages[0]).equal('message 1');
+      expect(messages[1]).equal('message 2');
+      done();
+    });
+  });
 });


### PR DESCRIPTION
## Motivation/Description of the PR

This PR will allow to propagate non test cycle events to the custom worker parallelisation script.

Example:

```js
// parallelisation script
workers.on('message', (data) => {
  console.log(data)
});
```

This will allow any `js` file that wants to communicate with the main thread can use the `parentPort.postMessage();` to send custom data.

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [x] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [x] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
