### PR TITLE
Enhancement to optionally link feature files to helper files

### DIFF
--- a/lib/interfaces/gherkin.js
+++ b/lib/interfaces/gherkin.js
@@ -21,6 +21,7 @@ module.exports = (text, file) => {
   suite.tags = tags || [];
   suite.comment = ast.feature.description;
   suite.feature = ast.feature;
+  suite.file = file;
   suite.timeout(0);
 
   suite.beforeEach('codeceptjs.before', () => scenario.setup(suite));
@@ -96,6 +97,7 @@ module.exports = (text, file) => {
           const title = `${child.name} ${JSON.stringify(current)} ${tags.join(' ')}`.trim();
           const test = new Test(title, async () => runSteps(addExampleInTable(exampleSteps, current)));
           test.tags = suite.tags.concat(tags);
+          test.file = file;
           suite.addTest(scenario.test(test));
         }
       }
@@ -105,6 +107,7 @@ module.exports = (text, file) => {
     const title = `${child.name} ${tags.join(' ')}`.trim();
     const test = new Test(title, async () => runSteps(child.steps));
     test.tags = suite.tags.concat(tags);
+    test.file = file;
     suite.addTest(scenario.test(test));
   }
 

--- a/lib/interfaces/gherkin.js
+++ b/lib/interfaces/gherkin.js
@@ -14,7 +14,9 @@ parser.stopAtFirstError = false;
 module.exports = (text, file) => {
   const ast = parser.parse(text);
 
-  if (!ast.feature) {throw new Error(`No 'Features' available in Gherkin '${file}' provided!`);}
+  if (!ast.feature) {
+    throw new Error(`No 'Features' available in Gherkin '${file}' provided!`);
+  }
   const suite = new Suite(ast.feature.name, new Context());
   const tags = ast.feature.tags.map(t => t.name);
   suite.title = `${suite.title} ${tags.join(' ')}`.trim();

--- a/lib/listener/helpers.js
+++ b/lib/listener/helpers.js
@@ -22,9 +22,6 @@ module.exports = function () {
   const runAsyncHelpersHook = (hook, param, force) => {
     if (store.dryRun) return;
     Object.keys(helpers).forEach((key) => {
-      if (helpers[key].feature && param.file) {
-        if (helpers[key].feature !== path.basename(param.file)) { return; }
-      }
       if (!helpers[key][hook]) return;
       recorder.add(`hook ${key}.${hook}()`, () => helpers[key][hook](param), force, false);
     });

--- a/lib/listener/helpers.js
+++ b/lib/listener/helpers.js
@@ -3,6 +3,7 @@ const container = require('../container');
 const recorder = require('../recorder');
 const store = require('../store');
 const { error } = require('../output');
+const path = require('path');
 /**
  * Enable Helpers to listen to test events
  */
@@ -21,6 +22,9 @@ module.exports = function () {
   const runAsyncHelpersHook = (hook, param, force) => {
     if (store.dryRun) return;
     Object.keys(helpers).forEach((key) => {
+      if (helpers[key]['feature'] && param.file) {
+          if (helpers[key]['feature'] != path.basename(param.file)) { return };
+      }
       if (!helpers[key][hook]) return;
       recorder.add(`hook ${key}.${hook}()`, () => helpers[key][hook](param), force, false);
     });

--- a/lib/listener/helpers.js
+++ b/lib/listener/helpers.js
@@ -1,9 +1,9 @@
+const path = require('path');
 const event = require('../event');
 const container = require('../container');
 const recorder = require('../recorder');
 const store = require('../store');
 const { error } = require('../output');
-const path = require('path');
 /**
  * Enable Helpers to listen to test events
  */
@@ -22,8 +22,8 @@ module.exports = function () {
   const runAsyncHelpersHook = (hook, param, force) => {
     if (store.dryRun) return;
     Object.keys(helpers).forEach((key) => {
-      if (helpers[key]['feature'] && param.file) {
-          if (helpers[key]['feature'] != path.basename(param.file)) { return };
+      if (helpers[key].feature && param.file) {
+        if (helpers[key].feature !== path.basename(param.file)) { return; }
       }
       if (!helpers[key][hook]) return;
       recorder.add(`hook ${key}.${hook}()`, () => helpers[key][hook](param), force, false);


### PR DESCRIPTION
When there are multiple helper files, there is no way to link feature files to the helper files and thus all hooks are executed. Which might be unnecessary in some cases.
This enhancement helps link a specific feature file to the helper file which ensures that the before/after hooks for tests and suites are executed only for that particular feature file.

Example:
The "feature" variable is the name of the feature file to which the helper is linked to.
If this variable is not set, the usual execution flow happens.

```
class MyHelper extends Helper {

    feature = "feature_one.feature"
        
    _after() {
    }
    _beforeStep(step) {
    }
    _beforeSuite(suite){
    }
}
module.exports = MyHelper;
```

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
