### PR TITLE
Adding support for attaching screenshots to cucumberJsonReporter

### DIFF
--- a/lib/plugin/screenshotOnFail.js
+++ b/lib/plugin/screenshotOnFail.js
@@ -107,6 +107,11 @@ module.exports = function (config) {
         if (allureReporter) {
           allureReporter.addAttachment('Last Seen Screenshot', fs.readFileSync(path.join(global.output_dir, fileName)), 'image/png');
         }
+
+        const cucumberReporter = Container.plugins('cucumberJsonReporter')
+        if(cucumberReporter){
+          cucumberReporter.addScreenshot(test,test.artifacts.screenshot)
+        }
       } catch (err) {
         output.plugin(err);
         if (

--- a/lib/plugin/screenshotOnFail.js
+++ b/lib/plugin/screenshotOnFail.js
@@ -110,7 +110,7 @@ module.exports = function (config) {
 
         const cucumberReporter = Container.plugins('cucumberJsonReporter')
         if(cucumberReporter){
-          cucumberReporter.addScreenshot(test,test.artifacts.screenshot)
+          cucumberReporter.addScreenshot(test.artifacts.screenshot)
         }
       } catch (err) {
         output.plugin(err);


### PR DESCRIPTION
## Motivation/Description of the PR
This PR is the partner to a [PR](https://github.com/ktryniszewski-mdsol/codeceptjs-cucumber-json-reporter/pull/2) in `codecept-cucumber-json-reporter` which will enable embedding of screenshots in Cucumber JSON when it has been specified as a plugin

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [x] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [x] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
