### PR TITLE
Step timeout not working due to override by NaN by test timeout

### DIFF
--- a/lib/listener/timeout.js
+++ b/lib/listener/timeout.js
@@ -56,7 +56,7 @@ module.exports = function () {
   });
 
   event.dispatcher.on(event.step.finished, (step) => {
-    timeout -= step.duration;
+    if (typeof timeout === 'number' && !Number.isNaN(timeout)) timeout -= step.duration;
 
     if (typeof timeout === 'number' && timeout <= 0 && recorder.isRunning()) {
       if (currentTest && currentTest.callback) {


### PR DESCRIPTION
## Motivation/Description of the PR
- In CodeceptJS 3.2.1 release step timeout is always reset to NaN so does not apply on steps when no test timeout set.
- Resolves #issueId (if applicable).

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [x] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [x] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
