### PR TITLE
Fix issue #2244 _clickablePoint() is not a function

### DIFF
--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -670,7 +670,7 @@ class Puppeteer extends Helper {
     assertElementExists(els);
 
     // Use manual mouse.move instead of .hover() so the offset can be added to the coordinates
-    const { x, y } = await els[0]._clickablePoint();
+    const { x, y } = await els[0].clickablePoint();
     await this.page.mouse.move(x + offsetX, y + offsetY);
     return this._waitForAction();
   }
@@ -726,7 +726,7 @@ class Puppeteer extends Helper {
       const els = await this._locate(locator);
       assertElementExists(els, locator, 'Element');
       await els[0]._scrollIntoViewIfNeeded();
-      const elementCoordinates = await els[0]._clickablePoint();
+      const elementCoordinates = await els[0].clickablePoint();
       await this.executeScript((x, y) => window.scrollBy(x, y), elementCoordinates.x + offsetX, elementCoordinates.y + offsetY);
     } else {
       await this.executeScript((x, y) => window.scrollTo(x, y), offsetX, offsetY);
@@ -1727,8 +1727,8 @@ class Puppeteer extends Helper {
     const src = await this._locate(locator);
     assertElementExists(src, locator, 'Slider Element');
 
-    // Note: Using private api ._clickablePoint because the .BoundingBox does not take into account iframe offsets!
-    const sliderSource = await src[0]._clickablePoint();
+    // Note: Using public api .clickablePoint because the .BoundingBox does not take into account iframe offsets!
+    const sliderSource = await src[0].clickablePoint();
 
     // Drag start point
     await this.page.mouse.move(sliderSource.x, sliderSource.y, { steps: 5 });
@@ -2406,9 +2406,9 @@ async function proceedDragAndDrop(sourceLocator, destinationLocator) {
   const dst = await this._locate(destinationLocator);
   assertElementExists(dst, destinationLocator, 'Destination Element');
 
-  // Note: Using private api ._clickablePoint becaues the .BoundingBox does not take into account iframe offsets!
-  const dragSource = await src[0]._clickablePoint();
-  const dragDestination = await dst[0]._clickablePoint();
+  // Note: Using public api .clickablePoint becaues the .BoundingBox does not take into account iframe offsets!
+  const dragSource = await src[0].clickablePoint();
+  const dragDestination = await dst[0].clickablePoint();
 
   // Drag start point
   await this.page.mouse.move(dragSource.x, dragSource.y, { steps: 5 });

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "nodemon": "^1.19.4",
     "playwright": "^1.9.1",
     "protractor": "^5.4.4",
-    "puppeteer": "^8.0.0",
+    "puppeteer": "^10.1.0",
     "qrcode-terminal": "^0.12.0",
     "rosie": "^1.6.0",
     "runok": "^0.9.2",


### PR DESCRIPTION
## Motivation/Description of the PR
This PR will fix the issues when using `scrollTo()`, `moveCursorTo()`, `dragSlider()`, or `proceedDragAndDrop()` function. This function will causes test fail, because of defined problem in issue #2244 . 

The problem is occured on latest version of puppeteer (10.0.0+). Due to some of method changes, especially on `_clickablePoint()`. Which this function is public right now (changed to `clickablePoint()` ) . This is the link of documentation: [ElementHandle.clickablePoint](https://github.com/puppeteer/puppeteer/blob/main/docs/api.md#elementhandleclickablepoint).

Glad to see if this PR is merged. Thanks! 

- Resolves #2244 

Applicable helpers:

- [ ] WebDriver
- [x] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
