### PR TITLE
Add type declaration to jsdoc of `Locator`.

### DIFF
--- a/lib/locator.js
+++ b/lib/locator.js
@@ -313,13 +313,13 @@ Locator.build = (locator) => {
 
 /**
  * Filters to modify locators
- * @type {function[]}
+ * @type {Array<function(CodeceptJS.LocatorOrString, Locator): void>}
  */
 Locator.filters = [];
 
 /**
  * Appends new `Locator` filter to an `Locator.filters` array, and returns the new length of the array.
- * @param {function} fn
+ * @param {function(CodeceptJS.LocatorOrString, Locator): void} fn
  * @returns {number}
  */
 Locator.addFilter = fn => Locator.filters.push(fn);

--- a/lib/locator.js
+++ b/lib/locator.js
@@ -313,11 +313,14 @@ Locator.build = (locator) => {
 
 /**
  * Filters to modify locators
+ * @type {function[]}
  */
 Locator.filters = [];
 
 /**
  * Appends new `Locator` filter to an `Locator.filters` array, and returns the new length of the array.
+ * @param {function} fn
+ * @returns {number}
  */
 Locator.addFilter = fn => Locator.filters.push(fn);
 


### PR DESCRIPTION
## Motivation/Description of the PR
- Description of this PR, which problem it solves
This PR fixed wrong type definition of  `Locator.filters` and `Locator.addFilter`.
These caused TypeScript's error.

- Resolves #issueId (if applicable).
#2794

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [x] Tests have been added
- [x] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
