### PR TITLE
playwright configuration - added locale

### DIFF
--- a/docs/helpers/Playwright.md
+++ b/docs/helpers/Playwright.md
@@ -47,6 +47,7 @@ This helper should be configured in codecept.json or codecept.conf.js
 -   `basicAuth`: (optional) the basic authentication to pass to base url. Example: {username: 'username', password: 'password'}
 -   `windowSize`: (optional) default window size. Set a dimension like `640x480`.
 -   `userAgent`: (optional) user-agent string.
+-   `locale`: (optional) locale string. Example: 'en-GB', 'de-DE', 'fr-FR', ...
 -   `manualStart`:  - do not start browser before a test, start it manually inside a helper with `this.helpers["Playwright"]._startBrowser()`.
 -   `chromium`: (optional) pass additional chromium options
 -   `electron`: (optional) pass additional electron options
@@ -158,6 +159,19 @@ const { devices } = require('playwright');
      url: "http://localhost",
      emulate: devices['iPhone 6'],
    }
+ }
+}
+```
+
+#### Example #7: Launch test with a specifc user locale
+
+```js
+{
+ helpers: {
+  Playwright : {
+    url: "http://localhost",
+    locale: "fr-FR",
+  }
  }
 }
 ```

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -80,6 +80,7 @@ const { createValueEngine, createDisabledEngine } = require('./extras/Playwright
  * * `basicAuth`: (optional) the basic authentication to pass to base url. Example: {username: 'username', password: 'password'}
  * * `windowSize`: (optional) default window size. Set a dimension like `640x480`.
  * * `userAgent`: (optional) user-agent string.
+ * * `locale`: (optional) locale string. Example: 'en-GB', 'de-DE', 'fr-FR', ...
  * * `manualStart`: (optional, default: false) - do not start browser before a test, start it manually inside a helper with `this.helpers["Playwright"]._startBrowser()`.
  * * `chromium`: (optional) pass additional chromium options
  * * `electron`: (optional) pass additional electron options
@@ -193,6 +194,19 @@ const { createValueEngine, createDisabledEngine } = require('./extras/Playwright
  *      url: "http://localhost",
  *      emulate: devices['iPhone 6'],
  *    }
+ *  }
+ * }
+ * ```
+ *
+ * #### Example #7: Launch test with a specifc user locale
+ *
+ * ```js
+ * {
+ *  helpers: {
+ *   Playwright : {
+ *     url: "http://localhost",
+ *     locale: "fr-FR",
+ *   }
  *  }
  * }
  * ```
@@ -372,6 +386,7 @@ class Playwright extends Helper {
       if (this.options.recordVideo) contextOptions.recordVideo = this.options.recordVideo;
       if (this.storageState) contextOptions.storageState = this.storageState;
       if (this.options.userAgent) contextOptions.userAgent = this.options.userAgent;
+      if (this.options.locale) contextOptions.locale = this.options.locale;
       this.browserContext = await this.browser.newContext(contextOptions); // Adding the HTTPSError ignore in the context so that we can ignore those errors
     }
 

--- a/lib/plugin/screenshotOnFail.js
+++ b/lib/plugin/screenshotOnFail.js
@@ -98,7 +98,7 @@ module.exports = function (config) {
         }
         await helper.saveScreenshot(fileName, options.fullPageScreenshots);
 
-        if (!test.artifacts) test.artifacts = {}
+        if (!test.artifacts) test.artifacts = {};
         test.artifacts.screenshot = path.join(global.output_dir, fileName);
         if (Container.mocha().options.reporterOptions['mocha-junit-reporter'] && Container.mocha().options.reporterOptions['mocha-junit-reporter'].options.attachments) {
           test.attachments = [path.join(global.output_dir, fileName)];


### PR DESCRIPTION
## Motivation/Description of the PR
- We have to test our application with differentes locales (french and english). Playwright provides an attribute 'locale' to change browser user locale. I added the mapping between CodeceptJS configuration and Playwright to correctly defined this property.

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [X] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [X] :rocket: New functionality
- [ ] :bug: Bug fix
- [X] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [X] Documentation has been added (Run `npm run docs`)
- [X] Lint checking (Run `npm run lint`)
- [X] Local tests are passed (Run `npm test`)
