### PR TITLE
fix: update playwright comments / docs for usePlaywrightTo method

### DIFF
--- a/docs/helpers/Playwright.md
+++ b/docs/helpers/Playwright.md
@@ -1695,11 +1695,11 @@ Use Playwright API inside a test.
 First argument is a description of an action.
 Second argument is async function that gets this helper as parameter.
 
-{ [`page`][23], [`context`][24] [`browser`][25] } objects from Playwright API are available.
+{ [`page`][23], [`browserContext`][24] [`browser`][25] } objects from Playwright API are available.
 
 ```js
-I.usePlaywrightTo('emulate offline mode', async ({ context }) => {
-  await context.setOffline(true);
+I.usePlaywrightTo('emulate offline mode', async ({ browserContext }) => {
+  await browserContext.setOffline(true);
 });
 ```
 

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -506,11 +506,11 @@ class Playwright extends Helper {
   * First argument is a description of an action.
   * Second argument is async function that gets this helper as parameter.
   *
-  * { [`page`](https://github.com/microsoft/playwright/blob/main/docs/src/api/class-page.md), [`context`](https://github.com/microsoft/playwright/blob/main/docs/src/api/class-browsercontext.md) [`browser`](https://github.com/microsoft/playwright/blob/main/docs/src/api/class-browser.md) } objects from Playwright API are available.
+  * { [`page`](https://github.com/microsoft/playwright/blob/main/docs/src/api/class-page.md), [`browserContext`](https://github.com/microsoft/playwright/blob/main/docs/src/api/class-browsercontext.md) [`browser`](https://github.com/microsoft/playwright/blob/main/docs/src/api/class-browser.md) } objects from Playwright API are available.
   *
   * ```js
-  * I.usePlaywrightTo('emulate offline mode', async ({ context }) => {
-  *   await context.setOffline(true);
+  * I.usePlaywrightTo('emulate offline mode', async ({ browserContext }) => {
+  *   await browserContext.setOffline(true);
   * });
   * ```
   *

--- a/test/helper/Playwright_test.js
+++ b/test/helper/Playwright_test.js
@@ -653,6 +653,16 @@ describe('Playwright', function () {
       });
       assert.equal('TestEd Beta 2.0', title);
     });
+
+    it('should pass expected parameters', async () => {
+      await I.amOnPage('/');
+      const params = await I.usePlaywrightTo('test', async (params) => {
+        return params;
+      });
+      expect(params.page).to.exist;
+      expect(params.browserContext).to.exist;
+      expect(params.browser).to.exist;
+    });
   });
 
   describe('#mockRoute, #stopMockingRoute', () => {


### PR DESCRIPTION
## Motivation/Description of the PR
I noticed that there was ambiguity in the method block comment and the generated readme for the `Playwright.usePlaywrightTo` method regarding the param naming.  In some places the BrowserContext object was called `browserContext` and in others it was only `context`. Since `browserContext` is the correct naming, I updated the comments to reflect that and hopefully save others some confusion in the future.  I also added a small unit test that checks the names and presence of all 3 params on that method callback.

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [x] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [x] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [x] Tests have been added
- [x] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
