### PR TITLE
Get the queue id from recorder

### DIFF
--- a/lib/recorder.js
+++ b/lib/recorder.js
@@ -322,6 +322,15 @@ module.exports = {
   },
 
   /**
+   * Get the queue id
+   * @return {number}
+   * @inner
+   */
+  getQueueId() {
+    return queueId;
+  },
+
+  /**
    * Get a state of current queue and tasks
    * @return {string}
    * @inner


### PR DESCRIPTION
## Motivation/Description of the PR
- As a QA, I want to get the queue id from the recorder so I can run the second retry in a different environment and/or with mocked data.

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [X] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [X] Lint checking (Run `npm run lint`)
- [X] Local tests are passed (Run `npm test`)
