### PR TITLE
Timeout operation priority according to the source

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -898,7 +898,7 @@ Run tests with plugin enabled:
 #### Configuration:
 
 -   `timeout` - global step timeout, default 150 seconds
--   `overrideTimeLimitsInCode` - whether to use timeouts set in plugin config to override step timeouts set in code with I.limitTime(x).action(...), default false
+-   `overrideStepLimits` - whether to use timeouts set in plugin config to override step timeouts set in code with I.limitTime(x).action(...), default false
 -   `noTimeoutSteps` - an array of steps with no timeout. Default:
 
     -   `amOnPage`
@@ -915,7 +915,7 @@ Run tests with plugin enabled:
 plugins: {
     stepTimeout: {
         enabled: true,
-        overrideTimeLimitsInCode: true,
+        overrideStepLimits: true,
         noTimeoutSteps: [
           'scroll*', // ignore all scroll steps
           /Cookie/, // ignore all steps with a Cookie in it (by regexp)

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -579,9 +579,9 @@ Run tests with plugin enabled:
 
 #### Configuration:
 
--   `retries` - number of retries (by default 5),
+-   `retries` - number of retries (by default 3),
 -   `when` - function, when to perform a retry (accepts error as parameter)
--   `factor` - The exponential factor to use. Default is 2.
+-   `factor` - The exponential factor to use. Default is 1.5.
 -   `minTimeout` - The number of milliseconds before starting the first retry. Default is 1000.
 -   `maxTimeout` - The maximum number of milliseconds between two retries. Default is Infinity.
 -   `randomize` - Randomizes the timeouts by multiplying with a factor between 1 to 2. Default is false.
@@ -898,7 +898,7 @@ Run tests with plugin enabled:
 #### Configuration:
 
 -   `timeout` - global step timeout, default 150 seconds
--   `force` - whether to use timeouts set in plugin config to override step timeouts set in code with I.limitTime(x).action(...), default false
+-   `overrideTimeLimitsInCode` - whether to use timeouts set in plugin config to override step timeouts set in code with I.limitTime(x).action(...), default false
 -   `noTimeoutSteps` - an array of steps with no timeout. Default:
 
     -   `amOnPage`
@@ -915,7 +915,7 @@ Run tests with plugin enabled:
 plugins: {
     stepTimeout: {
         enabled: true,
-        force: true,
+        overrideTimeLimitsInCode: true,
         noTimeoutSteps: [
           'scroll*', // ignore all scroll steps
           /Cookie/, // ignore all steps with a Cookie in it (by regexp)

--- a/lib/actor.js
+++ b/lib/actor.js
@@ -38,7 +38,7 @@ class Actor {
 
     event.dispatcher.prependOnceListener(event.step.before, (step) => {
       output.log(`Timeout to ${step}: ${timeout}s`);
-      step.setTotalTimeout(timeout * 1000, 2);
+      step.setTimeout(timeout * 1000, 25);
     });
 
     return this;
@@ -132,7 +132,7 @@ function recordStep(step, args) {
       step.startTime = Date.now();
     }
     return val = step.run(...args);
-  }, false, undefined, step.getTotalTimeout());
+  }, false, undefined, step.getTimeout());
 
   event.emit(event.step.after, step);
 

--- a/lib/actor.js
+++ b/lib/actor.js
@@ -38,7 +38,7 @@ class Actor {
 
     event.dispatcher.prependOnceListener(event.step.before, (step) => {
       output.log(`Timeout to ${step}: ${timeout}s`);
-      step.setTimeout(timeout * 1000, 25);
+      step.setTimeout(timeout * 1000, Step.TIMEOUT_ORDER.codeLimitTime);
     });
 
     return this;

--- a/lib/actor.js
+++ b/lib/actor.js
@@ -38,7 +38,7 @@ class Actor {
 
     event.dispatcher.prependOnceListener(event.step.before, (step) => {
       output.log(`Timeout to ${step}: ${timeout}s`);
-      step.totalTimeout = timeout * 1000;
+      step.setTotalTimeout(timeout * 1000, 2);
     });
 
     return this;
@@ -132,7 +132,7 @@ function recordStep(step, args) {
       step.startTime = Date.now();
     }
     return val = step.run(...args);
-  }, false, undefined, step.totalTimeout);
+  }, false, undefined, step.getTotalTimeout());
 
   event.emit(event.step.after, step);
 

--- a/lib/listener/timeout.js
+++ b/lib/listener/timeout.js
@@ -49,9 +49,9 @@ module.exports = function () {
     if (typeof timeout !== 'number') return;
 
     if (timeout < 0) {
-      step.totalTimeout = 0.01;
+      step.setTotalTimeout(0.01, 0);
     } else {
-      step.totalTimeout = timeout;
+      step.setTotalTimeout(timeout, 0);
     }
   });
 

--- a/lib/listener/timeout.js
+++ b/lib/listener/timeout.js
@@ -49,9 +49,9 @@ module.exports = function () {
     if (typeof timeout !== 'number') return;
 
     if (timeout < 0) {
-      step.setTotalTimeout(0.01, 0);
+      step.setTimeout(0.01, 5);
     } else {
-      step.setTotalTimeout(timeout, 0);
+      step.setTimeout(timeout, 5);
     }
   });
 

--- a/lib/listener/timeout.js
+++ b/lib/listener/timeout.js
@@ -3,6 +3,7 @@ const output = require('../output');
 const recorder = require('../recorder');
 const Config = require('../config');
 const { timeouts } = require('../store');
+const TIMEOUT_ORDER = require('../step').TIMEOUT_ORDER;
 
 module.exports = function () {
   let timeout;
@@ -49,9 +50,9 @@ module.exports = function () {
     if (typeof timeout !== 'number') return;
 
     if (timeout < 0) {
-      step.setTimeout(0.01, 5);
+      step.setTimeout(0.01, TIMEOUT_ORDER.testOrSuite);
     } else {
-      step.setTimeout(timeout, 5);
+      step.setTimeout(timeout, TIMEOUT_ORDER.testOrSuite);
     }
   });
 

--- a/lib/plugin/stepTimeout.js
+++ b/lib/plugin/stepTimeout.js
@@ -2,7 +2,7 @@ const event = require('../event');
 
 const defaultConfig = {
   timeout: 150,
-  force: false,
+  overrideTimeLimitsInCode: false,
   noTimeoutSteps: [
     'amOnPage',
     'wait*',
@@ -33,7 +33,7 @@ const defaultConfig = {
  * #### Configuration:
  *
  * * `timeout` - global step timeout, default 150 seconds
- * * `force` - whether to use timeouts set in plugin config to override step timeouts set in code with I.limitTime(x).action(...), default false
+ * * `overrideTimeLimitsInCode` - whether to use timeouts set in plugin config to override step timeouts set in code with I.limitTime(x).action(...), default false
  * * `noTimeoutSteps` - an array of steps with no timeout. Default:
  *     * `amOnPage`
  *     * `wait*`
@@ -49,7 +49,7 @@ const defaultConfig = {
  * plugins: {
  *     stepTimeout: {
  *         enabled: true,
- *         force: true,
+ *         overrideTimeLimitsInCode: true,
  *         noTimeoutSteps: [
  *           'scroll*', // ignore all scroll steps
  *           /Cookie/, // ignore all steps with a Cookie in it (by regexp)
@@ -85,6 +85,6 @@ module.exports = (config) => {
       }
     }
     stepTimeout = stepTimeout === undefined ? config.timeout : stepTimeout;
-    step.setTotalTimeout(stepTimeout * 1000, config.force ? 1 : 3);
+    step.setTotalTimeout(stepTimeout * 1000, config.overrideTimeLimitsInCode ? 1 : 3);
   });
 };

--- a/lib/plugin/stepTimeout.js
+++ b/lib/plugin/stepTimeout.js
@@ -2,7 +2,7 @@ const event = require('../event');
 
 const defaultConfig = {
   timeout: 150,
-  overrideTimeLimitsInCode: false,
+  overrideStepLimits: false,
   noTimeoutSteps: [
     'amOnPage',
     'wait*',
@@ -33,7 +33,7 @@ const defaultConfig = {
  * #### Configuration:
  *
  * * `timeout` - global step timeout, default 150 seconds
- * * `overrideTimeLimitsInCode` - whether to use timeouts set in plugin config to override step timeouts set in code with I.limitTime(x).action(...), default false
+ * * `overrideStepLimits` - whether to use timeouts set in plugin config to override step timeouts set in code with I.limitTime(x).action(...), default false
  * * `noTimeoutSteps` - an array of steps with no timeout. Default:
  *     * `amOnPage`
  *     * `wait*`
@@ -49,7 +49,7 @@ const defaultConfig = {
  * plugins: {
  *     stepTimeout: {
  *         enabled: true,
- *         overrideTimeLimitsInCode: true,
+ *         overrideStepLimits: true,
  *         noTimeoutSteps: [
  *           'scroll*', // ignore all scroll steps
  *           /Cookie/, // ignore all steps with a Cookie in it (by regexp)
@@ -85,6 +85,6 @@ module.exports = (config) => {
       }
     }
     stepTimeout = stepTimeout === undefined ? config.timeout : stepTimeout;
-    step.setTimeout(stepTimeout * 1000, config.overrideTimeLimitsInCode ? 15 : 35);
+    step.setTimeout(stepTimeout * 1000, config.overrideStepLimits ? 15 : 35);
   });
 };

--- a/lib/plugin/stepTimeout.js
+++ b/lib/plugin/stepTimeout.js
@@ -1,4 +1,5 @@
 const event = require('../event');
+const TIMEOUT_ORDER = require('../step').TIMEOUT_ORDER;
 
 const defaultConfig = {
   timeout: 150,
@@ -85,6 +86,6 @@ module.exports = (config) => {
       }
     }
     stepTimeout = stepTimeout === undefined ? config.timeout : stepTimeout;
-    step.setTimeout(stepTimeout * 1000, config.overrideStepLimits ? 15 : 35);
+    step.setTimeout(stepTimeout * 1000, config.overrideStepLimits ? TIMEOUT_ORDER.stepTimeoutHard : TIMEOUT_ORDER.stepTimeoutSoft);
   });
 };

--- a/lib/plugin/stepTimeout.js
+++ b/lib/plugin/stepTimeout.js
@@ -85,6 +85,6 @@ module.exports = (config) => {
       }
     }
     stepTimeout = stepTimeout === undefined ? config.timeout : stepTimeout;
-    step.totalTimeout = stepTimeout * 1000;
+    step.setTotalTimeout(stepTimeout * 1000, config.force ? 1 : 3);
   });
 };

--- a/lib/plugin/stepTimeout.js
+++ b/lib/plugin/stepTimeout.js
@@ -85,6 +85,6 @@ module.exports = (config) => {
       }
     }
     stepTimeout = stepTimeout === undefined ? config.timeout : stepTimeout;
-    step.setTotalTimeout(stepTimeout * 1000, config.overrideTimeLimitsInCode ? 1 : 3);
+    step.setTimeout(stepTimeout * 1000, config.overrideTimeLimitsInCode ? 15 : 35);
   });
 };

--- a/lib/step.js
+++ b/lib/step.js
@@ -44,14 +44,14 @@ class Step {
      * @method
      * @returns {number|undefined}
      */
-    this.getTotalTimeout = function () {
+    this.getTimeout = function () {
       let totalTimeout;
-      // iterate over all timeouts starting from highest values of source
-      new Map([...timeouts.entries()].sort().reverse()).forEach((timeout, source) => {
+      // iterate over all timeouts starting from highest values of order
+      new Map([...timeouts.entries()].sort().reverse()).forEach((timeout, order) => {
         if (timeout !== undefined && (
-          source !== 0 // souces > 0 always override value set earlier
-          || totalTimeout === undefined // source = 0 && totalTimeout === undefined => use timeout
-          || timeout > 0 && (timeout < totalTimeout || totalTimeout === 0) // source = 0 => timeout override smaller values or value of no timeout (totalTimeout === 0)
+          order >= 10 // souces >= 10 always override value set earlier
+          || totalTimeout === undefined // order = 0 && totalTimeout === undefined => use timeout
+          || timeout > 0 && (timeout < totalTimeout || totalTimeout === 0) // order < 10 => timeout override smaller values or value of no timeout (totalTimeout === 0)
         )) {
           totalTimeout = timeout;
         }
@@ -61,10 +61,10 @@ class Step {
     /**
      * @method
      * @param {number} timeout - timeout in milliseconds or 0 if no timeout
-     * @param {number} source - 0 - test/suite, 1 - config force=true, 2 - code, 3 - config force=false
+     * @param {number} order - <10 - test/suite, 10-19 - config force=true, 20-29 - code, 30-39 - config force=false
      */
-    this.setTotalTimeout = function (timeout, source = 3) {
-      timeouts.set(source, timeout);
+    this.setTimeout = function (timeout, order = 35) {
+      timeouts.set(order, timeout);
     };
 
     this.setTrace();

--- a/lib/step.js
+++ b/lib/step.js
@@ -49,9 +49,14 @@ class Step {
       // iterate over all timeouts starting from highest values of order
       new Map([...timeouts.entries()].sort().reverse()).forEach((timeout, order) => {
         if (timeout !== undefined && (
-          order >= 10 // souces >= 10 always override value set earlier
-          || totalTimeout === undefined // order = 0 && totalTimeout === undefined => use timeout
-          || timeout > 0 && (timeout < totalTimeout || totalTimeout === 0) // order < 10 => timeout override smaller values or value of no timeout (totalTimeout === 0)
+          // when orders >= 10 - timeout value overrides those set with higher order elements
+          order >= 10
+
+          // when `order < 10 && totalTimeout === undefined` - timeout is used when nothing is set by elements with higher order
+          || totalTimeout === undefined
+
+          // when `order < 10` - timeout overrides higher values of timeout or 'no timeout' (totalTimeout === 0) set by elements with higher order
+          || timeout > 0 && (timeout < totalTimeout || totalTimeout === 0)
         )) {
           totalTimeout = timeout;
         }
@@ -61,7 +66,7 @@ class Step {
     /**
      * @method
      * @param {number} timeout - timeout in milliseconds or 0 if no timeout
-     * @param {number} order - <10 - test/suite, 10-19 - config force=true, 20-29 - code, 30-39 - config force=false
+     * @param {number} order - <10 - test/suite, 10-19 - config when set to override timeouts from code, 20-29 - code, 30-39 - config
      */
     this.setTimeout = function (timeout, order = 35) {
       timeouts.set(order, timeout);

--- a/lib/step.js
+++ b/lib/step.js
@@ -13,6 +13,27 @@ const STACK_LINE = 4;
  * @param {string} name
  */
 class Step {
+  static get TIMEOUT_ORDER() {
+    return {
+      /**
+       * timeouts set with order below zero only override timeouts of higher order if their value is smaller
+       */
+      testOrSuite: -5,
+      /**
+       * 0-9 - designated for override of timeouts set from code, 5 is used by stepTimeout plugin when stepTimeout.config.overrideStepLimits=true
+       */
+      stepTimeoutHard: 5,
+      /**
+       * 10-19 - designated for timeouts set from code, 15 is order of I.setTimeout(t) operation
+       */
+      codeLimitTime: 15,
+      /**
+       * 20-29 - designated for timeout settings which could be overriden in tests code, 25 is used by stepTimeout plugin when stepTimeout.config.overrideStepLimits=false
+       */
+      stepTimeoutSoft: 25,
+    };
+  }
+
   constructor(helper, name) {
     /** @member {string} */
     this.actor = 'I'; // I = actor
@@ -49,13 +70,13 @@ class Step {
       // iterate over all timeouts starting from highest values of order
       new Map([...timeouts.entries()].sort().reverse()).forEach((timeout, order) => {
         if (timeout !== undefined && (
-          // when orders >= 10 - timeout value overrides those set with higher order elements
-          order >= 10
+          // when orders >= 0 - timeout value overrides those set with higher order elements
+          order >= 0
 
-          // when `order < 10 && totalTimeout === undefined` - timeout is used when nothing is set by elements with higher order
+          // when `order < 0 && totalTimeout === undefined` - timeout is used when nothing is set by elements with higher order
           || totalTimeout === undefined
 
-          // when `order < 10` - timeout overrides higher values of timeout or 'no timeout' (totalTimeout === 0) set by elements with higher order
+          // when `order < 0` - timeout overrides higher values of timeout or 'no timeout' (totalTimeout === 0) set by elements with higher order
           || timeout > 0 && (timeout < totalTimeout || totalTimeout === 0)
         )) {
           totalTimeout = timeout;
@@ -66,9 +87,10 @@ class Step {
     /**
      * @method
      * @param {number} timeout - timeout in milliseconds or 0 if no timeout
-     * @param {number} order - <10 - test/suite, 10-19 - config when set to override timeouts from code, 20-29 - code, 30-39 - config
+     * @param {number} order - order defines the priority of timeout, timeouts set with lower order override those set with higher order.
+     *                         When order below 0 value of timeout only override if new value is lower
      */
-    this.setTimeout = function (timeout, order = 35) {
+    this.setTimeout = function (timeout, order) {
       timeouts.set(order, timeout);
     };
 
@@ -261,6 +283,8 @@ class MetaStep extends Step {
     return result;
   }
 }
+
+Step.TIMEOUTS = {};
 
 /** @type {Class<MetaStep>} */
 Step.MetaStep = MetaStep;

--- a/lib/step.js
+++ b/lib/step.js
@@ -40,7 +40,10 @@ class Step {
     this.stack = '';
 
     const timeouts = new Map();
-    /** @method {number} */
+    /**
+     * @method
+     * @returns {number|undefined}
+     */
     this.getTotalTimeout = function () {
       let totalTimeout;
       // iterate over all timeouts starting from highest values of source

--- a/lib/step.js
+++ b/lib/step.js
@@ -38,8 +38,31 @@ class Step {
     this.metaStep = undefined;
     /** @member {string} */
     this.stack = '';
-    /** @member {number} */
-    this.totalTimeout = undefined;
+
+    const timeouts = new Map();
+    /** @method {number} */
+    this.getTotalTimeout = function () {
+      let totalTimeout;
+      // iterate over all timeouts starting from highest values of source
+      new Map([...timeouts.entries()].sort().reverse()).forEach((timeout, source) => {
+        if (timeout !== undefined && (
+          source !== 0 // souces > 0 always override value set earlier
+          || totalTimeout === undefined // source = 0 && totalTimeout === undefined => use timeout
+          || timeout > 0 && (timeout < totalTimeout || totalTimeout === 0) // source = 0 => timeout override smaller values or value of no timeout (totalTimeout === 0)
+        )) {
+          totalTimeout = timeout;
+        }
+      });
+      return totalTimeout;
+    };
+    /**
+     * @method
+     * @param {number} timeout - timeout in milliseconds or 0 if no timeout
+     * @param {number} source - 0 - test/suite, 1 - config force=true, 2 - code, 3 - config force=false
+     */
+    this.setTotalTimeout = function (timeout, source = 3) {
+      timeouts.set(source, timeout);
+    };
 
     this.setTrace();
   }


### PR DESCRIPTION
## Motivation/Description of the PR
- Step timeout is set form multiple sources and need to be selected using following logic:
  - between step timeout set on action from code with `I.limitTime` and timeout set with configuration of stepTimeout plugin one from the code has priority unless stepTimeout.config.force===true
  - test/suite timeout counter update stepTimeout if it is smaller than stepTimeout set from other sources. 
- Resolves #issueId (if applicable).

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [x] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [x] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [x] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
