### PR TITLE
fix(typings): fix seeTitleEquals Puppeteer and Protactor typings

### DIFF
--- a/docs/helpers/Puppeteer.md
+++ b/docs/helpers/Puppeteer.md
@@ -1614,7 +1614,7 @@ I.seeTitleEquals('Test title.');
 
 #### Parameters
 
--   `text`  
+-   `text` **[string][8]** value to check.
 
 ### selectOption
 

--- a/lib/helper/Protractor.js
+++ b/lib/helper/Protractor.js
@@ -838,11 +838,7 @@ class Protractor extends Helper {
   }
 
   /**
-   * Checks that title is equal to provided one.
-   *
-   * ```js
-   * I.seeTitleEquals('Test title.');
-   * ```
+   * {{> seeTitleEquals }}
    */
   async seeTitleEquals(text) {
     const title = await this.browser.getTitle();

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -773,11 +773,7 @@ class Puppeteer extends Helper {
   }
 
   /**
-   * Checks that title is equal to provided one.
-   *
-   * ```js
-   * I.seeTitleEquals('Test title.');
-   * ```
+   * {{> seeTitleEquals }}
    */
   async seeTitleEquals(text) {
     const title = await this.page.title();


### PR DESCRIPTION
## Motivation/Description of the PR
- fix `seeTitleEquals` Puppeteer and Protactor typings
- Resolves #issueId (if applicable).

Applicable helpers:

- [ ] WebDriver
- [x] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [x] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [] Local tests are passed (Run `npm test`)
