### PR TITLE
Use class instance of axios in REST helper

### DIFF
--- a/lib/helper/REST.js
+++ b/lib/helper/REST.js
@@ -59,7 +59,8 @@ class REST extends Helper {
 
     this.options = { ...this.options, ...config };
     this.headers = { ...this.options.defaultHeaders };
-    axios.defaults.headers = this.options.defaultHeaders;
+    this.axios = axios.create();
+    this.axios.defaults.headers = this.options.defaultHeaders;
   }
 
   static _checkRequirements() {
@@ -77,7 +78,7 @@ class REST extends Helper {
    */
   async _executeRequest(request) {
     const _debugRequest = { ...request };
-    axios.defaults.timeout = request.timeout || this.options.timeout;
+    this.axios.defaults.timeout = request.timeout || this.options.timeout;
 
     if (this.headers && this.headers.auth) {
       request.auth = this.headers.auth;
@@ -102,7 +103,7 @@ class REST extends Helper {
 
     let response;
     try {
-      response = await axios(request);
+      response = await this.axios(request);
     } catch (err) {
       if (!err.response) throw err;
       this.debugSection('Response', `Response error. Status code: ${err.response.status}`);


### PR DESCRIPTION
## Motivation/Description of the PR

- Use class instance of axios, not the global instance, to avoid contaminating global configuration.
- Fixes #2652 

I'm not sure I can think of any new tests for this, the REST helper seems quite well tested already....

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [x] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [x] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
