### PR TITLE
Popup initialisation should not use truthy value

### DIFF
--- a/lib/helper/extras/Popup.js
+++ b/lib/helper/extras/Popup.js
@@ -3,7 +3,7 @@
  */
 class Popup {
   constructor(popup, defaultAction) {
-    this._popup = popup || {};
+    this._popup = popup || null;
     this._actionType = '';
     this._defaultAction = defaultAction || '';
   }


### PR DESCRIPTION
Fixing popup property initialisation not to use truthy value which was incorrectly indicating presence of popup alert on each page by default

## Motivation/Description of the PR
- `{}` was used as empty value for initialisation of internal popup object but it wasn't correct as the places where that property was used were clearly expecting default not to be truthy:  
```
Popup.js

  constructor(popup, defaultAction) {
    this._popup = popup || {};
    this._actionType = '';
    this._defaultAction = defaultAction || '';
  }

  set popup(popup) {
    if (this._popup) {
      console.error('Popup already exists and was not closed. Popups must always be closed by calling either I.acceptPopup() or I.cancelPopup()');
    }
    this._popup = popup;
  }

  clear() {
    this._popup = null;
    this._actionType = '';
  }

  assertPopupVisible() {
    if (!this._popup) {
      throw new Error('There is no Popup visible');
    }
  }

  get popup() {
    return this._popup;
  }

Playwright.js
  
  /**
   * Grab the text within the popup. If no popup is visible then it will return null
   *
   * ```js
   * await I.grabPopupText();
   * ```
   * @return {Promise<string | null>}
   */
  async grabPopupText() {
    if (popupStore.popup) {
      return popupStore.popup.message();
    }
    return null;
  }
  
```
- Resolves #issueId unnecessary error logging and incorrect results on some popup operations (see snippet above).

Applicable helpers:

- [ ] WebDriver
- [X] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [X] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [X] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [X] Local tests are passed (Run `npm test`)
