### PR TITLE
fix(#2889): return always the same error contract from simplifyTest

### DIFF
--- a/lib/command/workers/runTests.js
+++ b/lib/command/workers/runTests.js
@@ -73,6 +73,27 @@ function filterTests() {
 }
 
 function initializeListeners() {
+  function simplifyError(error) {
+    if (error) {
+      const {
+        stack,
+        uncaught,
+        message,
+        actual,
+        expected,
+      } = error;
+
+      return {
+        stack,
+        uncaught,
+        message,
+        actual,
+        expected,
+      };
+    }
+
+    return null;
+  }
   function simplifyTest(test, err = null) {
     test = { ...test };
 
@@ -82,13 +103,10 @@ function initializeListeners() {
     }
 
     if (test.err) {
-      err = {
-        stack: test.err.stack,
-        uncaught: test.err.uncaught,
-        message: test.err.message,
-        actual: test.err.actual,
-        expected: test.err.expected,
-      };
+      err = simplifyError(test.err);
+      test.status = 'failed';
+    } else if (err) {
+      err = simplifyError(err);
       test.status = 'failed';
     }
     const parent = {};


### PR DESCRIPTION
## Motivation/Description of the PR
- Resolves #2889

Currently using patch-package with this fix on version 3.0.7 and been testing since then. With the complexity of the core api of codeceptjs, I could not find a way to replicate the error by sending an invalid object with **inspect** and **cliMessage** functions on it like shown in the reported issue. I would be glad to add some tests if someone could point me on how to build these tests to track the exact problem.

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
