### PR TITLE
feat(#2663): support for playwright-core usage

### DIFF
--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -19,6 +19,7 @@ const {
   getNormalizedKeyAttributeValue,
   isModifierKey,
   clearString,
+  requireWithFallback,
 } = require('../utils');
 const {
   isColorProperty,
@@ -235,7 +236,7 @@ class Playwright extends Helper {
   constructor(config) {
     super(config);
 
-    playwright = require('playwright');
+    playwright = requireWithFallback('playwright', 'playwright-core');
 
     // set defaults
     this.isRemoteBrowser = false;
@@ -334,7 +335,7 @@ class Playwright extends Helper {
 
   static _checkRequirements() {
     try {
-      require('playwright');
+      requireWithFallback('playwright', 'playwright-core');
     } catch (e) {
       return ['playwright@^1'];
     }

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -50,11 +50,15 @@ const { createValueEngine, createDisabledEngine } = require('./extras/Playwright
  *
  * This helper works with a browser out of the box with no additional tools required to install.
  *
- * Requires `playwright` package version ^1 to be installed:
+ * Requires `playwright` or `playwright-core` package version ^1 to be installed:
  *
  * ```
  * npm i playwright@^1 --save
+ *
+ * npm i playwright-core@^1 --save
  * ```
+ *
+ * Using the core version of playwright package, will prevent download of browser binaries and allows you to connect to an existing browser installation or for connecting to a remote one.
  *
  * ## Configuration
  *

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -54,11 +54,13 @@ const { createValueEngine, createDisabledEngine } = require('./extras/Playwright
  *
  * ```
  * npm i playwright@^1 --save
- *
+ * ```
+ * or
+ * ```
  * npm i playwright-core@^1 --save
  * ```
  *
- * Using the core version of playwright package, will prevent download of browser binaries and allows you to connect to an existing browser installation or for connecting to a remote one.
+ * Using playwright-core package, will prevent the download of browser binaries and allow connecting to an existing browser installation or for connecting to a remote one.
  *
  * ## Configuration
  *

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -47,10 +47,12 @@ const consoleLogStore = new Console();
  * Requires `puppeteer` or `puppeteer-core` package to be installed.
  * ```
  * npm i puppeteer --save
- *
+ * ```
+ * or
+ * ```
  * npm i puppeteer-core --save
  * ```
- * Using the core version of puppeteer package, will prevent download of browser binaries and allows you to connect to an existing browser installation or for connecting to a remote one.
+ * Using `puppeteer-core` package, will prevent the download of browser binaries and allow connecting to an existing browser installation or for connecting to a remote one.
  *
  * > Experimental Firefox support [can be activated](https://codecept.io/helpers/Puppeteer-firefox).
  *

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -22,6 +22,7 @@ const {
   screenshotOutputFolder,
   getNormalizedKeyAttributeValue,
   isModifierKey,
+  requireWithFallback,
 } = require('../utils');
 const {
   isColorProperty,
@@ -43,7 +44,13 @@ const consoleLogStore = new Console();
  * Browser control is executed via DevTools Protocol (instead of Selenium).
  * This helper works with a browser out of the box with no additional tools required to install.
  *
- * Requires `puppeteer` package to be installed.
+ * Requires `puppeteer` or `puppeteer-core` package to be installed.
+ * ```
+ * npm i puppeteer --save
+ *
+ * npm i puppeteer-core --save
+ * ```
+ * Using the core version of puppeteer package, will prevent download of browser binaries and allows you to connect to an existing browser installation or for connecting to a remote one.
  *
  * > Experimental Firefox support [can be activated](https://codecept.io/helpers/Puppeteer-firefox).
  *
@@ -182,7 +189,7 @@ class Puppeteer extends Helper {
   constructor(config) {
     super(config);
 
-    puppeteer = require('puppeteer');
+    puppeteer = requireWithFallback('puppeteer', 'puppeteer-core');
 
     // set defaults
     this.isRemoteBrowser = false;
@@ -245,7 +252,7 @@ class Puppeteer extends Helper {
 
   static _checkRequirements() {
     try {
-      require('puppeteer');
+      requireWithFallback('puppeteer', 'puppeteer-core');
     } catch (e) {
       return ['puppeteer'];
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -431,3 +431,23 @@ module.exports.modifierKeys = modifierKeys;
 module.exports.isModifierKey = function (key) {
   return modifierKeys.includes(key);
 };
+
+module.exports.requireWithFallback = function (...packages) {
+  const exists = function (pkg) {
+    try {
+      require.resolve(pkg);
+    } catch (e) {
+      return false;
+    }
+
+    return true;
+  };
+
+  for (const pkg of packages) {
+    if (exists(pkg)) {
+      return require(pkg);
+    }
+  }
+
+  throw new Error(`Cannot find modules ${packages.join(',')}`);
+};

--- a/test/unit/utils_test.js
+++ b/test/unit/utils_test.js
@@ -334,4 +334,15 @@ describe('utils', () => {
       }
     });
   });
+
+  describe('#requireWithFallback', () => {
+    it('returns the fallback package', () => {
+      expect(utils.requireWithFallback('unexisting-package', 'playwright')).eql(require('playwright'));
+    });
+
+    it('returns provide default require not found message', () => {
+      expect(() => utils.requireWithFallback('unexisting-package', 'unexisting-package2'))
+        .to.throw(Error, 'Cannot find modules unexisting-package,unexisting-package2');
+    });
+  });
 });


### PR DESCRIPTION
## Motivation/Description of the PR
- Resolves #2663 .

Added a simple utility that allows the require fallback of npm packages. If the first is not found it will try the next one in the chain.
I have been using it to include playwright-core instead of playwright because I don't want to download the browser binaries on yarn/npm install. This approach can be used for other helpers as well if you guys think it's worth it.

For example, it would be possible as well for puppeteer without adding 

```
npm config set puppeteer_skip_chromium_download true
```

as explained in https://github.com/codeceptjs/CodeceptJS/issues/2076
 

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [x] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [x] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [x] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
