### PR TITLE
Support for Array of Test Files 

### DIFF
--- a/lib/codecept.js
+++ b/lib/codecept.js
@@ -130,7 +130,14 @@ class Codecept {
     let patterns = [pattern];
     if (!pattern) {
       patterns = [];
-      if (this.config.tests && !this.opts.features) patterns.push(this.config.tests);
+      // If the user wants to test a specific set of test fles with their regex.
+      if (this.config.tests && !this.opts.features){
+        if(Array.isArray(this.config.tests)){
+          patterns.push(...this.config.tests);
+        }else{
+          patterns.push(this.config.tests);
+        }
+      }
       if (this.config.gherkin.features && !this.opts.tests) {
         if (Array.isArray(this.config.gherkin.features)) {
           this.config.gherkin.features.forEach(feature => {

--- a/lib/codecept.js
+++ b/lib/codecept.js
@@ -130,7 +130,8 @@ class Codecept {
     let patterns = [pattern];
     if (!pattern) {
       patterns = [];
-      // If the user wants to test a specific set of test fles with their regex.
+      
+      // If the user wants to test a specific set of test files as an array or string.
       if (this.config.tests && !this.opts.features){
         if(Array.isArray(this.config.tests)){
           patterns.push(...this.config.tests);
@@ -138,6 +139,7 @@ class Codecept {
           patterns.push(this.config.tests);
         }
       }
+      
       if (this.config.gherkin.features && !this.opts.tests) {
         if (Array.isArray(this.config.gherkin.features)) {
           this.config.gherkin.features.forEach(feature => {


### PR DESCRIPTION
## Motivation/Description of the PR
- Description of this PR, which problem it 

> When user wants to Specific set of tests rather than giving the regex or similar kind of files, user can specify a List of test files to est them

- Resolves #issueId (if applicable).
#2993
Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
