### PR TITLE
feat: versioning automatically

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
     "promise-retry": "^1.1.1",
     "requireg": "^0.2.2",
     "resq": "^1.10.0",
-    "semver": "^6.2.0",
     "sprintf-js": "^1.1.1"
   },
   "devDependencies": {
@@ -127,6 +126,7 @@
     "qrcode-terminal": "^0.12.0",
     "rosie": "^1.6.0",
     "runok": "^0.9.2",
+    "semver": "^6.3.0",
     "sinon": "^9.2.2",
     "sinon-chai": "^3.5.0",
     "testcafe": "^1.9.4",

--- a/runok.js
+++ b/runok.js
@@ -390,6 +390,27 @@ title: ${name}
     console.log('-- RELEASED --');
   },
 
+  async versioning() {
+    const semver = require('semver');
+
+    if (fs.existsSync('./package.json')) {
+      const packageFile = require('./package.json');
+      const currentVersion = packageFile.version;
+      let type = process.argv[3];
+      console.log(process.argv);
+      if (!['major', 'minor', 'patch'].includes(type)) {
+        type = 'patch';
+      }
+
+      const newVersion = semver.inc(packageFile.version, type);
+      packageFile.version = newVersion;
+      fs.writeFileSync('./package.json', JSON.stringify(packageFile, null, 2));
+      console.log('Version updated', currentVersion, '=>', newVersion);
+
+      console.log('Creating and switching to release branch...');
+      await exec(`git checkout -b release-${newVersion}`);
+    }
+  },
 };
 
 async function processChangelog() {

--- a/runok.js
+++ b/runok.js
@@ -397,7 +397,6 @@ title: ${name}
       const packageFile = require('./package.json');
       const currentVersion = packageFile.version;
       let type = process.argv[3];
-      console.log(process.argv);
       if (!['major', 'minor', 'patch'].includes(type)) {
         type = 'patch';
       }


### PR DESCRIPTION
## Motivation/Description of the PR
- Introduce the versioning automatically, it follows the semantics versioning. If no arg is passed, it's a patch version, otherwise we could pass `major`, `minor`, `patch`.

```
thanh@Thanhs-MacBook-Pro CodeceptJS % ./runok.js versioning
Version updated 3.0.8 => 3.0.9
Creating and switching to release branch...
[#1 EXEC] › ℹ  git checkout -b release-3.0.9
M       package.json
M       runok.js
[#1 EXEC] › ✔  Finished  in 38 ms

```