### PR TITLE
feat: adding faker.js support to gherkin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,10 @@ defaults: &defaults
         command: docker-compose run --rm test-acceptance.protractor
         working_directory: test
         when: always
+    - run:
+        command: docker-compose run --rm test-bdd.faker
+        working_directory: test
+        when: always
 
 jobs:
   docker:

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ website
 docs/build
 test/data/output
 test/acceptance/output
+test/bdd/output
 examples/output
 examples/selenoid-example/output
 test/data/app/db

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -510,8 +510,8 @@ Scenario Outline: ...
              When ...
              Then ...
         Examples:
-  | productName          | customer                | email               | anythingMore |
-  | {{commerce.product}} | Dr. {{ name.findName }} | {{ internet.email}} | staticData   |
+  | productName          | customer              | email              | anythingMore |
+  | {{commerce.product}} | Dr. {{name.findName}} | {{internet.email}} | staticData   |
 ```
 
 ### Parameters

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -478,9 +478,49 @@ I.click('=sign-up'); // matches => [data-qa=sign-up]
 
 -   `config`  
 
+## fakerTransform
+
+Use the [faker.js][4] package to generate fake data inside examples on your gherkin tests
+
+![Faker.js][5]
+
+#### Usage
+
+To start please install `faker.js` package
+
+    npm install -D faker
+
+    yarn add -D faker
+
+Add this plugin to config file:
+
+```js
+plugins: {
+   fakerTransform: {
+     enabled: true
+   }
+}
+```
+
+Add the faker API using a mustache string format inside examples tables in your gherkin scenario outline
+
+```feature
+Scenario Outline: ...
+            Given ...
+             When ...
+             Then ...
+        Examples:
+  | productName          | customer                | email               | anythingMore |
+  | {{commerce.product}} | Dr. {{ name.findName }} | {{ internet.email}} | staticData   |
+```
+
+### Parameters
+
+-   `config`  
+
 ## pauseOnFail
 
-Automatically launches [interactive pause][4] when a test fails.
+Automatically launches [interactive pause][6] when a test fails.
 
 Useful for debugging flaky tests on local environment.
 Add this plugin to config file:
@@ -527,9 +567,9 @@ Possible config options:
 
     Links:
 
--   [https://github.com/GoogleChrome/puppeteer/blob/v1.12.2/docs/api.md#class-coverage][5]
--   [https://github.com/istanbuljs/puppeteer-to-istanbul][6]
--   [https://github.com/gotwarlost/istanbul][7]
+-   [https://github.com/GoogleChrome/puppeteer/blob/v1.12.2/docs/api.md#class-coverage][7]
+-   [https://github.com/istanbuljs/puppeteer-to-istanbul][8]
+-   [https://github.com/gotwarlost/istanbul][9]
 
 ### Parameters
 
@@ -633,14 +673,14 @@ Possible config options:
 
 ## selenoid
 
-[Selenoid][8] plugin automatically starts browsers and video recording.
+[Selenoid][10] plugin automatically starts browsers and video recording.
 Works with WebDriver helper.
 
 ### Prerequisite
 
 This plugin **requires Docker** to be installed.
 
-> If you have issues starting Selenoid with this plugin consider using the official [Configuration Manager][9] tool from Selenoid
+> If you have issues starting Selenoid with this plugin consider using the official [Configuration Manager][11] tool from Selenoid
 
 ### Usage
 
@@ -669,7 +709,7 @@ plugins: {
   }
 ```
 
-When `autoCreate` is enabled it will pull the [latest Selenoid from DockerHub][10] and start Selenoid automatically.
+When `autoCreate` is enabled it will pull the [latest Selenoid from DockerHub][12] and start Selenoid automatically.
 It will also create `browsers.json` file required by Selenoid.
 
 In automatic mode the latest version of browser will be used for tests. It is recommended to specify exact version of each browser inside `browsers.json` file.
@@ -681,10 +721,10 @@ In automatic mode the latest version of browser will be used for tests. It is re
 While this plugin can create containers for you for better control it is recommended to create and launch containers manually.
 This is especially useful for Continous Integration server as you can configure scaling for Selenoid containers.
 
-> Use [Selenoid Configuration Manager][9] to create and start containers semi-automatically.
+> Use [Selenoid Configuration Manager][11] to create and start containers semi-automatically.
 
 1.  Create `browsers.json` file in the same directory `codecept.conf.js` is located
-    [Refer to Selenoid documentation][11] to know more about browsers.json.
+    [Refer to Selenoid documentation][13] to know more about browsers.json.
 
 _Sample browsers.json_
 
@@ -709,7 +749,7 @@ _Sample browsers.json_
 
 2.  Create Selenoid container
 
-Run the following command to create a container. To know more [refer here][12]
+Run the following command to create a container. To know more [refer here][14]
 
 ```bash
 docker create                                    \
@@ -742,7 +782,7 @@ When `allure` plugin is enabled a video is attached to report automatically.
 | enableVideo      | Enable video recording and use `video` folder of output (default: false)       |
 | enableLog        | Enable log recording and use `logs` folder of output (default: false)          |
 | deletePassed     | Delete video and logs of passed tests (default : true)                         |
-| additionalParams | example: `additionalParams: '--env TEST=test'` [Refer here][13] to know more   |
+| additionalParams | example: `additionalParams: '--env TEST=test'` [Refer here][15] to know more   |
 
 ### Parameters
 
@@ -750,7 +790,7 @@ When `allure` plugin is enabled a video is attached to report automatically.
 
 ## stepByStepReport
 
-![step-by-step-report][14]
+![step-by-step-report][16]
 
 Generates step by step report for a test.
 After each step in a test a screenshot is created. After test executed screenshots are combined into slideshow.
@@ -857,7 +897,7 @@ This plugin allows to run webdriverio services like:
 -   browserstack
 -   appium
 
-A complete list of all available services can be found on [webdriverio website][15].
+A complete list of all available services can be found on [webdriverio website][17].
 
 #### Setup
 
@@ -869,7 +909,7 @@ See examples below:
 
 #### Selenium Standalone Service
 
-Install `@wdio/selenium-standalone-service` package, as [described here][16].
+Install `@wdio/selenium-standalone-service` package, as [described here][18].
 It is important to make sure it is compatible with current webdriverio version.
 
 Enable `wdio` plugin in plugins list and add `selenium-standalone` service:
@@ -888,7 +928,7 @@ Please note, this service can be used with Protractor helper as well!
 
 #### Sauce Service
 
-Install `@wdio/sauce-service` package, as [described here][17].
+Install `@wdio/sauce-service` package, as [described here][19].
 It is important to make sure it is compatible with current webdriverio version.
 
 Enable `wdio` plugin in plugins list and add `sauce` service:
@@ -924,30 +964,34 @@ In the same manner additional services from webdriverio can be installed, enable
 
 [3]: https://codecept.io/locators#custom-locators
 
-[4]: /basics/#pause
+[4]: https://www.npmjs.com/package/faker
 
-[5]: https://github.com/GoogleChrome/puppeteer/blob/v1.12.2/docs/api.md#class-coverage
+[5]: https://raw.githubusercontent.com/Marak/faker.js/master/logo.png
 
-[6]: https://github.com/istanbuljs/puppeteer-to-istanbul
+[6]: /basics/#pause
 
-[7]: https://github.com/gotwarlost/istanbul
+[7]: https://github.com/GoogleChrome/puppeteer/blob/v1.12.2/docs/api.md#class-coverage
 
-[8]: https://aerokube.com/selenoid/
+[8]: https://github.com/istanbuljs/puppeteer-to-istanbul
 
-[9]: https://aerokube.com/cm/latest/
+[9]: https://github.com/gotwarlost/istanbul
 
-[10]: https://hub.docker.com/u/selenoid
+[10]: https://aerokube.com/selenoid/
 
-[11]: https://aerokube.com/selenoid/latest/#_prepare_configuration
+[11]: https://aerokube.com/cm/latest/
 
-[12]: https://aerokube.com/selenoid/latest/#_option_2_start_selenoid_container
+[12]: https://hub.docker.com/u/selenoid
 
-[13]: https://docs.docker.com/engine/reference/commandline/create/
+[13]: https://aerokube.com/selenoid/latest/#_prepare_configuration
 
-[14]: https://codecept.io/img/codeceptjs-slideshow.gif
+[14]: https://aerokube.com/selenoid/latest/#_option_2_start_selenoid_container
 
-[15]: https://webdriver.io
+[15]: https://docs.docker.com/engine/reference/commandline/create/
 
-[16]: https://webdriver.io/docs/selenium-standalone-service.html
+[16]: https://codecept.io/img/codeceptjs-slideshow.gif
 
-[17]: https://webdriver.io/docs/sauce-service.html
+[17]: https://webdriver.io
+
+[18]: https://webdriver.io/docs/selenium-standalone-service.html
+
+[19]: https://webdriver.io/docs/sauce-service.html

--- a/lib/interfaces/gherkin.js
+++ b/lib/interfaces/gherkin.js
@@ -6,6 +6,7 @@ const event = require('../event');
 const scenario = require('../scenario');
 const Step = require('../step');
 const DataTableArgument = require('../data/dataTableArgument');
+const transform = require('../transform');
 
 const parser = new Parser();
 parser.stopAtFirstError = false;
@@ -81,7 +82,7 @@ module.exports = (text) => {
           const current = {};
           for (const index in example.cells) {
             const placeholder = fields[index];
-            const value = example.cells[index].value;
+            const value = transform('gherkin.examples', example.cells[index].value);
             current[placeholder] = value;
             exampleSteps = exampleSteps.map((step) => {
               step = { ...step };

--- a/lib/plugin/fakerTransform.js
+++ b/lib/plugin/fakerTransform.js
@@ -36,8 +36,8 @@ const transform = require('../transform');
  *              When ...
  *              Then ...
  *         Examples:
- *   | productName          | customer                | email               | anythingMore |
- *   | {{commerce.product}} | Dr. {{ name.findName }} | {{ internet.email}} | staticData   |
+ *   | productName          | customer              | email              | anythingMore |
+ *   | {{commerce.product}} | Dr. {{name.findName}} | {{internet.email}} | staticData   |
  * ```
  *
  */

--- a/lib/plugin/fakerTransform.js
+++ b/lib/plugin/fakerTransform.js
@@ -1,0 +1,51 @@
+const faker = require('faker');
+const transform = require('../transform');
+
+/**
+ * Use the [faker.js](https://www.npmjs.com/package/faker) package to generate fake data inside examples on your gherkin tests
+ *
+ * ![Faker.js](https://raw.githubusercontent.com/Marak/faker.js/master/logo.png)
+ *
+ * #### Usage
+ *
+ * To start please install `faker.js` package
+ *
+ * ```
+ * npm install -D faker
+ * ```
+ *
+ * ```
+ * yarn add -D faker
+ * ```
+ *
+ * Add this plugin to config file:
+ *
+ * ```js
+ * plugins: {
+ *    fakerTransform: {
+ *      enabled: true
+ *    }
+ * }
+ * ```
+ *
+ * Add the faker API using a mustache string format inside examples tables in your gherkin scenario outline
+ *
+ * ```feature
+ * Scenario Outline: ...
+ *             Given ...
+ *              When ...
+ *              Then ...
+ *         Examples:
+ *   | productName          | customer                | email               | anythingMore |
+ *   | {{commerce.product}} | Dr. {{ name.findName }} | {{ internet.email}} | staticData   |
+ * ```
+ *
+ */
+module.exports = function (config) {
+  transform.addTransformerBeforeAll('gherkin.examples', (value) => {
+    if (typeof value === 'string' && value.length > 0) {
+      return faker.fake(value);
+    }
+    return value;
+  });
+};

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -1,0 +1,26 @@
+const transformers = {
+  'gherkin.examples': [],
+};
+
+function transform(target, value) {
+  if (target in transformers) {
+    for (const transform of transformers[target]) {
+      value = transform(value);
+    }
+  }
+  return value;
+}
+
+transform.addTransformer = function (target, transformer) {
+  if (target in transformers) {
+    transformers[target].push(transformer);
+  }
+};
+
+transform.addTransformerBeforeAll = function (target, transformer) {
+  if (target in transformers) {
+    transformers[target].unshift(transformer);
+  }
+};
+
+module.exports = transform;

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "eslint-plugin-mocha": "^6.3.0",
     "expect": "^26.6.2",
     "express": "^4.17.1",
-    "faker": "^4.1.0",
+    "faker": "^5.5.1",
     "form-data": "^3.0.0",
     "graphql": "^14.6.0",
     "husky": "^4.3.5",
@@ -141,6 +141,9 @@
   "engines": {
     "node": ">=8.9.1",
     "npm": ">=5.6.0"
+  },
+  "peerDependencies": {
+    "faker": "^5.5.1"
   },
   "es6": true,
   "husky": {

--- a/test/acceptance/session_test.js
+++ b/test/acceptance/session_test.js
@@ -51,17 +51,11 @@ Scenario('Different cookies for different sessions @WebDriverIO @Protractor @Pla
   const cookies = {};
 
   I.amOnPage(cookiePage);
-  I.click(locate('#uhfCookieAlert button').withText('Accept all'));
-  I.refreshPage();
   session('john', () => {
     I.amOnPage(cookiePage);
-    I.click(locate('#uhfCookieAlert button').withText('Accept all'));
-    I.refreshPage();
   });
   session('mary', () => {
     I.amOnPage(cookiePage);
-    I.click(locate('#uhfCookieAlert button').withText('Accept all'));
-    I.refreshPage();
   });
 
   cookies.default = (await I.grabCookie(cookieName)).value;

--- a/test/acceptance/session_test.js
+++ b/test/acceptance/session_test.js
@@ -51,11 +51,17 @@ Scenario('Different cookies for different sessions @WebDriverIO @Protractor @Pla
   const cookies = {};
 
   I.amOnPage(cookiePage);
+  I.click(locate('#uhfCookieAlert button').withText('Accept all'));
+  I.refreshPage();
   session('john', () => {
     I.amOnPage(cookiePage);
+    I.click(locate('#uhfCookieAlert button').withText('Accept all'));
+    I.refreshPage();
   });
   session('mary', () => {
     I.amOnPage(cookiePage);
+    I.click(locate('#uhfCookieAlert button').withText('Accept all'));
+    I.refreshPage();
   });
 
   cookies.default = (await I.grabCookie(cookieName)).value;

--- a/test/bdd/codecept.faker.js
+++ b/test/bdd/codecept.faker.js
@@ -1,0 +1,38 @@
+const TestHelper = require('../support/TestHelper');
+
+module.exports.config = {
+  timeout: 10000,
+  output: './output',
+  helpers: {
+    Puppeteer: {
+      url: TestHelper.siteUrl(),
+      show: false,
+      chrome: {
+        args: [
+          '--no-sandbox',
+          '--disable-setuid-sandbox',
+        ],
+      },
+    },
+    ScreenshotSessionHelper: {
+      require: '../support/ScreenshotSessionHelper.js',
+      outputPath: './output',
+    },
+  },
+  include: {},
+  bootstrap: false,
+  mocha: {},
+  plugins: {
+    screenshotOnFail: {
+      enabled: true,
+    },
+    fakerTransform: {
+      enabled: true,
+    },
+  },
+  name: 'bdd',
+  gherkin: {
+    features: './features/faker.feature',
+    steps: ['./defs/faker.js'],
+  },
+};

--- a/test/bdd/defs/faker.js
+++ b/test/bdd/defs/faker.js
@@ -1,0 +1,22 @@
+const assert = require('assert');
+
+const fields = {};
+
+Given('I sold the {string} car to {string} for {string}', (product, customer, price) => {
+  assert.notStrictEqual(fields.product, '{{vehicle.vehicle}}');
+  assert.notStrictEqual(fields.customer, 'Dr. {{name.findName}}');
+  assert.notStrictEqual(fields.price, '{{commerce.price}}');
+  Object.assign(fields, { product, customer, price });
+});
+
+When('customer {string} paid {string} for car {string} in {string}', (customer, price, product, cashier) => {
+  assert.strictEqual(fields.customer, customer);
+  assert.strictEqual(fields.price, price);
+  assert.strictEqual(fields.product, product);
+  Object.assign(fields, { cashier });
+});
+
+Then('{string} returned {string} in change to {string}', (cashier, change, customer) => {
+  assert.strictEqual(fields.cashier, cashier);
+  assert.strictEqual(fields.customer, customer);
+});

--- a/test/bdd/features/faker.feature
+++ b/test/bdd/features/faker.feature
@@ -1,0 +1,10 @@
+@bdd
+Feature: Faker examples
+
+  Scenario Outline: faker data genetation
+              Given I sold the "<product>" car to "<customer>" for "<price>"
+               When customer "<customer>" paid "<price>" for car "<product>" in "<cashier>"
+               Then "<cashier>" returned "<change>" in change to "<customer>"
+          Examples:
+  | product             | customer              | price              | cashier   |
+  | {{vehicle.vehicle}} | Dr. {{name.findName}} | {{commerce.price}} | cashier 2 |

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -134,6 +134,17 @@ services:
       - ./support:/support
       - node_modules:/node_modules
 
+  test-bdd.faker:
+    build: ..
+    env_file: .env
+    environment:
+      - CODECEPT_ARGS=-c codecept.faker.js
+    volumes:
+      - ./bdd:/tests
+      - ./data:/data
+      - ./support:/support
+      - node_modules:/node_modules
+
   selenium.chrome:
     image: selenium/standalone-chrome:3.141.59-oxygen
     shm_size: 2g


### PR DESCRIPTION
## To generate fake data inside examples on your gherkin tests
- I added a plugin called fakerTransform. This plugin adds a callback on transform function that will turning the faker API using a mustache string format inside example of the gherkin scenario outline before running the test steps

## Type of change

- :rocket: New functionality

## Checklist:

- [ x ] Tests have been added
- [ x ] Documentation has been added (Run `npm run docs`)
- [ x ] Lint checking (Run `npm run lint`)
- [ x ] Local tests are passed (Run `npm test`)