### PR TITLE
Update email.md

### DIFF
--- a/docs/email.md
+++ b/docs/email.md
@@ -145,6 +145,8 @@ After opening an email assertion methods are available.
 * `seeEmailIsFrom`
 * `seeInEmailBody`
 * `dontSeeInEmailBody`
+* `seeNumberOfEmailAttachments`
+* `seeEmailAttachment`
 
 And here is an example of their usage:
 
@@ -153,6 +155,9 @@ I.waitForLatestEmail()
 I.seeEmailIsFrom('@mysite.com');
 I.seeInEmailSubject('Awesome Proposal!');
 I.seeInEmailBody('To unsubscribe click here');
+I.seeNumberOfEmailAttachments(2);
+I.seeEmailAttachment('Attachment_1.pdf')
+I.seeEmailAttachment('Attachment_2.pdf')
 ```
 
 > More methods are listed in [helper's API reference](https://github.com/codeceptjs/mailslurp-helper/blob/master/README.md#api)


### PR DESCRIPTION
New available steps since v1.0.6 of Mailslurp helper added to documentation:

```
I.seeNumberOfEmailAttachments(2);
I.seeEmailAttachment('Attachment_1.pdf')
```

See recently merged PR: https://github.com/codeceptjs/mailslurp-helper/pull/22

## Motivation/Description of the PR
- Description of this PR, which problem it solves
- Resolves #issueId (if applicable).

Applicable helpers:

- [ ] WebDriver
- [ ] Puppeteer
- [ ] Nightmare
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] Protractor
- [ ] TestCafe
- [ ] Playwright

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
