### PR TITLE
Adding the code to connect to sauce labs using a sauce tunnel when testing an app

### DIFF
--- a/lib/helper/Appium.js
+++ b/lib/helper/Appium.js
@@ -183,6 +183,7 @@ class Appium extends Webdriver {
     config.capabilities.browserName = config.browser || config.capabilities.browserName;
     config.capabilities.app = config.app || config.capabilities.app;
     config.capabilities.platformName = config.platform || config.capabilities.platformName;
+    config.capabilities.tunnelIdentifier = config.tunnelIdentifier || config.capabilities.tunnelIdentifier; // Adding the code to connect to sauce labs via sauce tunnel
     config.waitForTimeout /= 1000; // convert to seconds
 
     // [CodeceptJS compatible] transform host to hostname


### PR DESCRIPTION
…sting an app

## Motivation/Description of the PR
- Description of this PR, which problem it solves
-  This PR fixes the problem if some one has to connect to sauce labs via the tunnel to test the app (Android & IOS)
- Resolves #issueId (if applicable).

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [*] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [*] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
