### PR TITLE
Playwright I.haveRequestHeaders should affect all the tabs

### DIFF
--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -780,7 +780,7 @@ class Playwright extends Helper {
     if (!customHeaders) {
       throw new Error('Cannot send empty headers.');
     }
-    return this.page.setExtraHTTPHeaders(customHeaders);
+    return this.browserContext.setExtraHTTPHeaders(customHeaders);
   }
 
   /**

--- a/lib/plugin/allure.js
+++ b/lib/plugin/allure.js
@@ -83,7 +83,6 @@ module.exports = (config) => {
 
   let currentMetaStep = [];
   let currentStep;
-  let isHookSteps = false;
 
   reporter.pendingCase = function (testName, timestamp, opts = {}) {
     reporter.startCase(testName, timestamp);
@@ -191,14 +190,6 @@ module.exports = (config) => {
     }
   });
 
-  event.dispatcher.on(event.hook.started, () => {
-    isHookSteps = true;
-  });
-
-  event.dispatcher.on(event.hook.passed, () => {
-    isHookSteps = false;
-  });
-
   event.dispatcher.on(event.suite.after, () => {
     reporter.endSuite();
   });
@@ -258,15 +249,13 @@ module.exports = (config) => {
   });
 
   event.dispatcher.on(event.step.started, (step) => {
-    if (isHookSteps === false) {
-      startMetaStep(step.metaStep);
-      if (currentStep !== step) {
-        // In multi-session scenarios, actors' names will be highlighted with ANSI
-        // escape sequences which are invalid XML values
-        step.actor = step.actor.replace(ansiRegExp(), '');
-        reporter.startStep(step.toString());
-        currentStep = step;
-      }
+    startMetaStep(step.metaStep);
+    if (currentStep !== step) {
+      // In multi-session scenarios, actors' names will be highlighted with ANSI
+      // escape sequences which are invalid XML values
+      step.actor = step.actor.replace(ansiRegExp(), '');
+      reporter.startStep(step.toString());
+      currentStep = step;
     }
   });
 


### PR DESCRIPTION
## Motivation/Description of the PR
- Once custom headers are applied with I.haveRequestHeaders, they will be effective not only on the first tab, but on all ones opened from the first one
- Resolves #3048

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [x] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
