### PR TITLE
Add http credentials to browserContext options

### DIFF
--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -365,11 +365,13 @@ class Playwright extends Helper {
         acceptDownloads: true,
         ...this.options.emulate,
       };
-      if (this.options.basicAuth) contextOptions.httpCredentials = this.options.basicAuth;
+      if (this.options.basicAuth) {
+        contextOptions.httpCredentials = this.options.basicAuth;
+        this.isAuthenticated = true;
+      }
       if (this.options.recordVideo) contextOptions.recordVideo = this.options.recordVideo;
       if (this.storageState) contextOptions.storageState = this.storageState;
       this.browserContext = await this.browser.newContext(contextOptions); // Adding the HTTPSError ignore in the context so that we can ignore those errors
-      this.isAuthenticated = true;
     }
 
     let mainPage;

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -354,6 +354,7 @@ class Playwright extends Helper {
     if (this.options.restart && !this.options.manualStart) await this._startBrowser();
     if (!this.isRunning && !this.options.manualStart) await this._startBrowser();
 
+    this.isAuthenticated = false;
     if (this.isElectron) {
       this.browserContext = this.browser.context();
     } else if (this.userDataDir) {
@@ -364,9 +365,11 @@ class Playwright extends Helper {
         acceptDownloads: true,
         ...this.options.emulate,
       };
+      if (this.options.basicAuth) contextOptions.httpCredentials = this.options.basicAuth;
       if (this.options.recordVideo) contextOptions.recordVideo = this.options.recordVideo;
       if (this.storageState) contextOptions.storageState = this.storageState;
       this.browserContext = await this.browser.newContext(contextOptions); // Adding the HTTPSError ignore in the context so that we can ignore those errors
+      this.isAuthenticated = true;
     }
 
     let mainPage;
@@ -559,7 +562,7 @@ class Playwright extends Helper {
     page.setDefaultNavigationTimeout(this.options.getPageTimeout);
     this.context = await this.page;
     this.contextLocator = null;
-    if (this.config.browser === 'chrome') {
+    if (this.options.browser === 'chrome') {
       await page.bringToFront();
     }
   }
@@ -714,9 +717,9 @@ class Playwright extends Helper {
       url = this.options.url + url;
     }
 
-    if (this.config.basicAuth && (this.isAuthenticated !== true)) {
+    if (this.options.basicAuth && (this.isAuthenticated !== true)) {
       if (url.includes(this.options.url)) {
-        await this.browserContext.setHTTPCredentials(this.config.basicAuth);
+        await this.browserContext.setHTTPCredentials(this.options.basicAuth);
         this.isAuthenticated = true;
       }
     }


### PR DESCRIPTION
## Motivation/Description of the PR
- Make sure Playwright browser context set on creation when possible
- Resolves #3035

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [x] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
