### PR TITLE
Allow Scenario to accept an asynchronous callback

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -66,7 +66,7 @@ declare namespace CodeceptJS {
   type StringOrSecret = string | CodeceptJS.Secret;
 
   interface HookCallback {
-    (args: SupportObject): void;
+    (args: SupportObject): void | Promise<void>;
   }
   interface Scenario extends IScenario {
     only: IScenario;

--- a/typings/tests/global-variables.types.ts
+++ b/typings/tests/global-variables.types.ts
@@ -28,6 +28,10 @@ Scenario('scenario',
     args.I // $ExpectType I
   }
 )
+Scenario(
+  'scenario',
+  async () => {} // $ExpectType () => Promise<void>
+)
 
 Before((args) => {
   args // $ExpectType SupportObject


### PR DESCRIPTION
## Motivation/Description of the PR
Some eslint rules do not play nice when passing asynchronous callback functions to Scenario and report errors. This PR improves the type to match the actual implementation.

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [x] :nail_care: Polish code

## Checklist:

- [x] Tests have been added
- [x] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
