### PR TITLE
fix: rest helper steps are ignored

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -604,12 +604,15 @@ Run tests with plugin enabled:
 -   `defaultIgnoredSteps` - an array of steps to be ignored for retry. Includes:
     -   `amOnPage`
     -   `wait*`
+    -   `send*`,
     -   `execute*`
     -   `run*`
     -   `have*`
 -   `ignoredSteps` - an array for custom steps to ignore on retry. Use it to append custom steps to ignored list.
     You can use step names or step prefixes ending with `*`. As such, `wait*` will match all steps starting with `wait`.
     To append your own steps to ignore list - copy and paste a default steps list. Regexp values are accepted as well.
+-   `removeDefaultIgnoreSteps` - an array to remove the step in the defaultIgnoredSteps list.
+    You can use step names or step prefixes ending with `*`. As such, `wait*` will match all steps starting with `wait`.
 
 #### Example
 
@@ -620,6 +623,9 @@ plugins: {
         ignoreSteps: [
           'scroll*', // ignore all scroll steps
           /Cookie/, // ignore all steps with a Cookie in it (by regexp)
+        ],
+        removeDefaultIgnoreSteps: [
+        'send*', // remove the send* steps in the defaultIgnoredSteps list
         ]
     }
 }

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -604,7 +604,6 @@ Run tests with plugin enabled:
 -   `defaultIgnoredSteps` - an array of steps to be ignored for retry. Includes:
     -   `amOnPage`
     -   `wait*`
-    -   `send*`
     -   `execute*`
     -   `run*`
     -   `have*`

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -604,7 +604,7 @@ Run tests with plugin enabled:
 -   `defaultIgnoredSteps` - an array of steps to be ignored for retry. Includes:
     -   `amOnPage`
     -   `wait*`
-    -   `send*`,
+    -   `send*`
     -   `execute*`
     -   `run*`
     -   `have*`

--- a/lib/plugin/retryFailedStep.js
+++ b/lib/plugin/retryFailedStep.js
@@ -6,11 +6,13 @@ const defaultConfig = {
   defaultIgnoredSteps: [
     'amOnPage',
     'wait*',
+    'send*',
     'execute*',
     'run*',
     'have*',
   ],
   ignoredSteps: [],
+  removeDefaultIgnoreSteps: [],
 };
 
 /**
@@ -44,12 +46,15 @@ const defaultConfig = {
  * * `defaultIgnoredSteps` - an array of steps to be ignored for retry. Includes:
  *     * `amOnPage`
  *     * `wait*`
+ *     * `send*`,
  *     * `execute*`
  *     * `run*`
  *     * `have*`
  * * `ignoredSteps` - an array for custom steps to ignore on retry. Use it to append custom steps to ignored list.
  * You can use step names or step prefixes ending with `*`. As such, `wait*` will match all steps starting with `wait`.
  * To append your own steps to ignore list - copy and paste a default steps list. Regexp values are accepted as well.
+ * * `removeDefaultIgnoreSteps` - an array to remove the step in the defaultIgnoredSteps list.
+ * You can use step names or step prefixes ending with `*`. As such, `wait*` will match all steps starting with `wait`.
  *
  * #### Example
  *
@@ -60,6 +65,9 @@ const defaultConfig = {
  *         ignoreSteps: [
  *           'scroll*', // ignore all scroll steps
  *           /Cookie/, // ignore all steps with a Cookie in it (by regexp)
+ *         ],
+ *         removeDefaultIgnoreSteps: [
+ *         'send*', // remove the send* steps in the defaultIgnoredSteps list
  *         ]
  *     }
  * }
@@ -80,6 +88,15 @@ const defaultConfig = {
  */
 module.exports = (config) => {
   config = Object.assign(defaultConfig, config);
+
+  if (config.removeDefaultIgnoreSteps.length > 0) {
+    config.removeDefaultIgnoreSteps.forEach(item => {
+      config.defaultIgnoredSteps = config.defaultIgnoredSteps.filter((step) => {
+        return item !== step;
+      });
+    });
+  }
+
   config.ignoredSteps = config.ignoredSteps.concat(config.defaultIgnoredSteps);
   const customWhen = config.when;
 

--- a/lib/plugin/retryFailedStep.js
+++ b/lib/plugin/retryFailedStep.js
@@ -6,7 +6,6 @@ const defaultConfig = {
   defaultIgnoredSteps: [
     'amOnPage',
     'wait*',
-    'send*',
     'execute*',
     'run*',
     'have*',
@@ -45,7 +44,6 @@ const defaultConfig = {
  * * `defaultIgnoredSteps` - an array of steps to be ignored for retry. Includes:
  *     * `amOnPage`
  *     * `wait*`
- *     * `send*`
  *     * `execute*`
  *     * `run*`
  *     * `have*`

--- a/lib/plugin/retryFailedStep.js
+++ b/lib/plugin/retryFailedStep.js
@@ -46,7 +46,7 @@ const defaultConfig = {
  * * `defaultIgnoredSteps` - an array of steps to be ignored for retry. Includes:
  *     * `amOnPage`
  *     * `wait*`
- *     * `send*`,
+ *     * `send*`
  *     * `execute*`
  *     * `run*`
  *     * `have*`


### PR DESCRIPTION
## Motivation/Description of the PR
- Currently, the `send*` steps of REST helper is added as defaultIgnoredSteps, that prevents users from using this plugin with REST helper. This PR adds the possibility to alter the `defaultIgnoredSteps` list.

Applicable helpers:

- [x] REST

Applicable plugins:

- [x] retryFailedStep

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [x] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
