### PR TITLE
Add is shadow locator to playwright

### DIFF
--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -2219,6 +2219,10 @@ function buildLocatorString(locator) {
   } if (locator.isXPath()) {
     // dont rely on heuristics of playwright for figuring out xpath
     return `xpath=${locator.value}`;
+  } if (locator.isShadow()) {
+    // playwright supports specific shadow syntax without commas
+    const els = locator.value.toString();
+    return els.replace(/,/g, ' ');
   }
   return locator.simplify();
 }

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "mocha-parallel-tests": "^2.3.0",
     "nightmare": "^3.0.2",
     "nodemon": "^1.19.4",
-    "playwright": "^1.9.1",
+    "playwright": "^1.10.0",
     "protractor": "^5.4.4",
     "puppeteer": "^8.0.0",
     "qrcode-terminal": "^0.12.0",

--- a/test/data/app/controllers.php
+++ b/test/data/app/controllers.php
@@ -175,6 +175,13 @@ class iframe_nested {
     }
 }
 
+class shadow_dom {
+    public function GET()
+    {
+        include __DIR__.'/view/shadow_dom.php';
+    }
+}
+
 class facebookController {
     function GET($matches) {
         include __DIR__.'/view/facebook.php';

--- a/test/data/app/index.php
+++ b/test/data/app/index.php
@@ -40,6 +40,7 @@ $urls = array(
     '/spinner' => 'spinner',
     '/iframe' => 'iframe',
     '/iframe_nested' => 'iframe_nested',
+    '/shadow_dom' => 'shadow_dom',
     '/dynamic' => 'dynamic',
     '/timeout' => 'timeout',
     '/download' => 'download',

--- a/test/data/app/view/shadow_dom.php
+++ b/test/data/app/view/shadow_dom.php
@@ -1,0 +1,47 @@
+<h1>Simple Shadow DOM</h1>
+
+<script>
+    customElements.define('my-app',
+        class extends HTMLElement {
+            constructor() {
+                super();
+
+                const template = document.getElementById('my-app');
+                const templateContent = template.content;
+
+                this.attachShadow({mode: 'open'}).appendChild(
+                    templateContent.cloneNode(true)
+                );
+            }
+        }
+    );
+
+    const slottedSpan = document.querySelector('my-app span');
+
+</script>
+
+<template id="my-app">
+  <style>
+    p {
+      color: white;
+      background-color: purple;
+      padding: 5px;
+    }
+  </style>
+  <p>
+    <slot name="my-text">My default text</slot>
+  </p>
+</template>
+
+
+<my-app>
+  <span slot="my-text">Let's have different text!</span>
+</my-app>
+
+
+<my-app>
+  <ul slot="my-text">
+    <li>Let's have some different text!</li>
+    <li>In a list!</li>
+  </ul>
+</my-app>

--- a/test/helper/Playwright_test.js
+++ b/test/helper/Playwright_test.js
@@ -272,6 +272,16 @@ describe('Playwright', function () {
       .then(() => I.seeNumberOfElements('#area1', 1)));
   });
 
+  describe('#seeElement shadow element', () => {
+    it('should return ok', () => I.amOnPage('/shadow_dom')
+      .then(() => I.seeElement({ shadow: ['my-app', 'span'] })));
+  });
+
+  describe('#see text in shadow element', () => {
+    it('should return ok', () => I.amOnPage('/shadow_dom')
+      .then(() => I.see("Let's have different text!", { shadow: ['my-app', 'span'] })));
+  });
+
   describe('#switchTo', () => {
     it('should switch reference to iframe content', () => I.amOnPage('/iframe')
       .then(() => I.switchTo('[name="content"]'))

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -53,7 +53,7 @@ declare namespace CodeceptJS {
     | { ios: string }
     | { android: string; ios: string }
     | { react: string }
-    | { shadow: string }
+    | { shadow: string | string[] }
     | { custom: string };
 
   interface CustomLocators {}


### PR DESCRIPTION
## Motivation/Description of the PR
In actual solution is a problem with use shadow elements in tests under Playwright driver, it returns error `page.$$: selector: expected string, got object`. This PR resolves this bug and returns elements to right syntax working with Playwright.

Applicable helpers:
- [x] Playwright

Applicable plugins:
NONE

## Type of change
- [x] :bug: Bug fix

## Checklist:

- [ok] Tests have been added
- [not needed] Documentation has been added (Run `npm run docs`)
- [ok] Lint checking (Run `npm run lint`)
- [ok] Local tests are passed (Run `npm test`)
