### PR TITLE
Handle matching/duplicate steps in cucumber style

### DIFF
--- a/lib/interfaces/bdd.js
+++ b/lib/interfaces/bdd.js
@@ -1,6 +1,9 @@
+
+const path = require('path');
 const { CucumberExpression, ParameterTypeRegistry } = require('cucumber-expressions');
 
 let steps = {};
+let matchingSteps = {}
 
 const STACK_POSITION = 2;
 
@@ -12,6 +15,12 @@ const addStep = (step, fn) => {
   const stack = (new Error()).stack;
   steps[step] = fn;
   fn.line = stack && stack.split('\n')[STACK_POSITION];
+  if (Object.keys(steps).includes(step)) {
+    if (!Object.keys(matchingSteps).includes(step)) {
+      matchingSteps[step] = []
+    }
+    matchingSteps[step].push(fn)
+  }
   if (fn.line) {
     fn.line = fn.line
       .trim()
@@ -22,12 +31,27 @@ const addStep = (step, fn) => {
 
 const parameterTypeRegistry = new ParameterTypeRegistry();
 
-const matchStep = (step) => {
+const _findClosestPath = (from, tos) => {
+  var _shortest = Infinity
+  var _closest = tos[0]
+  for (var each of tos) {
+    var to = each.line
+    to = to.slice(to.indexOf(path.sep) - 1, to.lastIndexOf(path.sep) + 1)
+    var _distance = (path.relative(from, to).split(path.sep).length - 1)
+    if (_distance < _shortest) {
+      _shortest = _distance;
+      _closest = each;
+    }
+  }
+  return _closest;
+}
+
+const matchStep = (step, featureName) => {
   for (const stepName in steps) {
     if (stepName.indexOf('/') === 0) {
       const res = step.match(new RegExp(stepName.slice(1, -1)));
       if (res) {
-        const fn = steps[stepName];
+        fn = steps[stepName];
         fn.params = res.slice(1);
         return fn;
       }
@@ -36,7 +60,12 @@ const matchStep = (step) => {
     const expression = new CucumberExpression(stepName, parameterTypeRegistry);
     const res = expression.match(step);
     if (res) {
-      const fn = steps[stepName];
+      var fn;
+      if (Object.keys(matchingSteps).includes(stepName)) {
+        fn = _findClosestPath(featureName, matchingSteps[stepName])
+      } else {
+        fn = steps[stepName];
+      }
       fn.params = res.map(arg => arg.getValue());
       return fn;
     }

--- a/lib/interfaces/bdd.js
+++ b/lib/interfaces/bdd.js
@@ -61,7 +61,7 @@ const matchStep = (step, featureName) => {
     const res = expression.match(step);
     if (res) {
       var fn;
-      if (Object.keys(matchingSteps).includes(stepName)) {
+      if (featureName && Object.keys(matchingSteps).includes(stepName)) {
         fn = _findClosestPath(featureName, matchingSteps[stepName])
       } else {
         fn = steps[stepName];

--- a/lib/interfaces/bdd.js
+++ b/lib/interfaces/bdd.js
@@ -1,9 +1,8 @@
-
 const path = require('path');
 const { CucumberExpression, ParameterTypeRegistry } = require('cucumber-expressions');
 
 let steps = {};
-let matchingSteps = {}
+let matchingSteps = {};
 
 const STACK_POSITION = 2;
 
@@ -17,9 +16,9 @@ const addStep = (step, fn) => {
   fn.line = stack && stack.split('\n')[STACK_POSITION];
   if (Object.keys(steps).includes(step)) {
     if (!Object.keys(matchingSteps).includes(step)) {
-      matchingSteps[step] = []
+      matchingSteps[step] = [];
     }
-    matchingSteps[step].push(fn)
+    matchingSteps[step].push(fn);
   }
   if (fn.line) {
     fn.line = fn.line
@@ -32,26 +31,26 @@ const addStep = (step, fn) => {
 const parameterTypeRegistry = new ParameterTypeRegistry();
 
 const _findClosestPath = (from, tos) => {
-  var _shortest = Infinity
-  var _closest = tos[0]
-  for (var each of tos) {
-    var to = each.line
-    to = to.slice(to.indexOf(path.sep) - 1, to.lastIndexOf(path.sep) + 1)
-    var _distance = (path.relative(from, to).split(path.sep).length - 1)
+  let _shortest = Infinity;
+  let _closest = tos[0];
+  for (const each of tos) {
+    let to = each.line;
+    to = to.slice(to.indexOf(path.sep) - 1, to.lastIndexOf(path.sep) + 1);
+    const _distance = (path.relative(from, to).split(path.sep).length - 1);
     if (_distance < _shortest) {
       _shortest = _distance;
       _closest = each;
     }
   }
   return _closest;
-}
+};
 
 const matchStep = (step, featureName) => {
   for (const stepName in steps) {
     if (stepName.indexOf('/') === 0) {
       const res = step.match(new RegExp(stepName.slice(1, -1)));
       if (res) {
-        fn = steps[stepName];
+        const fn = (featureName && Object.keys(matchingSteps).includes(stepName)) ? _findClosestPath(featureName, matchingSteps[stepName]) : steps[stepName];
         fn.params = res.slice(1);
         return fn;
       }
@@ -60,12 +59,7 @@ const matchStep = (step, featureName) => {
     const expression = new CucumberExpression(stepName, parameterTypeRegistry);
     const res = expression.match(step);
     if (res) {
-      var fn;
-      if (featureName && Object.keys(matchingSteps).includes(stepName)) {
-        fn = _findClosestPath(featureName, matchingSteps[stepName])
-      } else {
-        fn = steps[stepName];
-      }
+      const fn = (featureName && Object.keys(matchingSteps).includes(stepName)) ? _findClosestPath(featureName, matchingSteps[stepName]) : steps[stepName];
       fn.params = res.map(arg => arg.getValue());
       return fn;
     }
@@ -75,6 +69,7 @@ const matchStep = (step, featureName) => {
 
 const clearSteps = () => {
   steps = {};
+  matchingSteps = {};
 };
 
 const getSteps = () => {

--- a/lib/interfaces/gherkin.js
+++ b/lib/interfaces/gherkin.js
@@ -11,7 +11,7 @@ const transform = require('../transform');
 const parser = new Parser();
 parser.stopAtFirstError = false;
 
-module.exports = (text) => {
+module.exports = (text, file) => {
   const ast = parser.parse(text);
 
   const suite = new Suite(ast.feature.name, new Context());
@@ -41,7 +41,7 @@ module.exports = (text) => {
         }
         step.metaStep = metaStep;
       };
-      const fn = matchStep(step.text);
+      const fn = matchStep(step.text, file);
       if (step.argument) {
         step.argument.parse = () => {
           return new DataTableArgument(step.argument);

--- a/lib/mochaFactory.js
+++ b/lib/mochaFactory.js
@@ -34,9 +34,11 @@ class MochaFactory {
       // load features
       if (mocha.suite.suites.length === 0) {
         mocha.files
-          .filter(file => file.match(/\.feature$/))
-          .map(file => fs.readFileSync(file, 'utf8'))
-          .forEach(content => mocha.suite.addSuite(gherkinParser(content)));
+          .filter(file => file.match(/\.feature$/));
+
+        mocha.files.forEach(file => {
+          mocha.suite.addSuite(gherkinParser(fs.readFileSync(file, 'utf8'), file))
+        });
 
         // remove feature files
         mocha.files = mocha.files.filter(file => !file.match(/\.feature$/));

--- a/lib/mochaFactory.js
+++ b/lib/mochaFactory.js
@@ -34,11 +34,8 @@ class MochaFactory {
       // load features
       if (mocha.suite.suites.length === 0) {
         mocha.files
-          .filter(file => file.match(/\.feature$/));
-
-        mocha.files.forEach(file => {
-          mocha.suite.addSuite(gherkinParser(fs.readFileSync(file, 'utf8'), file))
-        });
+          .filter(file => file.match(/\.feature$/))
+          .forEach(file => mocha.suite.addSuite(gherkinParser(fs.readFileSync(file, 'utf8'), file)));
 
         // remove feature files
         mocha.files = mocha.files.filter(file => !file.match(/\.feature$/));


### PR DESCRIPTION
## Motivation/Description of the PR
Duplicate steps in step definition files are used in the order they are defined in the codecept configuration file. 
This change does a check for the closest step definition file containing the required step when the step is repeated in multiple files. This is similar to cucumbers logic.

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
