### PR TITLE
fix: Second argument of I.say throw misleading error with invalid system color

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -190,7 +190,7 @@ module.exports = {
    * @param {string} [color]
    */
   say(message, color = 'cyan') {
-    if (!colors[color]) {
+    if (colors[color] === undefined) {
       color = 'cyan';
     }
     if (outputLevel >= 1) print(`   ${colors[color].bold(message)}`);

--- a/lib/output.js
+++ b/lib/output.js
@@ -190,6 +190,9 @@ module.exports = {
    * @param {string} [color]
    */
   say(message, color = 'cyan') {
+    if (!colors[color]) {
+      color = 'cyan';
+    }
     if (outputLevel >= 1) print(`   ${colors[color].bold(message)}`);
   },
 

--- a/test/unit/output_test.js
+++ b/test/unit/output_test.js
@@ -53,6 +53,13 @@ describe('Output', () => {
     expect(console.log).to.have.been.calledTwice;
   });
 
+  it('should not throwing error when using non predefined system color for say function', () => {
+    const debugMsg = 'Dear Henrietta';
+
+    output.say(debugMsg, 'orange');
+    expect(console.log).to.have.been.called;
+  });
+
   afterEach(() => {
     console.log.restore();
   });


### PR DESCRIPTION
## Motivation/Description of the PR
- Resolves #2862 

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [x] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
