### PR TITLE
Content of Before/After/All hooks will be logged in Allure report now

### DIFF
--- a/lib/plugin/allure.js
+++ b/lib/plugin/allure.js
@@ -83,7 +83,6 @@ module.exports = (config) => {
 
   let currentMetaStep = [];
   let currentStep;
-  let isHookSteps = false;
 
   reporter.pendingCase = function (testName, timestamp, opts = {}) {
     reporter.startCase(testName, timestamp);
@@ -191,14 +190,6 @@ module.exports = (config) => {
     }
   });
 
-  event.dispatcher.on(event.hook.started, () => {
-    isHookSteps = true;
-  });
-
-  event.dispatcher.on(event.hook.passed, () => {
-    isHookSteps = false;
-  });
-
   event.dispatcher.on(event.suite.after, () => {
     reporter.endSuite();
   });
@@ -258,15 +249,13 @@ module.exports = (config) => {
   });
 
   event.dispatcher.on(event.step.started, (step) => {
-    if (isHookSteps === false) {
-      startMetaStep(step.metaStep);
-      if (currentStep !== step) {
-        // In multi-session scenarios, actors' names will be highlighted with ANSI
-        // escape sequences which are invalid XML values
-        step.actor = step.actor.replace(ansiRegExp(), '');
-        reporter.startStep(step.toString());
-        currentStep = step;
-      }
+    startMetaStep(step.metaStep);
+    if (currentStep !== step) {
+      // In multi-session scenarios, actors' names will be highlighted with ANSI
+      // escape sequences which are invalid XML values
+      step.actor = step.actor.replace(ansiRegExp(), '');
+      reporter.startStep(step.toString());
+      currentStep = step;
     }
   });
 


### PR DESCRIPTION
## Motivation/Description of the PR
- All actions put in Before/All and After/All will be logged in Allure reports
- Resolves https://github.com/codeceptjs/CodeceptJS/issues/2689


Applicable plugins:

- [x] allure

## Type of change

- [x] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
