### PR TITLE
Renamed MockRequestHelper to MockRequest in the documentation

### DIFF
--- a/docs/helpers/MockRequest.md
+++ b/docs/helpers/MockRequest.md
@@ -56,7 +56,7 @@ helpers: {
    Puppeteer: {
      // regular Puppeteer config here
    },
-   MockRequestHelper: {
+   MockRequest: {
      require: '@codeceptjs/mock-request',
    }
 }
@@ -67,7 +67,7 @@ helpers: {
 ```js
 // sample options
 helpers: {
-  MockRequestHelper: {
+  MockRequest: {
      require: '@codeceptjs/mock-request',
      mode: record,
      recordIfMissing: true,
@@ -115,7 +115,7 @@ helpers: {
    WebDriver: {
      // regular WebDriver config here
    },
-   MockRequestHelper: {
+   MockRequest: {
      require: '@codeceptjs/mock-request',
    }
 }


### PR DESCRIPTION
## Motivation/Description of the PR
- Quick fix in the documentation. :clipboard: Renamed MockRequestHelper to MockRequest because the documentation had referred to 2 different names.

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright
- [X] MockRequest

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [X] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [X] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
