### PR TITLE
Fix/define artifacts before/issue 3032

### DIFF
--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -1851,6 +1851,11 @@ class Playwright extends Helper {
 
   async _failed(test) {
     await this._withinEnd();
+
+    if (!test.artifacts) {
+      test.artifacts = {};
+    }
+
     if (this.options.recordVideo && this.page.video()) {
       test.artifacts.video = await this.page.video().path();
     }

--- a/lib/plugin/allure.js
+++ b/lib/plugin/allure.js
@@ -83,7 +83,6 @@ module.exports = (config) => {
 
   let currentMetaStep = [];
   let currentStep;
-  let isHookSteps = false;
 
   reporter.pendingCase = function (testName, timestamp, opts = {}) {
     reporter.startCase(testName, timestamp);
@@ -191,14 +190,6 @@ module.exports = (config) => {
     }
   });
 
-  event.dispatcher.on(event.hook.started, () => {
-    isHookSteps = true;
-  });
-
-  event.dispatcher.on(event.hook.passed, () => {
-    isHookSteps = false;
-  });
-
   event.dispatcher.on(event.suite.after, () => {
     reporter.endSuite();
   });
@@ -258,15 +249,13 @@ module.exports = (config) => {
   });
 
   event.dispatcher.on(event.step.started, (step) => {
-    if (isHookSteps === false) {
-      startMetaStep(step.metaStep);
-      if (currentStep !== step) {
-        // In multi-session scenarios, actors' names will be highlighted with ANSI
-        // escape sequences which are invalid XML values
-        step.actor = step.actor.replace(ansiRegExp(), '');
-        reporter.startStep(step.toString());
-        currentStep = step;
-      }
+    startMetaStep(step.metaStep);
+    if (currentStep !== step) {
+      // In multi-session scenarios, actors' names will be highlighted with ANSI
+      // escape sequences which are invalid XML values
+      step.actor = step.actor.replace(ansiRegExp(), '');
+      reporter.startStep(step.toString());
+      currentStep = step;
     }
   });
 


### PR DESCRIPTION
## Motivation/Description of the PR
- When error happens in Before with Playwright, video and trace will be assigned to `test.artifacts`
- Resolves #3032

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [x] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
