### PR TITLE
fix: dont call click on invisible elements

### DIFF
--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -2228,6 +2228,19 @@ async function findElements(matcher, locator) {
   return matcher.$$(buildLocatorString(locator));
 }
 
+async function getVisibleElements(elements) {
+  const visibleElements = [];
+  for (const element of elements) {
+    if (await element.isVisible()) {
+      visibleElements.push(element);
+    }
+  }
+  if (visibleElements.length === 0) {
+    throw new Error('No visible element was found');
+  }
+  return visibleElements;
+}
+
 async function proceedClick(locator, context = null, options = {}) {
   let matcher = await this._getContext();
   if (context) {
@@ -2247,7 +2260,8 @@ async function proceedClick(locator, context = null, options = {}) {
   if (options.force) {
     await els[0].dispatchEvent('click');
   } else {
-    await els[0].click(options);
+    const element = els.length > 1 ? (await getVisibleElements(els))[0] : els[0];
+    await element.click(options);
   }
   const promises = [];
   if (options.waitForNavigation) {

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -2236,7 +2236,7 @@ async function getVisibleElements(elements) {
     }
   }
   if (visibleElements.length === 0) {
-    throw new Error('No visible element was found');
+    return elements;
   }
   return visibleElements;
 }

--- a/test/data/app/controllers.php
+++ b/test/data/app/controllers.php
@@ -18,6 +18,15 @@ class info {
 
 }
 
+class invisible_elements {
+    function GET() {
+        if (isset($_SERVER['HTTP_X_REQUESTED_WITH'])) data::set('ajax',array('GET'));
+        data::set('params', $_GET);
+        include __DIR__.'/view/invisible_elements.php';
+    }
+
+}
+
 class redirect {
     function GET() {
         header('Location: /info');

--- a/test/data/app/index.php
+++ b/test/data/app/index.php
@@ -44,7 +44,8 @@ $urls = array(
     '/timeout' => 'timeout',
     '/download' => 'download',
     '/basic_auth' => 'basic_auth',
-    '/image' => 'basic_image'
+    '/image' => 'basic_image',
+    '/invisible_elements' => 'invisible_elements'
 );
 
 glue::stick($urls);

--- a/test/data/app/view/invisible_elements.php
+++ b/test/data/app/view/invisible_elements.php
@@ -1,0 +1,11 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+</head>
+<body>
+    <button style="display:none;">Hello World</button>
+    <button>Hello World</button>
+    <button style="display:none;">Hello World</button>
+</body>
+</html>

--- a/test/helper/Playwright_test.js
+++ b/test/helper/Playwright_test.js
@@ -85,6 +85,13 @@ describe('Playwright', function () {
 
   webApiTests.tests();
 
+  describe('#click', () => {
+    it('should not try to click on invisible elements', async () => {
+      await I.amOnPage('/invisible_elements');
+      await I.click('Hello World');
+    });
+  });
+
   describe('#waitForFunction', () => {
     it('should wait for function returns true', () => {
       return I.amOnPage('/form/wait_js')


### PR DESCRIPTION
## Motivation/Description of the PR
- When calling `I.click('Hello World')` and `Hello World` matches multiple elements in the DOM, the Playwright helper will call `click()` on the ElementHandle of the first element.
- When calling `click()` on an ElementHandle that is not visible, Playwright will wait until the element becomes visible.
- When the element does not become visible in a certain time, Playwright times out and the test will fail.
- This can be problematic if there is an invisible element in the DOM above the element that I'm trying to select and both share the same selector. Eventually this will result in:
```sh
elementHandle.click: Timeout 30000ms exceeded.
=========================== logs ===========================
attempting click action
  waiting for element to be visible, enabled and stable
    element is not visible - waiting...
============================================================
```
- What's super confusing about this (and also the reason why I almost went nuts today) is that the element you're selecting is clearly visible on the screenshot CodeceptJS is taking. Unless you dive into the CodeceptJS code and inspect the DOM, it's not very obvious what's going wrong here.

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [X] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [X] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [X] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [X] Lint checking (Run `npm run lint`)
- [X] Local tests are passed (Run `npm test`)
