### PR TITLE
screenshotOnFail plugin change: Check for helpers' types rather than names

### DIFF
--- a/lib/codecept.js
+++ b/lib/codecept.js
@@ -130,16 +130,16 @@ class Codecept {
     let patterns = [pattern];
     if (!pattern) {
       patterns = [];
-      
+
       // If the user wants to test a specific set of test files as an array or string.
-      if (this.config.tests && !this.opts.features){
-        if(Array.isArray(this.config.tests)){
+      if (this.config.tests && !this.opts.features) {
+        if (Array.isArray(this.config.tests)) {
           patterns.push(...this.config.tests);
-        }else{
+        } else {
           patterns.push(this.config.tests);
         }
       }
-      
+
       if (this.config.gherkin.features && !this.opts.tests) {
         if (Array.isArray(this.config.gherkin.features)) {
           this.config.gherkin.features.forEach(feature => {
@@ -156,7 +156,7 @@ class Codecept {
         if (!fsPath.isAbsolute(file)) {
           file = fsPath.join(global.codecept_dir, file);
         }
-         if(!this.testFiles.includes(fsPath.resolve(file))){
+        if (!this.testFiles.includes(fsPath.resolve(file))) {
           this.testFiles.push(fsPath.resolve(file));
         }
       });

--- a/lib/plugin/screenshotOnFail.js
+++ b/lib/plugin/screenshotOnFail.js
@@ -46,9 +46,10 @@ module.exports = function (config) {
   const helpers = Container.helpers();
   let helper;
 
-  for (const helperName of supportedHelpers) {
-    if (Object.keys(helpers).indexOf(helperName) > -1) {
-      helper = helpers[helperName];
+  for (const enabledHelper of Object.values(helpers)) {
+    if (supportedHelpers.find(supHelper => enabledHelper instanceof supHelper)) {
+      helper = enabledHelper;
+      break;
     }
   }
 
@@ -63,7 +64,7 @@ module.exports = function (config) {
   }
 
   if (Codeceptjs.container.mocha()) {
-    options.reportDir = Codeceptjs.container.mocha().options.reporterOptions
+    options.reportDir = Codeceptjs.container.mocha().options && Codeceptjs.container.mocha().options.reporterOptions
       && Codeceptjs.container.mocha().options.reporterOptions.reportDir;
   }
 

--- a/lib/plugin/standardActingHelpers.js
+++ b/lib/plugin/standardActingHelpers.js
@@ -1,11 +1,19 @@
+const Appium = require('../helper/Appium');
+const Playwright = require('../helper/Playwright');
+const WebDriver = require('../helper/WebDriver');
+const Puppeteer = require('../helper/Puppeteer');
+const TestCafe = require('../helper/TestCafe');
+const Nightmare = require('../helper/Nightmare');
+const Protractor = require('../helper/Protractor');
+
 const standardActingHelpers = [
-  'Playwright',
-  'WebDriver',
-  'Puppeteer',
-  'Appium',
-  'TestCafe',
-  'Protractor',
-  'Nightmare',
+  Playwright,
+  WebDriver,
+  Puppeteer,
+  Appium,
+  TestCafe,
+  Protractor,
+  Nightmare,
 ];
 
 module.exports = standardActingHelpers;

--- a/lib/step.js
+++ b/lib/step.js
@@ -223,7 +223,7 @@ class MetaStep extends Step {
       this.endTime = Date.now();
       event.dispatcher.removeListener(event.step.before, registerStep);
     }
-    if (rethrownError) {throw rethrownError;}
+    if (rethrownError) { throw rethrownError; }
     return result;
   }
 }

--- a/test/unit/plugin/screenshotOnFail_test.js
+++ b/test/unit/plugin/screenshotOnFail_test.js
@@ -6,17 +6,16 @@ const container = require('../../../lib/container');
 const event = require('../../../lib/event');
 const recorder = require('../../../lib/recorder');
 
-let screenshotSaved;
+const WebDriver = require('../../../lib/helper/WebDriver');
+
+let webDriverStub;
 
 describe('screenshotOnFail', () => {
   beforeEach(() => {
+    webDriverStub = sinon.createStubInstance(WebDriver);
     recorder.reset();
-    screenshotSaved = sinon.spy();
     container.clear({
-      WebDriver: {
-        options: {},
-        saveScreenshot: screenshotSaved,
-      },
+      WebDriver: webDriverStub,
     });
   });
 
@@ -24,32 +23,32 @@ describe('screenshotOnFail', () => {
     screenshotOnFail({});
     event.dispatcher.emit(event.test.failed, { title: 'Scenario with data driven | {"login":"admin","password":"123456"}' });
     await recorder.promise();
-    expect(screenshotSaved.called).is.ok;
-    expect('Scenario_with_data_driven.failed.png').is.equal(screenshotSaved.getCall(0).args[0]);
+    expect(webDriverStub.saveScreenshot.called).is.ok;
+    expect('Scenario_with_data_driven.failed.png').is.equal(webDriverStub.saveScreenshot.getCall(0).args[0]);
   });
 
   it('should create screenshot on fail', async () => {
     screenshotOnFail({});
     event.dispatcher.emit(event.test.failed, { title: 'test1' });
     await recorder.promise();
-    expect(screenshotSaved.called).is.ok;
-    expect('test1.failed.png').is.equal(screenshotSaved.getCall(0).args[0]);
+    expect(webDriverStub.saveScreenshot.called).is.ok;
+    expect('test1.failed.png').is.equal(webDriverStub.saveScreenshot.getCall(0).args[0]);
   });
 
   it('should create screenshot with unique name', async () => {
     screenshotOnFail({ uniqueScreenshotNames: true });
     event.dispatcher.emit(event.test.failed, { title: 'test1', uuid: 1 });
     await recorder.promise();
-    expect(screenshotSaved.called).is.ok;
-    expect('test1_1.failed.png').is.equal(screenshotSaved.getCall(0).args[0]);
+    expect(webDriverStub.saveScreenshot.called).is.ok;
+    expect('test1_1.failed.png').is.equal(webDriverStub.saveScreenshot.getCall(0).args[0]);
   });
 
   it('should create screenshot with unique name when uuid is null', async () => {
     screenshotOnFail({ uniqueScreenshotNames: true });
     event.dispatcher.emit(event.test.failed, { title: 'test1' });
     await recorder.promise();
-    expect(screenshotSaved.called).is.ok;
-    const fileName = screenshotSaved.getCall(0).args[0];
+    expect(webDriverStub.saveScreenshot.called).is.ok;
+    const fileName = webDriverStub.saveScreenshot.getCall(0).args[0];
     const regexpFileName = /test1_[0-9]{10}.failed.png/;
     expect(fileName.match(regexpFileName).length).is.equal(1);
   });


### PR DESCRIPTION
## Motivation/Description of the PR
This change slightly modifies the way the 'screenshotOnFail' plugin initializes its code. Currently, there is a verification for the supported helpers at the plugin initialization, comparing it by name. This does not allow for custom implementations of helpers like Appium, WebDriver etc on custom helpers that extend them, i.e.

class MyHelper extends Appium

The above will not activate the screenshotOnFail plugin as its not named as 'Appium', even though it inherits all of Appium's helper (including screenshot) functions

Applicable helpers:

- [x] WebDriver
- [x] Puppeteer
- [x] Nightmare
- [ ] REST
- [ ] FileHelper
- [x] Appium
- [x] Protractor
- [x] TestCafe
- [x] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [x] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
