### PR TITLE
Fix missing run-multiple gherkin features when using chunks

### DIFF
--- a/lib/command/run-multiple/collection.js
+++ b/lib/command/run-multiple/collection.js
@@ -80,6 +80,10 @@ class Collection {
         return;
       }
 
+      if (runConfig.gherkin && config.gherkin.features) {
+        patterns.push(runConfig.gherkin.features);
+      }
+
       createChunks(runConfig, patterns).forEach((runChunkConfig, index) => {
         const run = createRun(`${runName}:chunk${index + 1}`, runChunkConfig);
         run.setOriginalName(runName);


### PR DESCRIPTION
## Motivation/Description of the PR
When using `run-multiple` with a custom defined path to the features files, if you enable chunks, custom path is ignored.

This happens because when calling `createChunks` at `prepareChunks`, it only tests the paths against previously added to the pattern array, see [collection.js:87](https://github.com/codeceptjs/CodeceptJS/blob/9c3aeb894d843c93a385f89fb74a012be1e5f050/lib/command/run-multiple/collection.js#L87) and [chunk.js:65](https://github.com/codeceptjs/CodeceptJS/blob/9c3aeb894d843c93a385f89fb74a012be1e5f050/lib/command/run-multiple/chunk.js#L65).  As a next step it removes the run configuration and only the configuration created by the chunks remains.

When `chunks` property is omitted it works because it doesn't remove the run config, see [collection.js:80](https://github.com/codeceptjs/CodeceptJS/blob/9c3aeb894d843c93a385f89fb74a012be1e5f050/lib/command/run-multiple/collection.js#L80).

Sample config:

```
{
  gherkin: {
    features: 'path/to/common/folder'
  },
  ...,
  multiple: {
    desktop: {
      gherkin: {
        // This path is not ignored and its run config is not removed
        features: 'path/to/desktop/folder'
      }
    },
    mobile: {
      chunks: 2
      gherkin: {
        // This path is ignore due to the presence of chunks property
        features: 'path/to/mobile/folder'
      }
    }
  }
}
```

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
