### PR TITLE
Guard mocha cli reporter from registering step logger multiple times

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -7,6 +7,7 @@ const { MetaStep } = require('./step');
 
 const cursor = Base.cursor;
 let currentMetaStep = [];
+let codeceptjsEventDispatchersRegistered = false;
 
 class Cli extends Base {
   constructor(runner, opts) {
@@ -77,29 +78,33 @@ class Cli extends Base {
         }
       });
 
-      event.dispatcher.on(event.step.started, (step) => {
-        let processingStep = step;
-        const metaSteps = [];
-        while (processingStep.metaStep) {
-          metaSteps.unshift(processingStep.metaStep);
-          processingStep = processingStep.metaStep;
-        }
-        const shift = metaSteps.length;
+      if (!codeceptjsEventDispatchersRegistered) {
+        codeceptjsEventDispatchersRegistered = true;
 
-        for (let i = 0; i < Math.max(currentMetaStep.length, metaSteps.length); i++) {
-          if (currentMetaStep[i] !== metaSteps[i]) {
-            output.stepShift = 3 + 2 * i;
-            if (metaSteps[i]) output.step(metaSteps[i]);
+        event.dispatcher.on(event.step.started, (step) => {
+          let processingStep = step;
+          const metaSteps = [];
+          while (processingStep.metaStep) {
+            metaSteps.unshift(processingStep.metaStep);
+            processingStep = processingStep.metaStep;
           }
-        }
-        currentMetaStep = metaSteps;
-        output.stepShift = 3 + 2 * shift;
-        output.step(step);
-      });
+          const shift = metaSteps.length;
 
-      event.dispatcher.on(event.step.finished, () => {
-        output.stepShift = 0;
-      });
+          for (let i = 0; i < Math.max(currentMetaStep.length, metaSteps.length); i++) {
+            if (currentMetaStep[i] !== metaSteps[i]) {
+              output.stepShift = 3 + 2 * i;
+              if (metaSteps[i]) output.step(metaSteps[i]);
+            }
+          }
+          currentMetaStep = metaSteps;
+          output.stepShift = 3 + 2 * shift;
+          output.step(step);
+        });
+
+        event.dispatcher.on(event.step.finished, () => {
+          output.stepShift = 0;
+        });
+      }
     }
 
     runner.on('suite end', suite => {


### PR DESCRIPTION
## Motivation/Description of the PR
- Programmatic invocation of CodeceptJS allows multiple reruns of the tests from one node process with the logging registering on each test run and producing duplication of the log entries in console output being only problem so far. The change in CodeceptJS cli reporter insures logger is registered only once.
- Resolves #issueId (if applicable).

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
