### PR TITLE
Handle flags of Regex expression for cucumber

### DIFF
--- a/lib/interfaces/bdd.js
+++ b/lib/interfaces/bdd.js
@@ -25,7 +25,8 @@ const parameterTypeRegistry = new ParameterTypeRegistry();
 const matchStep = (step) => {
   for (const stepName in steps) {
     if (stepName.indexOf('/') === 0) {
-      const res = step.match(new RegExp(stepName.slice(1, -1)));
+      const regExpArr = stepName.match(new RegExp('^/(.*?)/([gimy]*)$')) || [];
+      const res = step.match(new RegExp(regExpArr[1], regExpArr[2]));
       if (res) {
         const fn = steps[stepName];
         fn.params = res.slice(1);
@@ -56,6 +57,7 @@ module.exports = {
   Given: addStep,
   When: addStep,
   Then: addStep,
+  And: addStep,
   matchStep,
   getSteps,
   clearSteps,

--- a/test/unit/bdd_test.js
+++ b/test/unit/bdd_test.js
@@ -3,6 +3,7 @@ const { Parser } = require('gherkin');
 const {
   Given,
   When,
+  And,
   Then,
   matchStep,
   clearSteps,
@@ -64,10 +65,12 @@ describe('BDD', () => {
   it('should load step definitions', () => {
     Given('I am a bird', () => 1);
     When('I fly over ocean', () => 2);
-    Then(/I see (.*?)/, () => 3);
+    And(/^I fly over land$/i, () => 3);
+    Then(/I see (.*?)/, () => 4);
     expect(1).is.equal(matchStep('I am a bird')());
-    expect(3).is.equal(matchStep('I see ocean')());
-    expect(3).is.equal(matchStep('I see world')());
+    expect(3).is.equal(matchStep('I Fly oVer Land')());
+    expect(4).is.equal(matchStep('I see ocean')());
+    expect(4).is.equal(matchStep('I see world')());
   });
 
   it('should contain tags', async () => {


### PR DESCRIPTION
## Motivation/Description of the PR
- Fixed issue - Handle flags of Regex expression for cucumber step definition.
- Resolves #3212.

## Current Issue
If you create a step definition like ``` Given(/^I am on "([^"]+)" page$/i, openPageStep); ``` and use ``` Given I am on "Login" page```, you will get error stating ````# No steps matching "I am on "Login" page"```` but It will work for ``` Given(/^I am on "([^"]+)" page$/, openPageStep); ```

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [x] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
