### PR TITLE
[P1] Fix for false positives

### DIFF
--- a/lib/step.js
+++ b/lib/step.js
@@ -212,16 +212,18 @@ class MetaStep extends Step {
       step.metaStep = this;
     };
     event.dispatcher.prependListener(event.step.before, registerStep);
+    var _error = null;
     try {
       this.startTime = Date.now();
       result = fn.apply(this.context, this.args);
     } catch (error) {
-      this.status = 'failed';
+      this.setStatus('failed');
+      _error = error;
     } finally {
       this.endTime = Date.now();
-
       event.dispatcher.removeListener(event.step.before, registerStep);
     }
+    if (_error) {throw _error;}
     return result;
   }
 }


### PR DESCRIPTION
**Description:**
When a helper contains a function that calls methods with invalid arguments, the failure is suppressed.
For example in the below helper, the line tagged as [HERE], contains an invalid argument "this.field.email". The correct argument is "this.fields.email".
Though the argument is invalid, the failure is suppressed and the test silently passes, resulting in a false postive

{
    fields = {
        email: '#user_basic_email',
        password: '#user_basic_password'
    };
    
    sendForm(email, password) {
        I.fillField(this.field.email, "test") [HERE]
    }
}

Resolves #issueId : https://github.com/codeceptjs/CodeceptJS/issues/1536

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [x] Playwright
[NOTE]: This was noticed/tested on Playwright, but it should be applicable to all helpers.
Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] puppeteerCoverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio
- [ ] subtitles

## Type of change

- [x] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
