### PR TITLE
Do not truncate log output on verbose level

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -235,8 +235,8 @@ function print(...msg) {
 }
 
 function truncate(msg, gap = 0) {
-  if (msg.indexOf('\n') > 0) {
-    return msg; // don't cut multi line steps
+  if (msg.indexOf('\n') > 0 || outputLevel >= 3) {
+    return msg; // don't cut multi line steps or on verbose log level
   }
   const width = (process.stdout.columns || 200) - gap - 4;
   if (msg.length > width) {


### PR DESCRIPTION
## Motivation/Description of the PR
- xpath selectors and other test data output on verbose level might be longer than 200 characters. As a test automation developer I want to see full strings in verbose log so I could use them while debugging or investigating the issues.  
- Resolves #issueId (if applicable).

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [x] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
