### PR TITLE
Fix mocha-multi config example

### DIFF
--- a/docs/reports.md
+++ b/docs/reports.md
@@ -352,10 +352,11 @@ Configure mocha-multi with reports that you want:
         }
       },
       "mochawesome": {
-       "stdout": "./output/console.log",
-       "options": {
-         "reportDir": "./output",
-         "reportFilename": "report"
+        "stdout": "./output/console.log",
+        "options": {
+          "reportDir": "./output",
+          "reportFilename": "report"
+        }
       },
       "mocha-junit-reporter": {
         "stdout": "./output/console.log",


### PR DESCRIPTION
Add missing closing brace and fix indentation.

## Motivation/Description of the PR
The example for configuring mocha-multi can't be directly copied because it's missing a closing brace.

## Type of change

- [x] :clipboard: Documentation changes/updates

## Checklist:

- [not needed] Tests have been added
- [x] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
    - At least, the failures were the same as on the main branch
