### PR TITLE
Add type declarations for @codeceptjs/helper package

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -97,28 +97,6 @@ declare namespace CodeceptJS {
   interface Globals {
     codeceptjs: typeof codeceptjs;
   }
-
-  class Helper {
-    constructor(config: unknown)
-    static _config(): unknown
-    _validateConfig(config: unknown): unknown
-    _setConfig(opts: unknown): unknown
-    _init(): unknown
-    _before(): unknown
-    _after(): unknown
-    _test(test: Mocha.Test): unknown
-    _passed(test: Mocha.Test): unknown
-    _failed(test: Mocha.Test): unknown
-    _beforeStep(step: CodeceptJS.Step): unknown
-    _afterStep(step: CodeceptJS.Step): unknown
-    _beforeSuite(suite: Mocha.Suite): unknown
-    _afterSuite(suite: Mocha.Suite): unknown
-    _finishTest(suite: Mocha.Suite): unknown
-    _useTo(description?: string, fn?: Function): void
-    get helpers(): any
-    debug(msg: string): void
-    debugSection(section: string, msg: string): void
-  }
 }
 
 // Globals
@@ -226,5 +204,5 @@ declare module "codeceptjs" {
 }
 
 declare module "@codeceptjs/helper" {
-  export default CodeceptJS.Helper;
+  export = CodeceptJS.Helper;
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -97,6 +97,28 @@ declare namespace CodeceptJS {
   interface Globals {
     codeceptjs: typeof codeceptjs;
   }
+
+  class Helper {
+    constructor(config: unknown)
+    static _config(): unknown
+    _validateConfig(config: unknown): unknown
+    _setConfig(opts: unknown): unknown
+    _init(): unknown
+    _before(): unknown
+    _after(): unknown
+    _test(test: Mocha.Test): unknown
+    _passed(test: Mocha.Test): unknown
+    _failed(test: Mocha.Test): unknown
+    _beforeStep(step: CodeceptJS.Step): unknown
+    _afterStep(step: CodeceptJS.Step): unknown
+    _beforeSuite(suite: Mocha.Suite): unknown
+    _afterSuite(suite: Mocha.Suite): unknown
+    _finishTest(suite: Mocha.Suite): unknown
+    _useTo(description?: string, fn?: Function): void
+    get helpers(): any
+    debug(msg: string): void
+    debugSection(section: string, msg: string): void
+  }
 }
 
 // Globals
@@ -201,4 +223,8 @@ declare namespace Mocha {
 
 declare module "codeceptjs" {
   export = codeceptjs;
+}
+
+declare module "@codeceptjs/helper" {
+  export default CodeceptJS.Helper;
 }


### PR DESCRIPTION
## Motivation/Description of the PR
This PR adds type declarations for the `@codeceptjs/helper`. I know there is a separate repo for this package but IMO it is more straightforward to keep all the types here as the other package probably doesn't make sense standalone.

This reduces the amount of errors returned by `dtslib` but there are still a few remaining that I will annotate in the comments.

I am also debating if it isn't better to also change this to an `interface` so that it could be extended in custom types, but will not allow for using visibility modifiers on the fields.

If everything looks alright, I'll change the PR status to ready for review.

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [x] :nail_care: Polish code

## Checklist:

- [x] Tests have been added
- [x] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
