### PR TITLE
[WIP] [FEATURE] allow screenshotOnFail images to be in subfolder

### DIFF
--- a/lib/helper/Mochawesome.js
+++ b/lib/helper/Mochawesome.js
@@ -47,18 +47,11 @@ class Mochawesome extends Helper {
       currentTest = { test: test.ctx.test };
       // ignore retries if we are in hook
       test._retries = -1;
-      fileName = clearString(`${test.title}_${currentTest.test.title}`);
     } else {
       currentTest = { test };
-      fileName = clearString(test.title);
-    }
-    if (this.options.uniqueScreenshotNames) {
-      const uuid = test.uuid || test.ctx.test.uuid;
-      fileName = `${fileName.substring(0, 10)}_${uuid}`;
     }
     if (test._retries < 1 || test._retries === test.retryNum) {
-      fileName = `${fileName}.failed.png`;
-      return addMochawesomeContext(currentTest, fileName);
+      return addMochawesomeContext(currentTest, test.ctx.test.attachments[0]);
     }
   }
 

--- a/lib/plugin/screenshotOnFail.js
+++ b/lib/plugin/screenshotOnFail.js
@@ -61,15 +61,26 @@ module.exports = function (config) {
       options.uniqueScreenshotNames = helpers.Mochawesome.config.uniqueScreenshotNames;
     }
   }
-
-  if (Codeceptjs.container.mocha()) {
-    options.reportDir = Codeceptjs.container.mocha().options.reporterOptions
-      && Codeceptjs.container.mocha().options.reporterOptions.reportDir;
+  options.reportDir = false;
+  if (
+    Codeceptjs.container.mocha()
+    && typeof Codeceptjs.container.mocha().options.reporterOptions !== 'undefined'
+    && typeof Codeceptjs.container.mocha().options.reporterOptions.reportDir !== 'undefined'
+  ) {
+    options.reportDir = Codeceptjs.container.mocha().options.reporterOptions.reportDir;
+  }
+  // support mocha-multi-reporters
+  if (
+    Codeceptjs.container.mocha()
+    && typeof Codeceptjs.container.mocha().options.reporterOptions.mochawesomeReporterOptions !== 'undefined'
+    && typeof Codeceptjs.container.mocha().options.reporterOptions.mochawesomeReporterOptions.reportDir !== 'undefined'
+  ) {
+    options.reportDir =  Container.mocha().options.reporterOptions.mochawesomeReporterOptions.reportDir;
   }
 
-  if (options.disableScreenshots) {
-    // old version of disabling screenshots
-    return;
+  let outputFolder = options.reportDir;
+  if (options.screenshotFolder) {
+    outputFolder = options.screenshotFolder;
   }
 
   event.dispatcher.on(event.test.failed, (test) => {
@@ -89,19 +100,26 @@ module.exports = function (config) {
       output.plugin('screenshotOnFail', 'Test failed, try to save a screenshot');
 
       try {
-        if (options.reportDir) {
-          fileName = path.join(options.reportDir, fileName);
-          const mochaReportDir = path.resolve(process.cwd(), options.reportDir);
+        if (outputFolder) {
+          fileName = path.join(outputFolder, fileName);
+          const mochaReportDir = path.resolve(process.cwd(), outputFolder);
           if (!fileExists(mochaReportDir)) {
             fs.mkdirSync(mochaReportDir);
           }
         }
         await helper.saveScreenshot(fileName, options.fullPageScreenshots);
 
+        let relativeFileName = path.relative(options.reportDir,fileName);
+
         if (!test.artifacts) test.artifacts = {};
-        test.artifacts.screenshot = path.join(global.output_dir, fileName);
-        if (Container.mocha().options.reporterOptions['mocha-junit-reporter'] && Container.mocha().options.reporterOptions['mocha-junit-reporter'].options.attachments) {
-          test.attachments = [path.join(global.output_dir, fileName)];
+        test.artifacts.screenshot = relativeFileName;
+        if (
+          // support mocha
+          (Container.mocha().options.reporterOptions['mocha-junit-reporter'] && Container.mocha().options.reporterOptions['mocha-junit-reporter'].options.attachments)
+          // support mocha-multi-reporters
+          || (Container.mocha().options.reporterOptions['mochaJunitReporterReporterOptions'] && Container.mocha().options.reporterOptions['mochaJunitReporterReporterOptions'].attachments)
+        ){
+          test.attachments = [relativeFileName];
         }
 
         const allureReporter = Container.plugins('allure');


### PR DESCRIPTION
## Motivation/Description of the PR
We really like to have a mochawesome report folder like:
```
> ls tests/output
assets
base
diff
failed
test
report.html
report.json
report.xml
```
So all the screenshots sorted away in `test` (`base` and `diff` accordingly) and additionally have the `failed` screenshots in a subfolder. The basic config would be mochawesome `reportDir: './tests/output/',` and
```js
    output: './tests/output/test',
    helpers: {
        ResembleHelper: {
            require: 'codeceptjs-resemblehelper',
            screenshotFolder: './tests/output/test',
            baseFolder: './tests/output/base',
            diffFolder: './tests/output/diff',
        }
    }
```
This creates everything accordingly, however in the reports the filename is added as plain file, without the relative path as the current implementation is expecting record and fail-screenshot to be in the same folder.

This PR should fix that and allows to add relative paths. As this ist bound to screenshotOnFail and Mochaweseome, currently two config options need to be added:
```js
    plugins: {
        screenshotOnFail: {
            screenshotFolder: './tests/output/failed/',
        }, 
```
Additionally no extensive testing was done for cases where report and images are not in a hierarchical relationship. 

A MWE with this code using `patch-package` is managed at https://github.com/jpmschuler/mwe-codeceptjs/tree/feature-screenshotOnFail-CustomFolder 

As I don't have much experiences in all the options and possibilities I don't know if that is an interesting approach, seeing the implementation https://github.com/codeceptjs/CodeceptJS/blob/3429731684fd8dab41d2ead02641e25998e1c86e/lib/helper/Mochawesome.js#L42-L63 
however suggests that the implementation of filename and path generation should not be redundant and could be replaced with just taking the attachment:
https://github.com/jpmschuler/CodeceptJS/blob/ec6d3a948e8fde9865b0a626040bcefb87677dc8/lib/helper/Mochawesome.js#L42-L56

Applicable helpers:

- [X] Mochawesome

Applicable plugins:

- [X] screenshotOnFail

## Type of change

- [ ] :fire: Breaking changes
- [X] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
