### PR TITLE
Fix: Playwright grabTextFrom()

### DIFF
--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -38,6 +38,7 @@ const consoleLogStore = new Console();
 const availableBrowsers = ['chromium', 'webkit', 'firefox', 'electron'];
 
 const { createValueEngine, createDisabledEngine } = require('./extras/PlaywrightPropEngine');
+const { pause } = require('..');
 /**
  * Uses [Playwright](https://github.com/microsoft/playwright) library to run tests inside:
  *
@@ -515,6 +516,7 @@ class Playwright extends Helper {
     if (!page) return;
     page.setDefaultNavigationTimeout(this.options.getPageTimeout);
     this.context = await this.page;
+    this.contextLocator = null;
     if (this.config.browser === 'chrome') {
       await page.bringToFront();
     }
@@ -656,6 +658,7 @@ class Playwright extends Helper {
     const els = await this._locate(locator);
     assertElementExists(els, locator);
     this.context = els[0];
+    this.contextLocator = locator;
 
     this.withinLocator = new Locator(locator);
   }
@@ -663,6 +666,7 @@ class Playwright extends Helper {
   async _withinEnd() {
     this.withinLocator = null;
     this.context = await this.page;
+    this.contextLocator = null;
   }
 
   _extractDataFromPerformanceTiming(timing, ...dataNames) {
@@ -1563,13 +1567,27 @@ class Playwright extends Helper {
   }
 
   /**
+   * Grab Locator if called within Context
+   *
+   * @param {*} locator
+   */
+  _contextLocator(locator) {
+    locator = buildLocatorString(new Locator(locator, 'css'));
+
+    if (this.contextLocator) {
+      locator = `${this.contextLocator} ${locator}`;
+    }
+
+    return locator;
+  }
+
+  /**
    * {{> grabTextFrom }}
    *
    */
   async grabTextFrom(locator) {
-    locator = (new Locator(locator, 'css')).value;
-    const page = await this.context || await this._getContext();
-    const text = await page.textContent(locator);
+    locator = this._contextLocator(locator);
+    const text = await this.page.textContent(locator);
     assertElementExists(text, locator);
     this.debugSection('Text', text);
     return text;
@@ -2095,6 +2113,7 @@ class Playwright extends Helper {
 
       if (locator >= 0 && locator < childFrames.length) {
         this.context = childFrames[locator];
+        this.contextLocator = locator;
       } else {
         throw new Error('Element #invalidIframeSelector was not found by text|CSS|XPath');
       }
@@ -2102,6 +2121,7 @@ class Playwright extends Helper {
     }
     if (!locator) {
       this.context = this.page;
+      this.contextLocator = null;
       return;
     }
 
@@ -2112,8 +2132,10 @@ class Playwright extends Helper {
 
     if (contentFrame) {
       this.context = contentFrame;
+      this.contextLocator = null;
     } else {
       this.context = els[0];
+      this.contextLocator = locator;
     }
   }
 
@@ -2507,11 +2529,13 @@ async function targetCreatedHandler(page) {
           // we are inside iframe?
           const frameEl = await this.context.frameElement();
           this.context = await frameEl.contentFrame();
+          this.contextLocator = null;
           return;
         }
         // if context element was in iframe - keep it
         // if (await this.context.ownerFrame()) return;
         this.context = page;
+        this.contextLocator = null;
       });
   });
   page.on('console', (msg) => {

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -1567,10 +1567,10 @@ class Playwright extends Helper {
    *
    */
   async grabTextFrom(locator) {
-    const texts = await this.grabTextFromAll(locator);
-    assertElementExists(texts, locator);
-    this.debugSection('Text', texts[0]);
-    return texts[0];
+    const text = await this.page.textContent(locator);
+    assertElementExists(text, locator);
+    this.debugSection('Text', text);
+    return text;
   }
 
   /**

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -1567,7 +1567,7 @@ class Playwright extends Helper {
    *
    */
   async grabTextFrom(locator) {
-    locator = new Locator(locator, 'css');
+    locator = (new Locator(locator, 'css')).value;
     const text = await this.page.textContent(locator);
     assertElementExists(text, locator);
     this.debugSection('Text', text);

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -1575,7 +1575,8 @@ class Playwright extends Helper {
     locator = buildLocatorString(new Locator(locator, 'css'));
 
     if (this.contextLocator) {
-      locator = `${this.contextLocator} ${locator}`;
+      const contextLocator = buildLocatorString(new Locator(this.contextLocator, 'css'));
+      locator = `${contextLocator} >> ${locator}`;
     }
 
     return locator;

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -38,7 +38,7 @@ const consoleLogStore = new Console();
 const availableBrowsers = ['chromium', 'webkit', 'firefox', 'electron'];
 
 const { createValueEngine, createDisabledEngine } = require('./extras/PlaywrightPropEngine');
-const { pause } = require('..');
+
 /**
  * Uses [Playwright](https://github.com/microsoft/playwright) library to run tests inside:
  *

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -1567,6 +1567,7 @@ class Playwright extends Helper {
    *
    */
   async grabTextFrom(locator) {
+    locator = new Locator(locator, 'css');
     const text = await this.page.textContent(locator);
     assertElementExists(text, locator);
     this.debugSection('Text', text);

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -1568,7 +1568,8 @@ class Playwright extends Helper {
    */
   async grabTextFrom(locator) {
     locator = (new Locator(locator, 'css')).value;
-    const text = await this.page.textContent(locator);
+    const page = await this.context || await this._getContext();
+    const text = await page.textContent(locator);
     assertElementExists(text, locator);
     this.debugSection('Text', text);
     return text;

--- a/test/acceptance/codecept.Playwright.js
+++ b/test/acceptance/codecept.Playwright.js
@@ -8,7 +8,7 @@ module.exports.config = {
   helpers: {
     Playwright: {
       url: TestHelper.siteUrl(),
-      show: false,
+      show: true,
       browser: process.env.BROWSER || 'chromium',
     },
     ScreenshotSessionHelper: {

--- a/test/acceptance/codecept.Playwright.js
+++ b/test/acceptance/codecept.Playwright.js
@@ -8,7 +8,7 @@ module.exports.config = {
   helpers: {
     Playwright: {
       url: TestHelper.siteUrl(),
-      show: true,
+      show: false,
       browser: process.env.BROWSER || 'chromium',
     },
     ScreenshotSessionHelper: {


### PR DESCRIPTION
## Motivation/Description of the PR

- `grabTextFrom` is broken on some elements since it does not call the Playwright's default method but reads the `innerHTML`
- **grabTextFrom** should call the `page.textContent` method of Playwright

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [x] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
