### PR TITLE
[Fix] Plugin documentaion

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -311,7 +311,7 @@ Scenario('login', async ( {I, login} ) => {
 Add descriptive nested steps for your tests:
 
 ```js
-Scenario('project update test', async (I) => {
+Scenario('project update test', async ({ I }) => {
   __`Given`;
   const projectId = await I.have('project');
 
@@ -388,7 +388,7 @@ const Given = () => step`Given`;
 const When = () => step`When`;
 const Then = () => step`Then`;
 
-Scenario('project update test', async (I) => {
+Scenario('project update test', async ({ I }) => {
   Given();
   const projectId = await I.have('project');
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -127,7 +127,7 @@ If a session expires automatically logs in again.
 ```js
 // inside a test file
 // use login to inject auto-login function
-Before(login => {
+Before({ login } => {
    login('user'); // login using user session
 });
 
@@ -387,7 +387,6 @@ const step = codeceptjs.container.plugins('commentStep');
 const Given = () => step`Given`;
 const When = () => step`When`;
 const Then = () => step`Then`;
-```
 
 Scenario('project update test', async (I) => {
   Given();
@@ -400,9 +399,6 @@ Scenario('project update test', async (I) => {
   projectPage.open(projectId);
   I.see('new title', 'h1');
 });
-
-```
-
 ```
 
 ### Parameters


### PR DESCRIPTION
- Fix autoLogin example: autoLogin > Usage
- Fix broken markdown code block in commentStep part

In the commentStep part of the plugin, I found that the last code block was broken.

## Motivation/Description of the PR
- Description of this PR, which problem it solves
- Resolves #issueId (if applicable).

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [x] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
