### PR TITLE
attach video to allure report if allure report is enabled

### DIFF
--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -1890,6 +1890,12 @@ class Playwright extends Helper {
 
     if (this.options.recordVideo && this.page.video()) {
       test.artifacts.video = await this.page.video().path();
+
+      const Container = require('../container');
+      const allureReporter = Container.plugins('allure');
+      if (allureReporter) {
+        allureReporter.addAttachment('Last Seen Video:', fs.readFileSync(test.artifacts.video));
+      }
     }
 
     if (this.options.trace) {


### PR DESCRIPTION
## Motivation/Description of the PR
- Currently we don't attach failed videos to allure report, so would be nice to see the failed videos are attached to allure report.

Applicable helpers:

- [x] Playwright

## Type of change

- [x] :rocket: New functionality

