### PR TITLE
Webdriver: Change get element attribute for property for method seeInField()

### DIFF
--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -2722,12 +2722,12 @@ async function proceedSeeField(assertType, field, value) {
     }
   };
 
-  const proceedSingle = el => this.browser.getElementProperty(getElementId(el), 'value').then((res) => {
+  const proceedSingle = el => (this.browser.isW3C ? el.getValue() : this.browser.getElementProperty(getElementId(el), 'value').then((res) => {
     if (res === null) {
       throw new Error(`Element ${el.selector} has no value property`);
     }
     stringIncludes(`fields by ${field}`)[assertType](value, res);
-  });
+  }));
 
   const filterBySelected = async elements => filterAsync(elements, async el => this.browser.isElementSelected(getElementId(el)));
 

--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -2710,7 +2710,7 @@ async function proceedSeeField(assertType, field, value) {
   const proceedMultiple = async (fields) => {
     const fieldResults = toArray(await forEachAsync(fields, async (el) => {
       const elementId = getElementId(el);
-      return this.browser.isW3C ? el.getValue() : this.browser.getElementAttribute(elementId, 'value');
+      return this.browser.isW3C ? el.getValue() : this.browser.getElementProperty(elementId, 'value');
     }));
 
     if (typeof value === 'boolean') {
@@ -2722,9 +2722,9 @@ async function proceedSeeField(assertType, field, value) {
     }
   };
 
-  const proceedSingle = el => this.browser.getElementAttribute(getElementId(el), 'value').then((res) => {
+  const proceedSingle = el => this.browser.getElementProperty(getElementId(el), 'value').then((res) => {
     if (res === null) {
-      throw new Error(`Element ${el.selector} has no value attribute`);
+      throw new Error(`Element ${el.selector} has no value property`);
     }
     stringIncludes(`fields by ${field}`)[assertType](value, res);
   });


### PR DESCRIPTION
## Motivation/Description of the PR
### Description of this PR

.seeInField sees the input as having a blank value, even though it is not blank.

This was working fine until yesterday, but after upgrading from Chrome 90 to Chrome 92, 15 of my tests are failing.

It's not clear exactly what change in behavior caused this, but it seems that this line in the CodeceptJS's Webdriver.js helper is at the heart of the matter:

```
const proceedSingle = el => this.browser.getElementAttribute(getElementId(el), 'value').then((res) => {
```
It looks like this line is grabbing the value of the input's value attribute instead of the input's actual value (which is not the same thing). In my case, the input has a blank value attribute but has a value, so .seeInField() seems to think the input is blank when it isn't.

Why is the .seeInField helper implemented this way? It seems that .grabValueFrom is able to grab this input's value just fine, so there is an inconsistency here.

Example:

```
const templateName = await I.grabValueFrom('#templateName');

console.log(templateName);  // logs "TestForms"

I.seeInField('#templateName', 'TestForms');  // fails with the assertion error below
```


### Resolves #2965.

Applicable helpers:

- [x] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
