### PR TITLE
Fix TravisCI failure on docker pull limit, fixes #2932

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ addons:
 services:
 - docker
 before_install:
-- docker pull selenium/standalone-chrome:3.141.59-oxygen
+- echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin && docker pull selenium/standalone-chrome:3.141.59-oxygen
 before_script:
 - docker run -d --net=host --shm-size=2g selenium/standalone-chrome:3.141.59-oxygen
 - export DBUS_SESSION_BUS_ADDRESS=/dev/null


### PR DESCRIPTION
Travis CI setup instructions are in the comments for https://github.com/nikocanvacom/CodeceptJS/pull/3

PR adds following TravisCI build environment variables: 
- DOCKER_PASSWORD
- DOCKER_USERNAME

**They would NEED TO BE SETUP in CodeceptJS TravisCI build configuration.**

## Motivation/Description of the PR
- Description of this PR, which problem it solves
- Resolves #issueId (if applicable).

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
