### PR TITLE
Fix: Hidden inputs are considered by fillField

### DIFF
--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -1239,7 +1239,7 @@ class Puppeteer extends Helper {
    * {{ react }}
    */
   async fillField(field, value) {
-    const els = await findFields.call(this, field);
+    const els = await findVisibleFields.call(this, field);
     assertElementExists(els, field, 'Field');
     const el = els[0];
     const tag = await el.getProperty('tagName').then(el => el.jsonValue());
@@ -1266,7 +1266,7 @@ class Puppeteer extends Helper {
    * {{ react }}
    */
   async appendField(field, value) {
-    const els = await findFields.call(this, field);
+    const els = await findVisibleFields.call(this, field);
     assertElementExists(els, field, 'Field');
     await els[0].press('End');
     await els[0].type(value, { delay: this.options.pressKeyDelay });
@@ -1308,7 +1308,7 @@ class Puppeteer extends Helper {
    * {{> selectOption }}
    */
   async selectOption(select, option) {
-    const els = await findFields.call(this, select);
+    const els = await findVisibleFields.call(this, select);
     assertElementExists(els, select, 'Selectable field');
     const el = els[0];
     if (await el.getProperty('tagName').then(t => t.jsonValue()) !== 'SELECT') {
@@ -2376,6 +2376,12 @@ async function proceedIsChecked(assertType, option) {
   return truth(`checkable ${option}`, 'to be checked')[assertType](selected);
 }
 
+async function findVisibleFields(locator) {
+  const els = await findFields.call(this, locator);
+  const visible = await Promise.all(els.map(el => el.boundingBox()));
+  return els.filter((el, index) => visible[index]);
+}
+
 async function findFields(locator) {
   const matchedLocator = new Locator(locator);
   if (!matchedLocator.isFuzzy()) {
@@ -2422,7 +2428,7 @@ async function proceedDragAndDrop(sourceLocator, destinationLocator) {
 }
 
 async function proceedSeeInField(assertType, field, value) {
-  const els = await findFields.call(this, field);
+  const els = await findVisibleFields.call(this, field);
   assertElementExists(els, field, 'Field');
   const el = els[0];
   const tag = await el.getProperty('tagName').then(el => el.jsonValue());

--- a/test/helper/webapi.js
+++ b/test/helper/webapi.js
@@ -546,6 +546,12 @@ module.exports.tests = function () {
       await I.click('Submit');
       assert.equal(formContents('name'), 'OLD_VALUE_AND_NEW');
     });
+
+    it('should not fill invisible fields', async () => {
+      if (isHelper('Playwright')) return; // It won't be implemented
+      await I.amOnPage('/form/field');
+      await assert.rejects(I.fillField('email', 'test@1234'));
+    });
   });
 
   describe('#clearField', () => {


### PR DESCRIPTION
## Motivation/Description of the PR
Hidden inputs are considered by fillField, but only visible and focusable inputs and text areas should get filled. I assumed that this also is valid for appendField, selectOption and proceedSeeInField.
- Add function 'findVisibleFields' to get only visible fields
- Replace function 'findFields' through 'findVisibleFields' for the following actions: 'fillField', 'appendField', 'selectOption' and 'proceedSeeInField'


Applicable helpers:

- [ ] WebDriver
- [X] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [X] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [X] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
(no changes by my commit)
- [X] Lint checking (Run `npm run lint`)
- [X] Local tests are passed (Run `npm test`)
