### PR TITLE
Github actions could skip playwright browser download where browser not used

### DIFF
--- a/.github/workflows/appium.yml
+++ b/.github/workflows/appium.yml
@@ -24,7 +24,9 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - run: PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = true npm install
+    - run: npm install
+      env:
+        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: true
     - run: 'npm run test:appium-quick'
       env: # Or as an environment variable
         SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}

--- a/.github/workflows/appium.yml
+++ b/.github/workflows/appium.yml
@@ -27,6 +27,7 @@ jobs:
     - run: npm install
       env:
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: true
+        PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
     - run: 'npm run test:appium-quick'
       env: # Or as an environment variable
         SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
@@ -50,6 +51,7 @@ jobs:
     - run: npm install
       env:
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: true
+        PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
     - run: 'npm run test:appium-other'
       env: # Or as an environment variable
         SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}

--- a/.github/workflows/appium.yml
+++ b/.github/workflows/appium.yml
@@ -24,7 +24,7 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - run: npm install
+    - run: PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = true npm install
     - run: 'npm run test:appium-quick'
       env: # Or as an environment variable
         SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
@@ -46,6 +46,8 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm install
+      env:
+        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: true
     - run: 'npm run test:appium-other'
       env: # Or as an environment variable
         SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}

--- a/.github/workflows/dtslint.yml
+++ b/.github/workflows/dtslint.yml
@@ -21,5 +21,7 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm install
+      env:
+        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: true
     - run: npm run def
     - run: npm run dtslint

--- a/.github/workflows/dtslint.yml
+++ b/.github/workflows/dtslint.yml
@@ -23,5 +23,6 @@ jobs:
     - run: npm install
       env:
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: true
+        PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
     - run: npm run def
     - run: npm run dtslint

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -35,6 +35,8 @@ jobs:
     - name: npm install
       run: |
         npm install
+      env:
+        PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
     - name: start a server
       run: "php -S 127.0.0.1:8000 -t test/data/app &"
     - name: run chromium tests

--- a/.github/workflows/puppeteer.yml
+++ b/.github/workflows/puppeteer.yml
@@ -34,6 +34,8 @@ jobs:
     - name: npm install
       run: |
         npm install
+      env:
+        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: true
     - name: start a server
       run: "php -S 127.0.0.1:8000 -t test/data/app &"
     - name: run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,4 +24,6 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm install
+      env:
+        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: true
     - run: npm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,4 +26,5 @@ jobs:
     - run: npm install
       env:
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: true
+        PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
     - run: npm test

--- a/.github/workflows/testcafe.yml
+++ b/.github/workflows/testcafe.yml
@@ -37,6 +37,7 @@ jobs:
         npm install
       env:
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: true
+        PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
     - name: start a server
       run: "php -S 127.0.0.1:8000 -t test/data/app &"
     - name: run unit tests

--- a/.github/workflows/testcafe.yml
+++ b/.github/workflows/testcafe.yml
@@ -35,6 +35,8 @@ jobs:
     - name: npm install
       run: |
         npm install
+      env:
+        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: true
     - name: start a server
       run: "php -S 127.0.0.1:8000 -t test/data/app &"
     - name: run unit tests

--- a/.github/workflows/webdriver.yml
+++ b/.github/workflows/webdriver.yml
@@ -37,6 +37,7 @@ jobs:
         npm install
       env:
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: true
+        PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
     - name: start a server
       run: "php -S 127.0.0.1:8000 -t test/data/app &"
     - name: run unit tests

--- a/.github/workflows/webdriver.yml
+++ b/.github/workflows/webdriver.yml
@@ -35,6 +35,8 @@ jobs:
     - name: npm install
       run: |
         npm install
+      env:
+        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: true
     - name: start a server
       run: "php -S 127.0.0.1:8000 -t test/data/app &"
     - name: run unit tests


### PR DESCRIPTION
## Motivation/Description of the PR
- Build is going to be a bit faster when `npm install` skips downloading of browsers for framework not tested in pipeline
- Resolves #issueId (if applicable).

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
