### PR TITLE
We should always close the browser

### DIFF
--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -554,10 +554,9 @@ class Puppeteer extends Helper {
     this.context = null;
     popupStore.clear();
     this.isAuthenticated = false;
+    await this.browser.close();
     if (this.isRemoteBrowser) {
       await this.browser.disconnect();
-    } else {
-      await this.browser.close();
     }
   }
 

--- a/test/helper/Puppeteer_test.js
+++ b/test/helper/Puppeteer_test.js
@@ -934,15 +934,9 @@ describe('Puppeteer', function () {
 
 let remoteBrowser;
 async function createRemoteBrowser() {
-  if (remoteBrowser) {
-    await remoteBrowser.close();
-  }
   remoteBrowser = await puppeteer.launch({
     args: ['--no-sandbox', '--disable-setuid-sandbox'],
     headless: true,
-  });
-  remoteBrowser.on('disconnected', () => {
-    remoteBrowser = null;
   });
   return remoteBrowser;
 }
@@ -1027,7 +1021,7 @@ describe('Puppeteer (remote browser)', function () {
       await I._stopBrowser();
 
       currentPages = await remoteBrowser.pages();
-      assert.equal(currentPages.length, 2);
+      assert.equal(currentPages.length, 0);
     });
   });
 });


### PR DESCRIPTION
Remote browser or not, we should always close the browser. 
Closing the browser will actually tell the remote browser provider that the session is to be ended (logs to be consolidated and session terminated), whereas only disconnecting might keep the session hanging for no reason.

## Motivation/Description of the PR
- Description of this PR, which problem it solves
When executing Codeceptjs/Puppeteer test suite using the browserstack grid, the session hang for 15min after the test suite finished executing and logs are not properly uploaded to the plateform. 
- Resolves #issueId (if applicable).
I don't have an issue ID as I identified the bug at the same time, I fixed it.

Applicable helpers:

- [ ] WebDriver
- [X] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [X] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
No test added as it would require credentials for a remote browsers provider. 
- [x] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
`npm test` -> 2 tests fail but they fail anyway on branch `3.x` on my system
