### PR TITLE
Adding more details in the error message

### DIFF
--- a/lib/container.js
+++ b/lib/container.js
@@ -215,7 +215,7 @@ function createSupportObjects(config) {
         newObj._init();
       }
     } catch (err) {
-      throw new Error(`Initialization failed for ${name}: ${newObj}\n${err.message}`);
+      throw new Error(`Initialization failed for ${name}: ${newObj}\n${err.message}\n${err.stack}`);
     }
     return newObj;
   }
@@ -288,7 +288,7 @@ function createPlugins(config, options = {}) {
       }
       plugins[pluginName] = require(module)(config[pluginName]);
     } catch (err) {
-      throw new Error(`Could not load plugin ${pluginName} from module '${module}':\n${err.message}`);
+      throw new Error(`Could not load plugin ${pluginName} from module '${module}':\n${err.message}\n${err.stack}`);
     }
   }
   return plugins;
@@ -380,7 +380,7 @@ function loadSupportObject(modulePath, supportObjectName) {
 
     return obj;
   } catch (err) {
-    throw new Error(`Could not include object ${supportObjectName} from module '${modulePath}'\n${err.message}`);
+    throw new Error(`Could not include object ${supportObjectName} from module '${modulePath}'\n${err.message}\n${err.stack}`);
   }
 }
 


### PR DESCRIPTION
## Adding more details in the error message
I had an error in my project and I was not able to solve because the error message did not tell me enough so I added the stack trace to error message to identify the error origin

### Before
    Could not include object Step Definition from /home/runner/work/*/*.def.js from module '/home/runner/work/*/*.js'
    Unexpected token '.'
    
    Error: 
        at loadSupportObject (/home/runner/work/*/node_modules/codeceptjs/lib/container.js:383:11)
        at loadGherkinSteps (/home/runner/work/*/node_modules/codeceptjs/lib/container.js:315:7)
        at Function.create (/home/runner/work/*/node_modules/codeceptjs/lib/container.js:47:25)
        at Codecept.init (/home/runner/work/*/node_modules/codeceptjs/lib/codecept.js:56:15)
        at Command.module.exports (/home/runner/work/*/node_modules/codeceptjs/lib/command/run.js:24:14)
        at Command.listener (/home/runner/work/*/node_modules/commander/index.js:315:8)
        at Command.emit (events.js:314:20)
        at Command.parseArgs (/home/runner/work/*/node_modules/commander/index.js:651:12)
        at Command.parse (/home/runner/work/*/node_modules/commander/index.js:474:21)
        at Object.<anonymous> (/home/runner/work/*/node_modules/codeceptjs/bin/codecept.js:191:9)
    error Command failed with exit code 1.
    info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.

### After


    Could not include object Step Definition from /home/runner/work/*/*.def.js from module '/home/runner/work/*/*.def.js'
    Unexpected token '.'
    /home/runner/work/*/tests/*.js:46
        if (result?.data?.error) {
                   ^
    
    SyntaxError: Unexpected token '.'
        at new Script (vm.js:88:7)
        at createScript (vm.js:261:10)
        at Object.runInThisContext (vm.js:309:10)
        at wrapSafe (internal/modules/cjs/loader.js:902:15)
        at Module._compile (internal/modules/cjs/loader.js:963:27)
        at Module.m._compile (/home/runner/work/*/node_modules/ts-node/src/index.ts:1056:23)
        at Module._extensions..js (internal/modules/cjs/loader.js:1027:10)
        at Object.require.extensions.<computed> [as .js] (/home/runner/work/*/node_modules/ts-node/src/index.ts:1059:12)
        at Module.load (internal/modules/cjs/loader.js:863:32)
        at Function.Module._load (internal/modules/cjs/loader.js:708:14)
    
    Error: 
        at loadSupportObject (/home/runner/work/*/node_modules/codeceptjs/lib/container.js:383:11)
        at loadGherkinSteps (/home/runner/work/*/node_modules/codeceptjs/lib/container.js:315:7)
        at Function.create (/home/runner/work/*/node_modules/codeceptjs/lib/container.js:47:25)
        at Codecept.init (/home/runner/work/*/node_modules/codeceptjs/lib/codecept.js:56:15)
        at Command.module.exports (/home/runner/work/*/node_modules/codeceptjs/lib/command/run.js:24:14)
        at Command.listener (/home/runner/work/*/node_modules/commander/index.js:315:8)
        at Command.emit (events.js:314:20)
        at Command.parseArgs (/home/runner/work/*/node_modules/commander/index.js:651:12)
        at Command.parse (/home/runner/work/*/node_modules/commander/index.js:474:21)
        at Object.<anonymous> (/home/runner/work/*/node_modules/codeceptjs/bin/codecept.js:191:9)
    error Command failed with exit code 1.
    info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
