### PR TITLE
Issue 2937 fix

### DIFF
--- a/lib/command/definitions.js
+++ b/lib/command/definitions.js
@@ -194,7 +194,14 @@ function getPath(originalPath, targetFolderPath, testsPath) {
   else if (parsedPath.ext === '.ts') parsedPath.base = parsedPath.name;
 
   if (!parsedPath.dir.startsWith('.')) return path.posix.join(parsedPath.dir, parsedPath.base);
-  const relativePath = path.posix.relative(targetFolderPath, path.posix.join(testsPath, parsedPath.dir, parsedPath.base));
+  const relativePath = path.posix.relative(
+    targetFolderPath.split(path.sep).join(path.posix.sep),
+    path.posix.join(
+      testsPath.split(path.sep).join(path.posix.sep),
+      parsedPath.dir.split(path.sep).join(path.posix.sep),
+      parsedPath.base.split(path.sep).join(path.posix.sep),
+    ),
+  );
 
   return relativePath.startsWith('.') ? relativePath : `./${relativePath}`;
 }

--- a/lib/plugin/allure.js
+++ b/lib/plugin/allure.js
@@ -83,7 +83,6 @@ module.exports = (config) => {
 
   let currentMetaStep = [];
   let currentStep;
-  let isHookSteps = false;
 
   reporter.pendingCase = function (testName, timestamp, opts = {}) {
     reporter.startCase(testName, timestamp);
@@ -191,14 +190,6 @@ module.exports = (config) => {
     }
   });
 
-  event.dispatcher.on(event.hook.started, () => {
-    isHookSteps = true;
-  });
-
-  event.dispatcher.on(event.hook.passed, () => {
-    isHookSteps = false;
-  });
-
   event.dispatcher.on(event.suite.after, () => {
     reporter.endSuite();
   });
@@ -258,15 +249,13 @@ module.exports = (config) => {
   });
 
   event.dispatcher.on(event.step.started, (step) => {
-    if (isHookSteps === false) {
-      startMetaStep(step.metaStep);
-      if (currentStep !== step) {
-        // In multi-session scenarios, actors' names will be highlighted with ANSI
-        // escape sequences which are invalid XML values
-        step.actor = step.actor.replace(ansiRegExp(), '');
-        reporter.startStep(step.toString());
-        currentStep = step;
-      }
+    startMetaStep(step.metaStep);
+    if (currentStep !== step) {
+      // In multi-session scenarios, actors' names will be highlighted with ANSI
+      // escape sequences which are invalid XML values
+      step.actor = step.actor.replace(ansiRegExp(), '');
+      reporter.startStep(step.toString());
+      currentStep = step;
     }
   });
 


### PR DESCRIPTION
## Motivation/Description of the PR
- Description of this PR, which problem it solves

  Fixes broken paths in the typings file, if it located in sub-folders of a project, generated by the command
```bash
npx codeceptjs def -o folder/sub-folder
```
on Windows

- Resolves #2937

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
