### PR TITLE
run-workers failure output Fix/2621

### DIFF
--- a/lib/workers.js
+++ b/lib/workers.js
@@ -349,7 +349,7 @@ class Workers extends EventEmitter {
           this.emit(event.test.finished, repackTest(message.data));
           break;
         case event.test.after:
-          this._updateFinishedTests(repackTest(message.data))
+          this._updateFinishedTests(repackTest(message.data));
           this.emit(event.test.after, repackTest(message.data));
           break;
         case event.all.after:

--- a/lib/workers.js
+++ b/lib/workers.js
@@ -349,6 +349,7 @@ class Workers extends EventEmitter {
           this.emit(event.test.finished, repackTest(message.data));
           break;
         case event.test.after:
+          this._updateFinishedTests(repackTest(message.data))
           this.emit(event.test.after, repackTest(message.data));
           break;
         case event.all.after:


### PR DESCRIPTION
## Fix test failure output of the `run-workers` command
- This pr applies the `_updateFinishedTests()` method to test object after event.test.after event. Bug seems to be occurring because this event was the only one receiving the test.err object, but it wasn't attaching the test id. When the `workers.printResults()` method was later called in `lib/command/run-workers.js`, no test id was present to iterate over in lines 415-417 of `lib/workers.js` when building the failed test results.
- Resolves #2621.

Applicable helpers:

- [x] WebDriver
- [x] Puppeteer
- [x] Nightmare
- [ ] REST
- [ ] FileHelper
- [x] Appium
- [x] Protractor
- [x] TestCafe
- [x] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [-] Local tests are passed (Run `npm test`) *

* Just as a note, this is discussed in issue #2621, but to clarify there are two test failures with this change.
``` 
  1) Workers
       should run simple worker:

      Uncaught AssertionError: expected true to equal false
      + expected - actual

      -true
      +false
      
      at Workers.<anonymous> (test/unit/worker_test.js:31:22)
      at Workers._finishRun (lib/workers.js:379:10)
      at Worker.<anonymous> (lib/workers.js:367:14)
      at Worker.[kOnExit] (internal/worker.js:240:10)
      at Worker.<computed>.onexit (internal/worker.js:174:20)

  2) Workers
       should run worker with custom config:

      Uncaught AssertionError: expected true to equal false
      + expected - actual

      -true
      +false
      
      at Workers.<anonymous> (test/unit/worker_test.js:110:22)
      at Workers._finishRun (lib/workers.js:379:10)
      at Worker.<anonymous> (lib/workers.js:367:14)
      at Worker.[kOnExit] (internal/worker.js:240:10)
      at Worker.<computed>.onexit (internal/worker.js:174:20)
```

The two failures are on `expect(status).equal(false)`, and I don't know enough about what these tests are trying to do to know if just changing this to `.equal(true)` instead would be an appropriate fix. Maybe there's another reason they're set this way and I'm missing something. @chwolf [encouraged me](https://github.com/codeceptjs/CodeceptJS/issues/2621#issuecomment-782394815) to issue the PR advising we can improve after the fix is applied.
