### PR TITLE
support channel for chromium playwright

### DIFF
--- a/docs/helpers/Playwright.md
+++ b/docs/helpers/Playwright.md
@@ -51,6 +51,7 @@ This helper should be configured in codecept.json or codecept.conf.js
 -   `manualStart`:  - do not start browser before a test, start it manually inside a helper with `this.helpers["Playwright"]._startBrowser()`.
 -   `chromium`: (optional) pass additional chromium options
 -   `electron`: (optional) pass additional electron options
+-   `channel`: (optional) While Playwright can operate against the stock Google Chrome and Microsoft Edge browsers available on the machine. In particular, current Playwright version will support Stable and Beta channels of these browsers. See [Google Chrome & Microsoft Edge][4].
 
 #### Video Recording Customization
 
@@ -58,7 +59,7 @@ By default, video is saved to `output/video` dir. You can customize this path by
 
 -   `video`: enables video recording for failed tests; videos are saved into `output/videos` folder
 -   `keepVideoForPassedTests`: - save videos for passed tests
--   `recordVideo`: [additional options for videos customization][4]
+-   `recordVideo`: [additional options for videos customization][5]
 
 #### Trace Recording Customization
 
@@ -111,7 +112,7 @@ Traces will be saved to `output/trace`
 }
 ```
 
-#### Example #4: Connect to remote browser by specifying [websocket endpoint][5]
+#### Example #4: Connect to remote browser by specifying [websocket endpoint][6]
 
 ```js
 {
@@ -128,7 +129,7 @@ Traces will be saved to `output/trace`
 
 #### Example #5: Testing with Chromium extensions
 
-[official docs][6]
+[official docs][7]
 
 ```js
 {
@@ -277,13 +278,13 @@ Set current page
 
 #### Parameters
 
--   `page` **[object][7]** page to set
+-   `page` **[object][8]** page to set
 
 ### acceptPopup
 
 Accepts the active JavaScript native popup window, as created by window.alert|window.confirm|window.prompt.
 Don't confuse popups with modal windows, as created by [various
-libraries][8].
+libraries][9].
 
 ### amAcceptingPopups
 
@@ -320,7 +321,7 @@ I.amOnPage('/login'); // opens a login page
 
 #### Parameters
 
--   `url` **[string][9]** url path or global url.
+-   `url` **[string][10]** url path or global url.
 
 ### appendField
 
@@ -333,8 +334,8 @@ I.appendField('#myTextField', 'appended');
 
 #### Parameters
 
--   `field` **([string][9] | [object][7])** located by label|name|CSS|XPath|strict locator
--   `value` **[string][9]** text value to append.
+-   `field` **([string][10] | [object][8])** located by label|name|CSS|XPath|strict locator
+-   `value` **[string][10]** text value to append.
 
 ### attachFile
 
@@ -349,8 +350,8 @@ I.attachFile('form input[name=avatar]', 'data/avatar.jpg');
 
 #### Parameters
 
--   `locator` **([string][9] | [object][7])** field located by label|name|CSS|XPath|strict locator.
--   `pathToFile` **[string][9]** local file path relative to codecept.json config file.
+-   `locator` **([string][10] | [object][8])** field located by label|name|CSS|XPath|strict locator.
+-   `pathToFile` **[string][10]** local file path relative to codecept.json config file.
 
 ### cancelPopup
 
@@ -371,8 +372,8 @@ I.checkOption('agree', '//form');
 
 #### Parameters
 
--   `field` **([string][9] | [object][7])** checkbox located by label | name | CSS | XPath | strict locator.
--   `context` **([string][9]? | [object][7])** (optional, `null` by default) element located by CSS | XPath | strict locator. 
+-   `field` **([string][10] | [object][8])** checkbox located by label | name | CSS | XPath | strict locator.
+-   `context` **([string][10]? | [object][8])** (optional, `null` by default) element located by CSS | XPath | strict locator. 
 
 ### clearCookie
 
@@ -386,7 +387,7 @@ I.clearCookie('test');
 
 #### Parameters
 
--   `cookie` **[string][9]?** (optional, `null` by default) cookie name 
+-   `cookie` **[string][10]?** (optional, `null` by default) cookie name 
 
 ### clearField
 
@@ -401,7 +402,7 @@ I.clearField('#email');
 #### Parameters
 
 -   `field`  
--   `editable` **([string][9] | [object][7])** field located by label|name|CSS|XPath|strict locator.
+-   `editable` **([string][10] | [object][8])** field located by label|name|CSS|XPath|strict locator.
 
 ### click
 
@@ -429,8 +430,8 @@ I.click({css: 'nav a.login'});
 
 #### Parameters
 
--   `locator` **([string][9] | [object][7])** clickable link or button located by text, or any element located by CSS|XPath|strict locator.
--   `context` **([string][9]? | [object][7])** (optional, `null` by default) element to search in CSS|XPath|Strict locator. 
+-   `locator` **([string][10] | [object][8])** clickable link or button located by text, or any element located by CSS|XPath|strict locator.
+-   `context` **([string][10]? | [object][8])** (optional, `null` by default) element to search in CSS|XPath|Strict locator. 
 
 ### clickLink
 
@@ -469,8 +470,8 @@ I.dontSee('Login', '.nav'); // no login inside .nav element
 
 #### Parameters
 
--   `text` **[string][9]** which is not present.
--   `context` **([string][9] | [object][7])?** (optional) element located by CSS|XPath|strict locator in which to perfrom search. 
+-   `text` **[string][10]** which is not present.
+-   `context` **([string][10] | [object][8])?** (optional) element located by CSS|XPath|strict locator in which to perfrom search. 
 
 ### dontSeeCheckboxIsChecked
 
@@ -484,7 +485,7 @@ I.dontSeeCheckboxIsChecked('agree'); // located by name
 
 #### Parameters
 
--   `field` **([string][9] | [object][7])** located by label|name|CSS|XPath|strict locator.
+-   `field` **([string][10] | [object][8])** located by label|name|CSS|XPath|strict locator.
 
 ### dontSeeCookie
 
@@ -496,7 +497,7 @@ I.dontSeeCookie('auth'); // no auth cookie
 
 #### Parameters
 
--   `name` **[string][9]** cookie name.
+-   `name` **[string][10]** cookie name.
 
 ### dontSeeCurrentUrlEquals
 
@@ -510,7 +511,7 @@ I.dontSeeCurrentUrlEquals('http://mysite.com/login'); // absolute urls are also 
 
 #### Parameters
 
--   `url` **[string][9]** value to check.
+-   `url` **[string][10]** value to check.
 
 ### dontSeeElement
 
@@ -522,7 +523,7 @@ I.dontSeeElement('.modal'); // modal is not shown
 
 #### Parameters
 
--   `locator` **([string][9] | [object][7])** located by CSS|XPath|Strict locator.
+-   `locator` **([string][10] | [object][8])** located by CSS|XPath|Strict locator.
 
 ### dontSeeElementInDOM
 
@@ -534,7 +535,7 @@ I.dontSeeElementInDOM('.nav'); // checks that element is not on page visible or 
 
 #### Parameters
 
--   `locator` **([string][9] | [object][7])** located by CSS|XPath|Strict locator.
+-   `locator` **([string][10] | [object][8])** located by CSS|XPath|Strict locator.
 
 ### dontSeeInCurrentUrl
 
@@ -542,7 +543,7 @@ Checks that current url does not contain a provided fragment.
 
 #### Parameters
 
--   `url` **[string][9]** value to check.
+-   `url` **[string][10]** value to check.
 
 ### dontSeeInField
 
@@ -556,8 +557,8 @@ I.dontSeeInField({ css: 'form input.email' }, 'user@user.com'); // field by CSS
 
 #### Parameters
 
--   `field` **([string][9] | [object][7])** located by label|name|CSS|XPath|strict locator.
--   `value` **[string][9]** value to check.
+-   `field` **([string][10] | [object][8])** located by label|name|CSS|XPath|strict locator.
+-   `value` **[string][10]** value to check.
 
 ### dontSeeInSource
 
@@ -570,7 +571,7 @@ I.dontSeeInSource('<!--'); // no comments in source
 #### Parameters
 
 -   `text`  
--   `value` **[string][9]** to check.
+-   `value` **[string][10]** to check.
 
 ### dontSeeInTitle
 
@@ -582,7 +583,7 @@ I.dontSeeInTitle('Error');
 
 #### Parameters
 
--   `text` **[string][9]** value to check.
+-   `text` **[string][10]** value to check.
 
 ### doubleClick
 
@@ -598,8 +599,8 @@ I.doubleClick('.btn.edit');
 
 #### Parameters
 
--   `locator` **([string][9] | [object][7])** clickable link or button located by text, or any element located by CSS|XPath|strict locator.
--   `context` **([string][9]? | [object][7])** (optional, `null` by default) element to search in CSS|XPath|Strict locator. 
+-   `locator` **([string][10] | [object][8])** clickable link or button located by text, or any element located by CSS|XPath|strict locator.
+-   `context` **([string][10]? | [object][8])** (optional, `null` by default) element to search in CSS|XPath|Strict locator. 
 
 ### dragAndDrop
 
@@ -611,8 +612,8 @@ I.dragAndDrop('#dragHandle', '#container');
 
 #### Parameters
 
--   `srcElement` **([string][9] | [object][7])** located by CSS|XPath|strict locator.
--   `destElement` **([string][9] | [object][7])** located by CSS|XPath|strict locator.
+-   `srcElement` **([string][10] | [object][8])** located by CSS|XPath|strict locator.
+-   `destElement` **([string][10] | [object][8])** located by CSS|XPath|strict locator.
 
 ### dragSlider
 
@@ -626,8 +627,8 @@ I.dragSlider('#slider', -70);
 
 #### Parameters
 
--   `locator` **([string][9] | [object][7])** located by label|name|CSS|XPath|strict locator.
--   `offsetX` **[number][10]** position to drag. 
+-   `locator` **([string][10] | [object][8])** located by label|name|CSS|XPath|strict locator.
+-   `offsetX` **[number][11]** position to drag. 
 
 ### executeScript
 
@@ -654,10 +655,10 @@ If a function returns a Promise it will wait for its resolution.
 
 #### Parameters
 
--   `fn` **([string][9] | [function][11])** function to be executed in browser context.
+-   `fn` **([string][10] | [function][12])** function to be executed in browser context.
 -   `arg` **any?** optional argument to pass to the function
 
-Returns **[Promise][12]&lt;any>** 
+Returns **[Promise][13]&lt;any>** 
 
 ### fillField
 
@@ -677,8 +678,8 @@ I.fillField({css: 'form#login input[name=username]'}, 'John');
 
 #### Parameters
 
--   `field` **([string][9] | [object][7])** located by label|name|CSS|XPath|strict locator.
--   `value` **([string][9] | [object][7])** text value to fill.
+-   `field` **([string][10] | [object][8])** located by label|name|CSS|XPath|strict locator.
+-   `value` **([string][10] | [object][8])** text value to fill.
 
 ### forceClick
 
@@ -709,8 +710,8 @@ I.forceClick({css: 'nav a.login'});
 
 #### Parameters
 
--   `locator` **([string][9] | [object][7])** clickable link or button located by text, or any element located by CSS|XPath|strict locator.
--   `context` **([string][9]? | [object][7])** (optional, `null` by default) element to search in CSS|XPath|Strict locator. 
+-   `locator` **([string][10] | [object][8])** clickable link or button located by text, or any element located by CSS|XPath|strict locator.
+-   `context` **([string][10]? | [object][8])** (optional, `null` by default) element to search in CSS|XPath|Strict locator. 
 
 ### grabAttributeFrom
 
@@ -724,10 +725,10 @@ let hint = await I.grabAttributeFrom('#tooltip', 'title');
 
 #### Parameters
 
--   `locator` **([string][9] | [object][7])** element located by CSS|XPath|strict locator.
--   `attr` **[string][9]** attribute name.
+-   `locator` **([string][10] | [object][8])** element located by CSS|XPath|strict locator.
+-   `attr` **[string][10]** attribute name.
 
-Returns **[Promise][12]&lt;[string][9]>** attribute value
+Returns **[Promise][13]&lt;[string][10]>** attribute value
 
 ### grabAttributeFromAll
 
@@ -740,10 +741,10 @@ let hints = await I.grabAttributeFromAll('.tooltip', 'title');
 
 #### Parameters
 
--   `locator` **([string][9] | [object][7])** element located by CSS|XPath|strict locator.
--   `attr` **[string][9]** attribute name.
+-   `locator` **([string][10] | [object][8])** element located by CSS|XPath|strict locator.
+-   `attr` **[string][10]** attribute name.
 
-Returns **[Promise][12]&lt;[Array][13]&lt;[string][9]>>** attribute value
+Returns **[Promise][13]&lt;[Array][14]&lt;[string][10]>>** attribute value
 
 ### grabBrowserLogs
 
@@ -754,7 +755,7 @@ let logs = await I.grabBrowserLogs();
 console.log(JSON.stringify(logs))
 ```
 
-Returns **[Promise][12]&lt;[Array][13]&lt;any>>** 
+Returns **[Promise][13]&lt;[Array][14]&lt;any>>** 
 
 ### grabCookie
 
@@ -769,9 +770,9 @@ assert(cookie.value, '123456');
 
 #### Parameters
 
--   `name` **[string][9]?** cookie name. 
+-   `name` **[string][10]?** cookie name. 
 
-Returns **([Promise][12]&lt;[string][9]> | [Promise][12]&lt;[Array][13]&lt;[string][9]>>)** attribute valueReturns cookie in JSON format. If name not passed returns all cookies for this domain.
+Returns **([Promise][13]&lt;[string][10]> | [Promise][13]&lt;[Array][14]&lt;[string][10]>>)** attribute valueReturns cookie in JSON format. If name not passed returns all cookies for this domain.
 
 ### grabCssPropertyFrom
 
@@ -785,10 +786,10 @@ const value = await I.grabCssPropertyFrom('h3', 'font-weight');
 
 #### Parameters
 
--   `locator` **([string][9] | [object][7])** element located by CSS|XPath|strict locator.
--   `cssProperty` **[string][9]** CSS property name.
+-   `locator` **([string][10] | [object][8])** element located by CSS|XPath|strict locator.
+-   `cssProperty` **[string][10]** CSS property name.
 
-Returns **[Promise][12]&lt;[string][9]>** CSS value
+Returns **[Promise][13]&lt;[string][10]>** CSS value
 
 ### grabCssPropertyFromAll
 
@@ -801,10 +802,10 @@ const values = await I.grabCssPropertyFromAll('h3', 'font-weight');
 
 #### Parameters
 
--   `locator` **([string][9] | [object][7])** element located by CSS|XPath|strict locator.
--   `cssProperty` **[string][9]** CSS property name.
+-   `locator` **([string][10] | [object][8])** element located by CSS|XPath|strict locator.
+-   `cssProperty` **[string][10]** CSS property name.
 
-Returns **[Promise][12]&lt;[Array][13]&lt;[string][9]>>** CSS value
+Returns **[Promise][13]&lt;[Array][14]&lt;[string][10]>>** CSS value
 
 ### grabCurrentUrl
 
@@ -816,7 +817,7 @@ let url = await I.grabCurrentUrl();
 console.log(`Current URL is [${url}]`);
 ```
 
-Returns **[Promise][12]&lt;[string][9]>** current URL
+Returns **[Promise][13]&lt;[string][10]>** current URL
 
 ### grabDataFromPerformanceTiming
 
@@ -863,11 +864,11 @@ const width = await I.grabElementBoundingRect('h3', 'width');
 
 #### Parameters
 
--   `locator` **([string][9] | [object][7])** element located by CSS|XPath|strict locator.
+-   `locator` **([string][10] | [object][8])** element located by CSS|XPath|strict locator.
 -   `prop`  
--   `elementSize` **[string][9]?** x, y, width or height of the given element.
+-   `elementSize` **[string][10]?** x, y, width or height of the given element.
 
-Returns **([Promise][12]&lt;DOMRect> | [Promise][12]&lt;[number][10]>)** Element bounding rectangle
+Returns **([Promise][13]&lt;DOMRect> | [Promise][13]&lt;[number][11]>)** Element bounding rectangle
 
 ### grabHTMLFrom
 
@@ -882,9 +883,9 @@ let postHTML = await I.grabHTMLFrom('#post');
 #### Parameters
 
 -   `locator`  
--   `element` **([string][9] | [object][7])** located by CSS|XPath|strict locator.
+-   `element` **([string][10] | [object][8])** located by CSS|XPath|strict locator.
 
-Returns **[Promise][12]&lt;[string][9]>** HTML code for an element
+Returns **[Promise][13]&lt;[string][10]>** HTML code for an element
 
 ### grabHTMLFromAll
 
@@ -898,9 +899,9 @@ let postHTMLs = await I.grabHTMLFromAll('.post');
 #### Parameters
 
 -   `locator`  
--   `element` **([string][9] | [object][7])** located by CSS|XPath|strict locator.
+-   `element` **([string][10] | [object][8])** located by CSS|XPath|strict locator.
 
-Returns **[Promise][12]&lt;[Array][13]&lt;[string][9]>>** HTML code for an element
+Returns **[Promise][13]&lt;[Array][14]&lt;[string][10]>>** HTML code for an element
 
 ### grabNumberOfOpenTabs
 
@@ -911,7 +912,7 @@ Resumes test execution, so **should be used inside async function with `await`**
 let tabs = await I.grabNumberOfOpenTabs();
 ```
 
-Returns **[Promise][12]&lt;[number][10]>** number of open tabs
+Returns **[Promise][13]&lt;[number][11]>** number of open tabs
 
 ### grabNumberOfVisibleElements
 
@@ -924,9 +925,9 @@ let numOfElements = await I.grabNumberOfVisibleElements('p');
 
 #### Parameters
 
--   `locator` **([string][9] | [object][7])** located by CSS|XPath|strict locator.
+-   `locator` **([string][10] | [object][8])** located by CSS|XPath|strict locator.
 
-Returns **[Promise][12]&lt;[number][10]>** number of visible elements
+Returns **[Promise][13]&lt;[number][11]>** number of visible elements
 
 ### grabPageScrollPosition
 
@@ -937,7 +938,7 @@ Resumes test execution, so **should be used inside an async function with `await
 let { x, y } = await I.grabPageScrollPosition();
 ```
 
-Returns **[Promise][12]&lt;PageScrollPosition>** scroll position
+Returns **[Promise][13]&lt;PageScrollPosition>** scroll position
 
 ### grabPopupText
 
@@ -947,7 +948,7 @@ Grab the text within the popup. If no popup is visible then it will return null
 await I.grabPopupText();
 ```
 
-Returns **[Promise][12]&lt;([string][9] | null)>** 
+Returns **[Promise][13]&lt;([string][10] | null)>** 
 
 ### grabSource
 
@@ -958,7 +959,7 @@ Resumes test execution, so **should be used inside async function with `await`**
 let pageSource = await I.grabSource();
 ```
 
-Returns **[Promise][12]&lt;[string][9]>** source code
+Returns **[Promise][13]&lt;[string][10]>** source code
 
 ### grabTextFrom
 
@@ -973,9 +974,9 @@ If multiple elements found returns first element.
 
 #### Parameters
 
--   `locator` **([string][9] | [object][7])** element located by CSS|XPath|strict locator.
+-   `locator` **([string][10] | [object][8])** element located by CSS|XPath|strict locator.
 
-Returns **[Promise][12]&lt;[string][9]>** attribute value
+Returns **[Promise][13]&lt;[string][10]>** attribute value
 
 ### grabTextFromAll
 
@@ -988,9 +989,9 @@ let pins = await I.grabTextFromAll('#pin li');
 
 #### Parameters
 
--   `locator` **([string][9] | [object][7])** element located by CSS|XPath|strict locator.
+-   `locator` **([string][10] | [object][8])** element located by CSS|XPath|strict locator.
 
-Returns **[Promise][12]&lt;[Array][13]&lt;[string][9]>>** attribute value
+Returns **[Promise][13]&lt;[Array][14]&lt;[string][10]>>** attribute value
 
 ### grabTitle
 
@@ -1001,7 +1002,7 @@ Resumes test execution, so **should be used inside async with `await`** operator
 let title = await I.grabTitle();
 ```
 
-Returns **[Promise][12]&lt;[string][9]>** title
+Returns **[Promise][13]&lt;[string][10]>** title
 
 ### grabValueFrom
 
@@ -1015,9 +1016,9 @@ let email = await I.grabValueFrom('input[name=email]');
 
 #### Parameters
 
--   `locator` **([string][9] | [object][7])** field located by label|name|CSS|XPath|strict locator.
+-   `locator` **([string][10] | [object][8])** field located by label|name|CSS|XPath|strict locator.
 
-Returns **[Promise][12]&lt;[string][9]>** attribute value
+Returns **[Promise][13]&lt;[string][10]>** attribute value
 
 ### grabValueFromAll
 
@@ -1030,16 +1031,16 @@ let inputs = await I.grabValueFromAll('//form/input');
 
 #### Parameters
 
--   `locator` **([string][9] | [object][7])** field located by label|name|CSS|XPath|strict locator.
+-   `locator` **([string][10] | [object][8])** field located by label|name|CSS|XPath|strict locator.
 
-Returns **[Promise][12]&lt;[Array][13]&lt;[string][9]>>** attribute value
+Returns **[Promise][13]&lt;[Array][14]&lt;[string][10]>>** attribute value
 
 ### handleDownloads
 
 Handles a file download.Aa file name is required to save the file on disk.
 Files are saved to "output" directory.
 
-Should be used with [FileSystem helper][14] to check that file were downloaded correctly.
+Should be used with [FileSystem helper][15] to check that file were downloaded correctly.
 
 ```js
 I.handleDownloads('downloads/avatar.jpg');
@@ -1050,7 +1051,7 @@ I.waitForFile('downloads/avatar.jpg', 5);
 
 #### Parameters
 
--   `fileName` **[string][9]?** set filename for downloaded file 
+-   `fileName` **[string][10]?** set filename for downloaded file 
 
 ### haveRequestHeaders
 
@@ -1064,22 +1065,22 @@ I.haveRequestHeaders({
 
 #### Parameters
 
--   `customHeaders` **[object][7]** headers to set
+-   `customHeaders` **[object][8]** headers to set
 
 ### mockRoute
 
-Mocks network request using [`browserContext.route`][15] of Playwright
+Mocks network request using [`browserContext.route`][16] of Playwright
 
 ```js
 I.mockRoute(/(.png$)|(.jpg$)/, route => route.abort());
 ```
 
-This method allows intercepting and mocking requests & responses. [Learn more about it][16]
+This method allows intercepting and mocking requests & responses. [Learn more about it][17]
 
 #### Parameters
 
--   `url` **[string][9]?** URL, regex or pattern for to match URL
--   `handler` **[function][11]?** a function to process request
+-   `url` **[string][10]?** URL, regex or pattern for to match URL
+-   `handler` **[function][12]?** a function to process request
 
 ### moveCursorTo
 
@@ -1093,9 +1094,9 @@ I.moveCursorTo('#submit', 5,5);
 
 #### Parameters
 
--   `locator` **([string][9] | [object][7])** located by CSS|XPath|strict locator.
--   `offsetX` **[number][10]** (optional, `0` by default) X-axis offset. 
--   `offsetY` **[number][10]** (optional, `0` by default) Y-axis offset. 
+-   `locator` **([string][10] | [object][8])** located by CSS|XPath|strict locator.
+-   `offsetX` **[number][11]** (optional, `0` by default) X-axis offset. 
+-   `offsetY` **[number][11]** (optional, `0` by default) Y-axis offset. 
 
 ### openNewTab
 
@@ -1105,7 +1106,7 @@ Open new tab and automatically switched to new tab
 I.openNewTab();
 ```
 
-You can pass in [page options][17] to emulate device on this page
+You can pass in [page options][18] to emulate device on this page
 
 ```js
 // enable mobile
@@ -1120,7 +1121,7 @@ I.openNewTab({ isMobile: true });
 
 Presses a key in the browser (on a focused element).
 
-_Hint:_ For populating text field or textarea, it is recommended to use [`fillField`][18].
+_Hint:_ For populating text field or textarea, it is recommended to use [`fillField`][19].
 
 ```js
 I.pressKey('Backspace');
@@ -1179,13 +1180,13 @@ Some of the supported key names are:
 
 #### Parameters
 
--   `key` **([string][9] | [Array][13]&lt;[string][9]>)** key or array of keys to press._Note:_ Shortcuts like `'Meta'` + `'A'` do not work on macOS ([GoogleChrome/Puppeteer#1313][19]).
+-   `key` **([string][10] | [Array][14]&lt;[string][10]>)** key or array of keys to press._Note:_ Shortcuts like `'Meta'` + `'A'` do not work on macOS ([GoogleChrome/Puppeteer#1313][20]).
 
 ### pressKeyDown
 
 Presses a key in the browser and leaves it in a down state.
 
-To make combinations with modifier key and user operation (e.g. `'Control'` + [`click`][20]).
+To make combinations with modifier key and user operation (e.g. `'Control'` + [`click`][21]).
 
 ```js
 I.pressKeyDown('Control');
@@ -1195,13 +1196,13 @@ I.pressKeyUp('Control');
 
 #### Parameters
 
--   `key` **[string][9]** name of key to press down.
+-   `key` **[string][10]** name of key to press down.
 
 ### pressKeyUp
 
 Releases a key in the browser which was previously set to a down state.
 
-To make combinations with modifier key and user operation (e.g. `'Control'` + [`click`][20]).
+To make combinations with modifier key and user operation (e.g. `'Control'` + [`click`][21]).
 
 ```js
 I.pressKeyDown('Control');
@@ -1211,7 +1212,7 @@ I.pressKeyUp('Control');
 
 #### Parameters
 
--   `key` **[string][9]** name of key to release.
+-   `key` **[string][10]** name of key to release.
 
 ### refreshPage
 
@@ -1228,8 +1229,8 @@ First parameter can be set to `maximize`.
 
 #### Parameters
 
--   `width` **[number][10]** width in pixels or `maximize`.
--   `height` **[number][10]** height in pixels.Unlike other drivers Playwright changes the size of a viewport, not the window!
+-   `width` **[number][11]** width in pixels or `maximize`.
+-   `height` **[number][11]** height in pixels.Unlike other drivers Playwright changes the size of a viewport, not the window!
     Playwright does not control the window of a browser so it can't adjust its real size.
     It also can't maximize a window.Update configuration to change real window size on start:```js
     // inside codecept.conf.js
@@ -1252,8 +1253,8 @@ I.rightClick('Click me', '.context');
 
 #### Parameters
 
--   `locator` **([string][9] | [object][7])** clickable element located by CSS|XPath|strict locator.
--   `context` **([string][9]? | [object][7])** (optional, `null` by default) element located by CSS|XPath|strict locator. 
+-   `locator` **([string][10] | [object][8])** clickable element located by CSS|XPath|strict locator.
+-   `context` **([string][10]? | [object][8])** (optional, `null` by default) element located by CSS|XPath|strict locator. 
 
 ### saveElementScreenshot
 
@@ -1266,8 +1267,8 @@ I.saveElementScreenshot(`#submit`,'debug.png');
 
 #### Parameters
 
--   `locator` **([string][9] | [object][7])** element located by CSS|XPath|strict locator.
--   `fileName` **[string][9]** file name to save.
+-   `locator` **([string][10] | [object][8])** element located by CSS|XPath|strict locator.
+-   `fileName` **[string][10]** file name to save.
 
 ### saveScreenshot
 
@@ -1282,8 +1283,8 @@ I.saveScreenshot('debug.png', true) //resizes to available scrollHeight and scro
 
 #### Parameters
 
--   `fileName` **[string][9]** file name to save.
--   `fullPage` **[boolean][21]** (optional, `false` by default) flag to enable fullscreen screenshot mode. 
+-   `fileName` **[string][10]** file name to save.
+-   `fullPage` **[boolean][22]** (optional, `false` by default) flag to enable fullscreen screenshot mode. 
 
 ### scrollPageToBottom
 
@@ -1313,9 +1314,9 @@ I.scrollTo('#submit', 5, 5);
 
 #### Parameters
 
--   `locator` **([string][9] | [object][7])** located by CSS|XPath|strict locator.
--   `offsetX` **[number][10]** (optional, `0` by default) X-axis offset. 
--   `offsetY` **[number][10]** (optional, `0` by default) Y-axis offset. 
+-   `locator` **([string][10] | [object][8])** located by CSS|XPath|strict locator.
+-   `offsetX` **[number][11]** (optional, `0` by default) X-axis offset. 
+-   `offsetY` **[number][11]** (optional, `0` by default) Y-axis offset. 
 
 ### see
 
@@ -1330,8 +1331,8 @@ I.see('Register', {css: 'form.register'}); // use strict locator
 
 #### Parameters
 
--   `text` **[string][9]** expected on page.
--   `context` **([string][9]? | [object][7])** (optional, `null` by default) element located by CSS|Xpath|strict locator in which to search for text. 
+-   `text` **[string][10]** expected on page.
+-   `context` **([string][10]? | [object][8])** (optional, `null` by default) element located by CSS|Xpath|strict locator in which to search for text. 
 
 ### seeAttributesOnElements
 
@@ -1343,8 +1344,8 @@ I.seeAttributesOnElements('//form', { method: "post"});
 
 #### Parameters
 
--   `locator` **([string][9] | [object][7])** located by CSS|XPath|strict locator.
--   `attributes` **[object][7]** attributes and their values to check.
+-   `locator` **([string][10] | [object][8])** located by CSS|XPath|strict locator.
+-   `attributes` **[object][8]** attributes and their values to check.
 
 ### seeCheckboxIsChecked
 
@@ -1358,7 +1359,7 @@ I.seeCheckboxIsChecked({css: '#signup_form input[type=checkbox]'});
 
 #### Parameters
 
--   `field` **([string][9] | [object][7])** located by label|name|CSS|XPath|strict locator.
+-   `field` **([string][10] | [object][8])** located by label|name|CSS|XPath|strict locator.
 
 ### seeCookie
 
@@ -1370,7 +1371,7 @@ I.seeCookie('Auth');
 
 #### Parameters
 
--   `name` **[string][9]** cookie name.
+-   `name` **[string][10]** cookie name.
 
 ### seeCssPropertiesOnElements
 
@@ -1382,8 +1383,8 @@ I.seeCssPropertiesOnElements('h3', { 'font-weight': "bold"});
 
 #### Parameters
 
--   `locator` **([string][9] | [object][7])** located by CSS|XPath|strict locator.
--   `cssProperties` **[object][7]** object with CSS properties and their values to check.
+-   `locator` **([string][10] | [object][8])** located by CSS|XPath|strict locator.
+-   `cssProperties` **[object][8]** object with CSS properties and their values to check.
 
 ### seeCurrentUrlEquals
 
@@ -1398,7 +1399,7 @@ I.seeCurrentUrlEquals('http://my.site.com/register');
 
 #### Parameters
 
--   `url` **[string][9]** value to check.
+-   `url` **[string][10]** value to check.
 
 ### seeElement
 
@@ -1411,7 +1412,7 @@ I.seeElement('#modal');
 
 #### Parameters
 
--   `locator` **([string][9] | [object][7])** located by CSS|XPath|strict locator.
+-   `locator` **([string][10] | [object][8])** located by CSS|XPath|strict locator.
 
 ### seeElementInDOM
 
@@ -1424,7 +1425,7 @@ I.seeElementInDOM('#modal');
 
 #### Parameters
 
--   `locator` **([string][9] | [object][7])** element located by CSS|XPath|strict locator.
+-   `locator` **([string][10] | [object][8])** element located by CSS|XPath|strict locator.
 
 ### seeInCurrentUrl
 
@@ -1436,7 +1437,7 @@ I.seeInCurrentUrl('/register'); // we are on registration page
 
 #### Parameters
 
--   `url` **[string][9]** a fragment to check
+-   `url` **[string][10]** a fragment to check
 
 ### seeInField
 
@@ -1452,8 +1453,8 @@ I.seeInField('#searchform input','Search');
 
 #### Parameters
 
--   `field` **([string][9] | [object][7])** located by label|name|CSS|XPath|strict locator.
--   `value` **[string][9]** value to check.
+-   `field` **([string][10] | [object][8])** located by label|name|CSS|XPath|strict locator.
+-   `value` **[string][10]** value to check.
 
 ### seeInPopup
 
@@ -1466,7 +1467,7 @@ I.seeInPopup('Popup text');
 
 #### Parameters
 
--   `text` **[string][9]** value to check.
+-   `text` **[string][10]** value to check.
 
 ### seeInSource
 
@@ -1478,7 +1479,7 @@ I.seeInSource('<h1>Green eggs &amp; ham</h1>');
 
 #### Parameters
 
--   `text` **[string][9]** value to check.
+-   `text` **[string][10]** value to check.
 
 ### seeInTitle
 
@@ -1490,7 +1491,7 @@ I.seeInTitle('Home Page');
 
 #### Parameters
 
--   `text` **[string][9]** text value to check.
+-   `text` **[string][10]** text value to check.
 
 ### seeNumberOfElements
 
@@ -1503,8 +1504,8 @@ I.seeNumberOfElements('#submitBtn', 1);
 
 #### Parameters
 
--   `locator` **([string][9] | [object][7])** element located by CSS|XPath|strict locator.
--   `num` **[number][10]** number of elements.
+-   `locator` **([string][10] | [object][8])** element located by CSS|XPath|strict locator.
+-   `num` **[number][11]** number of elements.
 
 ### seeNumberOfVisibleElements
 
@@ -1517,8 +1518,8 @@ I.seeNumberOfVisibleElements('.buttons', 3);
 
 #### Parameters
 
--   `locator` **([string][9] | [object][7])** element located by CSS|XPath|strict locator.
--   `num` **[number][10]** number of elements.
+-   `locator` **([string][10] | [object][8])** element located by CSS|XPath|strict locator.
+-   `num` **[number][11]** number of elements.
 
 ### seeTextEquals
 
@@ -1530,8 +1531,8 @@ I.seeTextEquals('text', 'h1');
 
 #### Parameters
 
--   `text` **[string][9]** element value to check.
--   `context` **([string][9] | [object][7])?** element located by CSS|XPath|strict locator. 
+-   `text` **[string][10]** element value to check.
+-   `context` **([string][10] | [object][8])?** element located by CSS|XPath|strict locator. 
 
 ### seeTitleEquals
 
@@ -1543,7 +1544,7 @@ I.seeTitleEquals('Test title.');
 
 #### Parameters
 
--   `text` **[string][9]** value to check.
+-   `text` **[string][10]** value to check.
 
 ### selectOption
 
@@ -1568,8 +1569,8 @@ I.selectOption('Which OS do you use?', ['Android', 'iOS']);
 
 #### Parameters
 
--   `select` **([string][9] | [object][7])** field located by label|name|CSS|XPath|strict locator.
--   `option` **([string][9] | [Array][13]&lt;any>)** visible text or value of option.
+-   `select` **([string][10] | [object][8])** field located by label|name|CSS|XPath|strict locator.
+-   `option` **([string][10] | [Array][14]&lt;any>)** visible text or value of option.
 
 ### setCookie
 
@@ -1589,7 +1590,7 @@ I.setCookie([
 
 #### Parameters
 
--   `cookie` **(Cookie | [Array][13]&lt;Cookie>)** a cookie object or array of cookie objects.
+-   `cookie` **(Cookie | [Array][14]&lt;Cookie>)** a cookie object or array of cookie objects.
 
 ### stopMockingRoute
 
@@ -1604,8 +1605,8 @@ If no handler is passed, all mock requests for the rote are disabled.
 
 #### Parameters
 
--   `url` **[string][9]?** URL, regex or pattern for to match URL
--   `handler` **[function][11]?** a function to process request
+-   `url` **[string][10]?** URL, regex or pattern for to match URL
+-   `handler` **[function][12]?** a function to process request
 
 ### switchTo
 
@@ -1618,7 +1619,7 @@ I.switchTo(); // switch back to main page
 
 #### Parameters
 
--   `locator` **([string][9]? | [object][7])** (optional, `null` by default) element located by CSS|XPath|strict locator. 
+-   `locator` **([string][10]? | [object][8])** (optional, `null` by default) element located by CSS|XPath|strict locator. 
 
 ### switchToNextTab
 
@@ -1631,7 +1632,7 @@ I.switchToNextTab(2);
 
 #### Parameters
 
--   `num` **[number][10]**  
+-   `num` **[number][11]**  
 
 ### switchToPreviousTab
 
@@ -1644,13 +1645,13 @@ I.switchToPreviousTab(2);
 
 #### Parameters
 
--   `num` **[number][10]**  
+-   `num` **[number][11]**  
 
 ### type
 
 Types out the given text into an active field.
 To slow down typing use a second parameter, to set interval between key presses.
-_Note:_ Should be used when [`fillField`][18] is not an option.
+_Note:_ Should be used when [`fillField`][19] is not an option.
 
 ```js
 // passing in a string
@@ -1666,8 +1667,8 @@ I.type(['T', 'E', 'X', 'T']);
 #### Parameters
 
 -   `keys`  
--   `delay` **[number][10]?** (optional) delay in ms between key presses 
--   `key` **([string][9] | [Array][13]&lt;[string][9]>)** or array of keys to type.
+-   `delay` **[number][11]?** (optional) delay in ms between key presses 
+-   `key` **([string][10] | [Array][14]&lt;[string][10]>)** or array of keys to type.
 
 ### uncheckOption
 
@@ -1684,8 +1685,8 @@ I.uncheckOption('agree', '//form');
 
 #### Parameters
 
--   `field` **([string][9] | [object][7])** checkbox located by label | name | CSS | XPath | strict locator.
--   `context` **([string][9]? | [object][7])** (optional, `null` by default) element located by CSS | XPath | strict locator. 
+-   `field` **([string][10] | [object][8])** checkbox located by label | name | CSS | XPath | strict locator.
+-   `context` **([string][10]? | [object][8])** (optional, `null` by default) element located by CSS | XPath | strict locator. 
 
 ### usePlaywrightTo
 
@@ -1694,7 +1695,7 @@ Use Playwright API inside a test.
 First argument is a description of an action.
 Second argument is async function that gets this helper as parameter.
 
-{ [`page`][22], [`context`][23] [`browser`][24] } objects from Playwright API are available.
+{ [`page`][23], [`context`][24] [`browser`][25] } objects from Playwright API are available.
 
 ```js
 I.usePlaywrightTo('emulate offline mode', async ({ context }) {
@@ -1704,8 +1705,8 @@ I.usePlaywrightTo('emulate offline mode', async ({ context }) {
 
 #### Parameters
 
--   `description` **[string][9]** used to show in logs.
--   `fn` **[function][11]** async functuion that executed with Playwright helper as argument
+-   `description` **[string][10]** used to show in logs.
+-   `fn` **[function][12]** async functuion that executed with Playwright helper as argument
 
 ### wait
 
@@ -1717,7 +1718,7 @@ I.wait(2); // wait 2 secs
 
 #### Parameters
 
--   `sec` **[number][10]** number of second to wait.
+-   `sec` **[number][11]** number of second to wait.
 
 ### waitForClickable
 
@@ -1731,9 +1732,9 @@ I.waitForClickable('.btn.continue', 5); // wait for 5 secs
 
 #### Parameters
 
--   `locator` **([string][9] | [object][7])** element located by CSS|XPath|strict locator.
+-   `locator` **([string][10] | [object][8])** element located by CSS|XPath|strict locator.
 -   `waitTimeout`  
--   `sec` **[number][10]?** (optional, `1` by default) time in seconds to wait
+-   `sec` **[number][11]?** (optional, `1` by default) time in seconds to wait
 
 ### waitForDetached
 
@@ -1746,8 +1747,8 @@ I.waitForDetached('#popup');
 
 #### Parameters
 
--   `locator` **([string][9] | [object][7])** element located by CSS|XPath|strict locator.
--   `sec` **[number][10]** (optional, `1` by default) time in seconds to wait 
+-   `locator` **([string][10] | [object][8])** element located by CSS|XPath|strict locator.
+-   `sec` **[number][11]** (optional, `1` by default) time in seconds to wait 
 
 ### waitForElement
 
@@ -1761,8 +1762,8 @@ I.waitForElement('.btn.continue', 5); // wait for 5 secs
 
 #### Parameters
 
--   `locator` **([string][9] | [object][7])** element located by CSS|XPath|strict locator.
--   `sec` **[number][10]?** (optional, `1` by default) time in seconds to wait
+-   `locator` **([string][10] | [object][8])** element located by CSS|XPath|strict locator.
+-   `sec` **[number][11]?** (optional, `1` by default) time in seconds to wait
 
 ### waitForEnabled
 
@@ -1771,8 +1772,8 @@ Element can be located by CSS or XPath.
 
 #### Parameters
 
--   `locator` **([string][9] | [object][7])** element located by CSS|XPath|strict locator.
--   `sec` **[number][10]** (optional) time in seconds to wait, 1 by default. 
+-   `locator` **([string][10] | [object][8])** element located by CSS|XPath|strict locator.
+-   `sec` **[number][11]** (optional) time in seconds to wait, 1 by default. 
 
 ### waitForFunction
 
@@ -1791,9 +1792,9 @@ I.waitForFunction((count) => window.requests == count, [3], 5) // pass args and 
 
 #### Parameters
 
--   `fn` **([string][9] | [function][11])** to be executed in browser context.
--   `argsOrSec` **([Array][13]&lt;any> | [number][10])?** (optional, `1` by default) arguments for function or seconds. 
--   `sec` **[number][10]?** (optional, `1` by default) time in seconds to wait 
+-   `fn` **([string][10] | [function][12])** to be executed in browser context.
+-   `argsOrSec` **([Array][14]&lt;any> | [number][11])?** (optional, `1` by default) arguments for function or seconds. 
+-   `sec` **[number][11]?** (optional, `1` by default) time in seconds to wait 
 
 ### waitForInvisible
 
@@ -1806,14 +1807,14 @@ I.waitForInvisible('#popup');
 
 #### Parameters
 
--   `locator` **([string][9] | [object][7])** element located by CSS|XPath|strict locator.
--   `sec` **[number][10]** (optional, `1` by default) time in seconds to wait 
+-   `locator` **([string][10] | [object][8])** element located by CSS|XPath|strict locator.
+-   `sec` **[number][11]** (optional, `1` by default) time in seconds to wait 
 
 ### waitForNavigation
 
 Waits for navigation to finish. By default takes configured `waitForNavigation` option.
 
-See [Playwright's reference][25]
+See [Playwright's reference][26]
 
 #### Parameters
 
@@ -1830,8 +1831,8 @@ I.waitForRequest(request => request.url() === 'http://example.com' && request.me
 
 #### Parameters
 
--   `urlOrPredicate` **([string][9] | [function][11])** 
--   `sec` **[number][10]?** seconds to wait 
+-   `urlOrPredicate` **([string][10] | [function][12])** 
+-   `sec` **[number][11]?** seconds to wait 
 
 ### waitForResponse
 
@@ -1844,8 +1845,8 @@ I.waitForResponse(response => response.url() === 'https://example.com' && respon
 
 #### Parameters
 
--   `urlOrPredicate` **([string][9] | [function][11])** 
--   `sec` **[number][10]?** number of seconds to wait 
+-   `urlOrPredicate` **([string][10] | [function][12])** 
+-   `sec` **[number][11]?** number of seconds to wait 
 
 ### waitForText
 
@@ -1860,9 +1861,9 @@ I.waitForText('Thank you, form has been submitted', 5, '#modal');
 
 #### Parameters
 
--   `text` **[string][9]** to wait for.
--   `sec` **[number][10]** (optional, `1` by default) time in seconds to wait 
--   `context` **([string][9] | [object][7])?** (optional) element located by CSS|XPath|strict locator. 
+-   `text` **[string][10]** to wait for.
+-   `sec` **[number][11]** (optional, `1` by default) time in seconds to wait 
+-   `context` **([string][10] | [object][8])?** (optional) element located by CSS|XPath|strict locator. 
 
 ### waitForValue
 
@@ -1874,9 +1875,9 @@ I.waitForValue('//input', "GoodValue");
 
 #### Parameters
 
--   `field` **([string][9] | [object][7])** input field.
--   `value` **[string][9]** expected value.
--   `sec` **[number][10]** (optional, `1` by default) time in seconds to wait 
+-   `field` **([string][10] | [object][8])** input field.
+-   `value` **[string][10]** expected value.
+-   `sec` **[number][11]** (optional, `1` by default) time in seconds to wait 
 
 ### waitForVisible
 
@@ -1889,8 +1890,8 @@ I.waitForVisible('#popup');
 
 #### Parameters
 
--   `locator` **([string][9] | [object][7])** element located by CSS|XPath|strict locator.
--   `sec` **[number][10]** (optional, `1` by default) time in seconds to waitThis method accepts [React selectors][26]. 
+-   `locator` **([string][10] | [object][8])** element located by CSS|XPath|strict locator.
+-   `sec` **[number][11]** (optional, `1` by default) time in seconds to waitThis method accepts [React selectors][27]. 
 
 ### waitInUrl
 
@@ -1902,8 +1903,8 @@ I.waitInUrl('/info', 2);
 
 #### Parameters
 
--   `urlPart` **[string][9]** value to check.
--   `sec` **[number][10]** (optional, `1` by default) time in seconds to wait 
+-   `urlPart` **[string][10]** value to check.
+-   `sec` **[number][11]** (optional, `1` by default) time in seconds to wait 
 
 ### waitNumberOfVisibleElements
 
@@ -1915,9 +1916,9 @@ I.waitNumberOfVisibleElements('a', 3);
 
 #### Parameters
 
--   `locator` **([string][9] | [object][7])** element located by CSS|XPath|strict locator.
--   `num` **[number][10]** number of elements.
--   `sec` **[number][10]** (optional, `1` by default) time in seconds to wait 
+-   `locator` **([string][10] | [object][8])** element located by CSS|XPath|strict locator.
+-   `num` **[number][11]** number of elements.
+-   `sec` **[number][11]** (optional, `1` by default) time in seconds to wait 
 
 ### waitToHide
 
@@ -1930,8 +1931,8 @@ I.waitToHide('#popup');
 
 #### Parameters
 
--   `locator` **([string][9] | [object][7])** element located by CSS|XPath|strict locator.
--   `sec` **[number][10]** (optional, `1` by default) time in seconds to wait 
+-   `locator` **([string][10] | [object][8])** element located by CSS|XPath|strict locator.
+-   `sec` **[number][11]** (optional, `1` by default) time in seconds to wait 
 
 ### waitUrlEquals
 
@@ -1944,8 +1945,8 @@ I.waitUrlEquals('http://127.0.0.1:8000/info');
 
 #### Parameters
 
--   `urlPart` **[string][9]** value to check.
--   `sec` **[number][10]** (optional, `1` by default) time in seconds to wait 
+-   `urlPart` **[string][10]** value to check.
+-   `sec` **[number][11]** (optional, `1` by default) time in seconds to wait 
 
 [1]: https://github.com/microsoft/playwright
 
@@ -1953,48 +1954,50 @@ I.waitUrlEquals('http://127.0.0.1:8000/info');
 
 [3]: https://github.com/microsoft/playwright/blob/master/docs/api.md#pagewaitfornavigationoptions
 
-[4]: https://playwright.dev/docs/next/api/class-browser#browser-new-context
+[4]: https://playwright.dev/docs/browsers/#google-chrome--microsoft-edge
 
-[5]: https://playwright.dev/docs/api/class-browsertype#browsertypeconnectparams
+[5]: https://playwright.dev/docs/next/api/class-browser#browser-new-context
 
-[6]: https://github.com/microsoft/playwright/blob/v0.11.0/docs/api.md#working-with-chrome-extensions
+[6]: https://playwright.dev/docs/api/class-browsertype#browsertypeconnectparams
 
-[7]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
+[7]: https://github.com/microsoft/playwright/blob/v0.11.0/docs/api.md#working-with-chrome-extensions
 
-[8]: https://jster.net/category/windows-modals-popups
+[8]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
 
-[9]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
+[9]: http://jster.net/category/windows-modals-popups
 
-[10]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
+[10]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
 
-[11]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function
+[11]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
 
-[12]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise
+[12]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function
 
-[13]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
+[13]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise
 
-[14]: https://codecept.io/helpers/FileSystem
+[14]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
 
-[15]: https://playwright.dev/docs/api/class-browsercontext#browser-context-route
+[15]: https://codecept.io/helpers/FileSystem
 
-[16]: https://playwright.dev/docs/network#handle-requests
+[16]: https://playwright.dev/docs/api/class-browsercontext#browser-context-route
 
-[17]: https://github.com/microsoft/playwright/blob/master/docs/api.md#browsernewpageoptions
+[17]: https://playwright.dev/docs/network#handle-requests
 
-[18]: #fillfield
+[18]: https://github.com/microsoft/playwright/blob/master/docs/api.md#browsernewpageoptions
 
-[19]: https://github.com/GoogleChrome/puppeteer/issues/1313
+[19]: #fillfield
 
-[20]: #click
+[20]: https://github.com/GoogleChrome/puppeteer/issues/1313
 
-[21]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean
+[21]: #click
 
-[22]: https://github.com/microsoft/playwright/blob/master/docs/api.md#class-page
+[22]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean
 
-[23]: https://github.com/microsoft/playwright/blob/master/docs/api.md#class-context
+[23]: https://github.com/microsoft/playwright/blob/master/docs/api.md#class-page
 
-[24]: https://github.com/microsoft/playwright/blob/master/docs/api.md#class-browser
+[24]: https://github.com/microsoft/playwright/blob/master/docs/api.md#class-context
 
-[25]: https://playwright.dev/docs/api/class-page?_highlight=waitfornavi#pagewaitfornavigationoptions
+[25]: https://github.com/microsoft/playwright/blob/master/docs/api.md#class-browser
 
-[26]: https://codecept.io/react
+[26]: https://playwright.dev/docs/api/class-page?_highlight=waitfornavi#pagewaitfornavigationoptions
+
+[27]: https://codecept.io/react

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -14,7 +14,6 @@ const {
   ucfirst,
   fileExists,
   chunkArray,
-  toCamelCase,
   convertCssPropertiesToCamelCase,
   screenshotOutputFolder,
   getNormalizedKeyAttributeValue,
@@ -84,6 +83,7 @@ const { createValueEngine, createDisabledEngine } = require('./extras/Playwright
  * * `manualStart`: (optional, default: false) - do not start browser before a test, start it manually inside a helper with `this.helpers["Playwright"]._startBrowser()`.
  * * `chromium`: (optional) pass additional chromium options
  * * `electron`: (optional) pass additional electron options
+ * * `channel`: (optional) While Playwright can operate against the stock Google Chrome and Microsoft Edge browsers available on the machine. In particular, current Playwright version will support Stable and Beta channels of these browsers. See [Google Chrome & Microsoft Edge](https://playwright.dev/docs/browsers/#google-chrome--microsoft-edge).
  *
  * #### Video Recording Customization
  *
@@ -301,6 +301,11 @@ class Playwright extends Helper {
       headless: !this.options.show,
       ...this._getOptionsForBrowser(config),
     };
+
+    if (this.options.channel && this.options.browser === 'chromium') {
+      this.playwrightOptions.channel = this.options.channel;
+    }
+
     if (this.options.video) {
       this.options.recordVideo = { size: parseWindowSize(this.options.windowSize) };
     }


### PR DESCRIPTION
## Motivation/Description of the PR
While Playwright can download and use the recent Chromium build, it can operate against the stock Google Chrome and Microsoft Edge browsers available on the machine. In particular, current Playwright version will support Stable and Beta channels of these browsers.
https://playwright.dev/docs/browsers/#google-chrome--microsoft-edge

Applicable helpers:
- [x] Playwright

## Type of change
- [x] :bug: Bug fix


## Checklist:

- [ ] Tests have been added
- [x] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
