### PR TITLE
Add return type for REST helpers

### DIFF
--- a/docs/helpers/REST.md
+++ b/docs/helpers/REST.md
@@ -61,6 +61,8 @@ Executes axios request
 
 -   `request` **any** 
 
+Returns **[Promise][2]&lt;any>** response
+
 ### _url
 
 Generates url based on format sent (takes endpoint + url if latter lacks 'http')
@@ -80,7 +82,9 @@ I.sendDeleteRequest('/api/users/1');
 #### Parameters
 
 -   `url` **any** 
--   `headers` **[object][2]** the headers object to be sent. By default it is sent as an empty object 
+-   `headers` **[object][3]** the headers object to be sent. By default it is sent as an empty object 
+
+Returns **[Promise][2]&lt;any>** response
 
 ### sendGetRequest
 
@@ -93,7 +97,9 @@ I.sendGetRequest('/api/users.json');
 #### Parameters
 
 -   `url` **any** 
--   `headers` **[object][2]** the headers object to be sent. By default it is sent as an empty object 
+-   `headers` **[object][3]** the headers object to be sent. By default it is sent as an empty object 
+
+Returns **[Promise][2]&lt;any>** response
 
 ### sendPatchRequest
 
@@ -108,9 +114,11 @@ I.sendPatchRequest('/api/users.json', secret({ "email": "user@user.com" }));
 
 #### Parameters
 
--   `url` **[string][3]** 
+-   `url` **[string][4]** 
 -   `payload` **any** the payload to be sent. By default it is sent as an empty object 
--   `headers` **[object][2]** the headers object to be sent. By default it is sent as an empty object 
+-   `headers` **[object][3]** the headers object to be sent. By default it is sent as an empty object 
+
+Returns **[Promise][2]&lt;any>** response
 
 ### sendPostRequest
 
@@ -127,7 +135,9 @@ I.sendPostRequest('/api/users.json', secret({ "email": "user@user.com" }));
 
 -   `url` **any** 
 -   `payload` **any** the payload to be sent. By default it is sent as an empty object 
--   `headers` **[object][2]** the headers object to be sent. By default it is sent as an empty object 
+-   `headers` **[object][3]** the headers object to be sent. By default it is sent as an empty object 
+
+Returns **[Promise][2]&lt;any>** response
 
 ### sendPutRequest
 
@@ -142,9 +152,11 @@ I.sendPutRequest('/api/users.json', secret({ "email": "user@user.com" }));
 
 #### Parameters
 
--   `url` **[string][3]** 
+-   `url` **[string][4]** 
 -   `payload` **any** the payload to be sent. By default it is sent as an empty object 
--   `headers` **[object][2]** the headers object to be sent. By default it is sent as an empty object 
+-   `headers` **[object][3]** the headers object to be sent. By default it is sent as an empty object 
+
+Returns **[Promise][2]&lt;any>** response
 
 ### setRequestTimeout
 
@@ -160,6 +172,8 @@ I.setRequestTimeout(10000); // In milliseconds
 
 [1]: https://github.com/axios/axios
 
-[2]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
+[2]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise
 
-[3]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
+[3]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
+
+[4]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String

--- a/lib/helper/REST.js
+++ b/lib/helper/REST.js
@@ -75,6 +75,8 @@ class REST extends Helper {
    * Executes axios request
    *
    * @param {*} request
+   *
+   * @returns {Promise<*>} response
    */
   async _executeRequest(request) {
     const _debugRequest = { ...request };
@@ -143,6 +145,8 @@ class REST extends Helper {
    *
    * @param {*} url
    * @param {object} [headers={}] - the headers object to be sent. By default it is sent as an empty object
+   *
+   * @returns {Promise<*>} response
    */
   async sendGetRequest(url, headers = {}) {
     const request = {
@@ -166,6 +170,8 @@ class REST extends Helper {
    * @param {*} url
    * @param {*} [payload={}] - the payload to be sent. By default it is sent as an empty object
    * @param {object} [headers={}] - the headers object to be sent. By default it is sent as an empty object
+   *
+   * @returns {Promise<*>} response
    */
   async sendPostRequest(url, payload = {}, headers = {}) {
     const request = {
@@ -197,6 +203,8 @@ class REST extends Helper {
    * @param {string} url
    * @param {*} [payload={}] - the payload to be sent. By default it is sent as an empty object
    * @param {object} [headers={}] - the headers object to be sent. By default it is sent as an empty object
+   *
+   * @returns {Promise<*>} response
    */
   async sendPatchRequest(url, payload = {}, headers = {}) {
     const request = {
@@ -228,6 +236,8 @@ class REST extends Helper {
    * @param {string} url
    * @param {*} [payload={}] - the payload to be sent. By default it is sent as an empty object
    * @param {object} [headers={}] - the headers object to be sent. By default it is sent as an empty object
+   *
+   * @returns {Promise<*>} response
    */
   async sendPutRequest(url, payload = {}, headers = {}) {
     const request = {
@@ -254,6 +264,8 @@ class REST extends Helper {
    *
    * @param {*} url
    * @param {object} [headers={}] - the headers object to be sent. By default it is sent as an empty object
+   *
+   * @returns {Promise<*>} response
    */
   async sendDeleteRequest(url, headers = {}) {
     const request = {


### PR DESCRIPTION
## Motivation/Description of the PR
- Description of this PR, which problem it solves
  The return type of the rest helpers was void which is incorrect. They actually return the Axios response object
- Resolves #2590

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [x] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [x] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)

I can't install detox locally for some reason which makes testing, linting... locally hard. I did notice though that the JSDoc I've written is assumably not correct but I have no clue why... If somebody could help me that would be greatly appreciated!