### PR TITLE
[FEATURE] plugin screenshotOnFail should allow other file extensions

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -650,6 +650,7 @@ Possible config options:
 
 -   `uniqueScreenshotNames`: use unique names for screenshot. Default: false.
 -   `fullPageScreenshots`: make full page screenshots. Default: false.
+-   `imageExtension`: define image file format. Default: png.
 
 ### Parameters
 

--- a/lib/plugin/screenshotOnFail.js
+++ b/lib/plugin/screenshotOnFail.js
@@ -75,6 +75,7 @@ module.exports = function (config) {
   event.dispatcher.on(event.test.failed, (test) => {
     recorder.add('screenshot of failed test', async () => {
       let fileName = clearString(test.title);
+      const imageExtension =  options.imageExtension ? options.imageExtension : 'png';
       // This prevent data driven to be included in the failed screenshot file name
       if (fileName.indexOf('{') !== -1) {
         fileName = fileName.substr(0, (fileName.indexOf('{') - 3)).trim();
@@ -82,9 +83,9 @@ module.exports = function (config) {
       if (test.ctx && test.ctx.test && test.ctx.test.type === 'hook') fileName = clearString(`${test.title}_${test.ctx.test.title}`);
       if (options.uniqueScreenshotNames && test) {
         const uuid = _getUUID(test);
-        fileName = `${fileName.substring(0, 10)}_${uuid}.failed.png`;
+        fileName = `${fileName.substring(0, 10)}_${uuid}.failed.${imageExtension}`;
       } else {
-        fileName += '.failed.png';
+        fileName += `.failed.${imageExtension}`;
       }
       output.plugin('screenshotOnFail', 'Test failed, try to save a screenshot');
 
@@ -105,7 +106,7 @@ module.exports = function (config) {
 
         const allureReporter = Container.plugins('allure');
         if (allureReporter) {
-          allureReporter.addAttachment('Last Seen Screenshot', fs.readFileSync(path.join(global.output_dir, fileName)), 'image/png');
+          allureReporter.addAttachment('Last Seen Screenshot', fs.readFileSync(path.join(global.output_dir, fileName)), `image/${imageExtension}`);
         }
 
         const cucumberReporter = Container.plugins('cucumberJsonReporter');


### PR DESCRIPTION
## Motivation/Description of the PR
Resemble.js allows for various file extensions, while most step away from JPG due to the artefacts, PNG seems common. However resemble.js allows WEBP as well. 
While `I.saveScreenshot` and `I.seeVisualDiff `allow the file extension to be set by filename, in plugin `screenshotOnFail` this is hardcoded. I suggest to allow an override via an option key.

Using webp drastically reduces artefacts size, at best to about one third, thus the artefact size in CI/CD is improved perhaps even circumventing limits (e.g. uploading artefacts to GitLab Pages often has a size limit).

Applicable plugins:
- [X] screenshotOnFail

## Type of change
- [X] :rocket: New functionality

## Checklist:
- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)

(none of these work out of the box)