### PR TITLE
Fixed issue where cucumberJsonReporter not working with fakerTransform plugin 

### DIFF
--- a/lib/interfaces/gherkin.js
+++ b/lib/interfaces/gherkin.js
@@ -83,6 +83,7 @@ module.exports = (text) => {
           for (const index in example.cells) {
             const placeholder = fields[index];
             const value = transform('gherkin.examples', example.cells[index].value);
+            example.cells[index].value = value;
             current[placeholder] = value;
             exampleSteps = exampleSteps.map((step) => {
               step = { ...step };


### PR DESCRIPTION
## Motivation/Description of the PR

This PR fixes issue where  cucumberJsonReporter plugin fails to generate report when `Scenario Outline` uses fakerTransform plugin .

The root cause is that `fakerTransform` transform function updates all the steps and suite object but the underlying gherkin feature still has `Examples` with the faker mustache strings. 

Replacing those cells with faker transformed value resolves the issue.

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
