### PR TITLE
improve(config): Support cjs file extensions for config file

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -128,7 +128,7 @@ function loadConfigFile(configFile) {
   const extensionName = path.extname(configFile);
 
   // .conf.js config file
-  if (extensionName === '.js' || extensionName === '.ts') {
+  if (extensionName === '.js' || extensionName === '.ts' || extensionName === '.cjs') {
     return Config.create(require(configFile).config);
   }
 


### PR DESCRIPTION
I am attempting to set my project to be a esm module by using the package.json property "type" with the value of "module".
Noticed codecept didn't support importing esm so I changed all of my acceptance testing files to be commonjs files denoted with the .cjs file extension. Need to add this extension to the list of checked extensions so the config file will be loaded.

On a side note is there any plan to support esm modules. Would have to swap to use dynamic imports or first try to use require then fallback to dynamic import if the error is "ERR_REQUIRE_ESM".  Mocha currently supports esm modules but have to use loadFiles Aync instead of loadFiles. I looked at your require code a bit and wasn't sure how to best handle having to deal with the fact dynamic imports return a promise.