### PR TITLE
Add React Locator Support to Playwright

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -29,7 +29,7 @@ Depending on a type of a change you should do the following.
 
 ## Helpers
 
-Please keep in mind that CodeceptJS have **unified API** for WebDriverIO, Appium, Protractor, Nightmare, Puppeteer, TestCafe. Tests written using those helpers should be compatible at syntax level. However, some of helpers may contain unique methods. That happens. If, for instance, WebDriverIO has method XXX and Nightmare doesn't, you can implement XXX inside Nightmare using the same method signature.
+Please keep in mind that CodeceptJS have **unified API** for Playwright, WebDriverIO, Appium, Protractor, Nightmare, Puppeteer, TestCafe. Tests written using those helpers should be compatible at syntax level. However, some of helpers may contain unique methods. That happens. If, for instance, WebDriverIO has method XXX and Nightmare doesn't, you can implement XXX inside Nightmare using the same method signature.
 
 ### Updating a WebDriver | Nightmare
 

--- a/docs/react.md
+++ b/docs/react.md
@@ -55,7 +55,7 @@ For React apps a special `react` locator is available. It allows to select an el
 { react: 'Input', state: 'valid'}
 ```
 
-In WebDriver and Puppeteer you can use React locators in any method where locator is required:
+In WebDriver, Puppeteer, and Playwright you can use React locators in any method where locator is required:
 
 ```js
 I.click({ react: 'Tab', props: { title: 'Click Me!' }});

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -28,6 +28,7 @@ const ElementNotFound = require('./errors/ElementNotFound');
 const RemoteBrowserConnectionRefused = require('./errors/RemoteBrowserConnectionRefused');
 const Popup = require('./extras/Popup');
 const Console = require('./extras/Console');
+const findReact = require('./extras/React');
 
 let playwright;
 let perfTiming;
@@ -2249,6 +2250,7 @@ function buildLocatorString(locator) {
 }
 
 async function findElements(matcher, locator) {
+  if (locator.react) return findReact(matcher, locator);
   locator = new Locator(locator, 'css');
   return matcher.$$(buildLocatorString(locator));
 }
@@ -2297,6 +2299,8 @@ async function proceedClick(locator, context = null, options = {}) {
 }
 
 async function findClickable(matcher, locator) {
+  if (locator.react) return findReact(matcher, locator);
+
   locator = new Locator(locator);
   if (!locator.isFuzzy()) return findElements.call(this, matcher, locator);
 

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -2264,7 +2264,7 @@ class Puppeteer extends Helper {
 module.exports = Puppeteer;
 
 async function findElements(matcher, locator) {
-  if (locator.react) return findReact(matcher, locator);
+  if (locator.react) return findReact(matcher.executionContext(), locator);
   locator = new Locator(locator, 'css');
   if (!locator.isXPath()) return matcher.$$(locator.simplify());
   return matcher.$x(locator.value);
@@ -2293,7 +2293,7 @@ async function proceedClick(locator, context = null, options = {}) {
 }
 
 async function findClickable(matcher, locator) {
-  if (locator.react) return findReact(matcher, locator);
+  if (locator.react) return findReact(matcher.executionContext(), locator);
   locator = new Locator(locator);
   if (!locator.isFuzzy()) return findElements.call(this, matcher, locator);
 

--- a/lib/helper/extras/React.js
+++ b/lib/helper/extras/React.js
@@ -4,50 +4,62 @@ let resqScript;
 
 module.exports = async function findReact(matcher, locator) {
   if (!resqScript) resqScript = fs.readFileSync(require.resolve('resq'));
-  await matcher.executionContext().evaluate(resqScript.toString());
-  await matcher.executionContext().evaluate(() => window.resq.waitToLoadReact());
-  const arrayHandle = await matcher.executionContext().evaluateHandle((selector, props, state) => {
-    let elements = window.resq.resq$$(selector);
-    if (Object.keys(props).length) {
-      elements = elements.byProps(props);
-    }
-    if (Object.keys(state).length) {
-      elements = elements.byState(state);
-    }
+  await matcher.evaluate(resqScript.toString());
+  await matcher
+    .evaluate(() => window.resq.waitToLoadReact());
+  const arrayHandle = await matcher.evaluateHandle(
+    (obj) => {
+      const { selector, props, state } = obj;
 
-    if (!elements.length) {
-      return [];
-    }
-
-    // resq returns an array of HTMLElements if the React component is a fragment
-    // this avoids having nested arrays of nodes which the driver does not understand
-    // [[div, div], [div, div]] => [div, div, div, div]
-    let nodes = [];
-
-    elements.forEach((element) => {
-      let { node, isFragment } = element;
-
-      if (!node) {
-        isFragment = true;
-        node = element.children;
+      let elements = window.resq.resq$$(selector);
+      if (Object.keys(props).length) {
+        elements = elements.byProps(props);
+      }
+      if (Object.keys(state).length) {
+        elements = elements.byState(state);
       }
 
-      if (isFragment) {
-        nodes = nodes.concat(node);
-      } else {
-        nodes.push(node);
+      if (!elements.length) {
+        return [];
       }
-    });
 
-    return [...nodes];
-  }, locator.react, locator.props || {}, locator.state || {}, locator.children || {}, matcher);
+      // resq returns an array of HTMLElements if the React component is a fragment
+      // this avoids having nested arrays of nodes which the driver does not understand
+      // [[div, div], [div, div]] => [div, div, div, div]
+      let nodes = [];
+
+      elements.forEach((element) => {
+        let { node, isFragment } = element;
+
+        if (!node) {
+          isFragment = true;
+          node = element.children;
+        }
+
+        if (isFragment) {
+          nodes = nodes.concat(node);
+        } else {
+          nodes.push(node);
+        }
+      });
+
+      return [...nodes];
+    },
+    {
+      selector: locator.react,
+      props: locator.props || {},
+      state: locator.state || {},
+    },
+  );
 
   const properties = await arrayHandle.getProperties();
   await arrayHandle.dispose();
   const result = [];
   for (const property of properties.values()) {
     const elementHandle = property.asElement();
-    if (elementHandle) { result.push(elementHandle); }
+    if (elementHandle) {
+      result.push(elementHandle);
+    }
   }
 
   return result;

--- a/test/acceptance/react_test.js
+++ b/test/acceptance/react_test.js
@@ -1,6 +1,6 @@
 Feature('React Selectors');
 
-Scenario('props @WebDriver @Puppeteer', ({ I }) => {
+Scenario('props @WebDriver @Puppeteer @Playwright', ({ I }) => {
   I.amOnPage('https://ahfarmer.github.io/calculator/');
   I.click('7');
   I.seeElement({ react: 't', props: { name: '5' } });
@@ -11,7 +11,7 @@ Scenario('props @WebDriver @Puppeteer', ({ I }) => {
   I.seeElement({ react: 't', props: { value: '81' } });
 });
 
-Scenario('component name @Puppeteer', ({ I }) => {
+Scenario('component name @Puppeteer @Playwright', ({ I }) => {
   I.amOnPage('http://negomi.github.io/react-burger-menu/');
   I.click({ react: 'BurgerIcon' });
   I.waitForVisible('#slide', 10);


### PR DESCRIPTION
## Motivation/Description of the PR
- Add react locator support to Playwright. Help keeps the API more uniform.
- Resolves #2696
- Also added Playwright to the Contribution doc.

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ X] Playwright
## Type of change

- [ ] :fire: Breaking changes
- [X ] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [X ] Tests have been added
- [X ] Documentation has been added (Run `npm run docs`)
- [X ] Lint checking (Run `npm run lint`)
- [ X] Local tests are passed (Run `npm test`)
