### PR TITLE
GraphQL Helper - use helper-specific instance of axios instead of global

### DIFF
--- a/lib/helper/GraphQL.js
+++ b/lib/helper/GraphQL.js
@@ -1,7 +1,5 @@
-let axios = require('axios');
+const axios = require('axios').default;
 const Helper = require('../helper');
-
-let headers = {};
 
 /**
  * GraphQL helper allows to send additional requests to a GraphQl endpoint during acceptance tests.
@@ -41,15 +39,16 @@ let headers = {};
 class GraphQL extends Helper {
   constructor(config) {
     super(config);
-    axios = require('axios');
+    this.axios = axios.create();
+    this.headers = {};
     this.options = {
       timeout: 10000,
       defaultHeaders: {},
       endpoint: '',
     };
     this.options = Object.assign(this.options, config);
-    headers = { ...this.options.defaultHeaders };
-    axios.defaults.headers = this.options.defaultHeaders;
+    this.headers = { ...this.options.defaultHeaders };
+    this.axios.defaults.headers = this.options.defaultHeaders;
   }
 
   static _checkRequirements() {
@@ -66,10 +65,10 @@ class GraphQL extends Helper {
    * @param {object} request
    */
   async _executeQuery(request) {
-    axios.defaults.timeout = request.timeout || this.options.timeout;
+    this.axios.defaults.timeout = request.timeout || this.options.timeout;
 
-    if (headers && headers.auth) {
-      request.auth = headers.auth;
+    if (this.headers && this.headers.auth) {
+      request.auth = this.headers.auth;
     }
 
     request.headers = Object.assign(request.headers, {
@@ -84,7 +83,7 @@ class GraphQL extends Helper {
 
     let response;
     try {
-      response = await axios(request);
+      response = await this.axios(request);
     } catch (err) {
       if (!err.response) throw err;
       this.debugSection(


### PR DESCRIPTION
## Motivation/Description of the PR

This uses a helper-specific instance of Axios instead of the global instance, to keep from changing global defaults.

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright
- [x] GraphQL

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [x] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added -- **There are already good GQL helper tests**
- [x] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
