### PR TITLE
Reset of playwright dialog event listener before registration of new one

### DIFF
--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -533,6 +533,7 @@ class Playwright extends Helper {
     if (!page) {
       return;
     }
+    page.removeAllListeners('dialog');
     page.on('dialog', async (dialog) => {
       popupStore.popup = dialog;
       const action = popupStore.actionType || this.options.defaultPopupAction;


### PR DESCRIPTION
## Motivation/Description of the PR
- Playwright Alert popup handling code register multiple event listeners when multiple scenarios executed in one browser which causes error situation and error logging to console when an alert appear on the page.
- Resolves #2945.

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [X] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [X] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [X] Local tests are passed (Run `npm test`)
