### PR TITLE
Fixed unhandled empty feature files

### DIFF
--- a/lib/interfaces/gherkin.js
+++ b/lib/interfaces/gherkin.js
@@ -11,9 +11,10 @@ const transform = require('../transform');
 const parser = new Parser();
 parser.stopAtFirstError = false;
 
-module.exports = (text) => {
+module.exports = (text, file) => {
   const ast = parser.parse(text);
 
+  if (!ast.feature) {throw new Error(`No 'Features' available in Gherkin '${file}' provided!`);}
   const suite = new Suite(ast.feature.name, new Context());
   const tags = ast.feature.tags.map(t => t.name);
   suite.title = `${suite.title} ${tags.join(' ')}`.trim();

--- a/lib/mochaFactory.js
+++ b/lib/mochaFactory.js
@@ -35,8 +35,7 @@ class MochaFactory {
       if (mocha.suite.suites.length === 0) {
         mocha.files
           .filter(file => file.match(/\.feature$/))
-          .map(file => fs.readFileSync(file, 'utf8'))
-          .forEach(content => mocha.suite.addSuite(gherkinParser(content)));
+          .forEach(file => mocha.suite.addSuite(gherkinParser(fs.readFileSync(file, 'utf8'), file)));
 
         // remove feature files
         mocha.files = mocha.files.filter(file => !file.match(/\.feature$/));


### PR DESCRIPTION
## Motivation/Description of the PR
When a Feature file is empty, instead of showing an error that the Feature file is empty, the below error is displayed.
This is irrelevant to the actual problem and as a result users will not understand what the problem is, thereby costing a lot of time for resolution.

TypeError: Cannot read property 'name' of undefined
at module.exports (/Users/node_modules/codeceptjs/lib/interfaces/gherkin.js:18:39)
at /Users/node_modules/codeceptjs/lib/mochaFactory.js:38:32
at Array.map ()
at Mocha.mocha.loadFiles (/Users/node_modules/codeceptjs/lib/mochaFactory.js:36:21)
at Mocha.run (/Users/node_modules/codeceptjs/node_modules/mocha/lib/mocha.js:966:10)
at /Users/node_modules/codeceptjs/lib/codecept.js:188:15
at new Promise ()
at Codecept.run (/Users/node_modules/codeceptjs/lib/codecept.js:171:12)
at Function.run (/Users/lib/utils/runner.util.ts:27:18)
at main (/Users/lib/runner.ts:6:10)

Applicable helpers: Applies to all helpers

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
