### PR TITLE
feat: add switchToTab

### DIFF
--- a/docs/helpers/Playwright.md
+++ b/docs/helpers/Playwright.md
@@ -2335,6 +2335,19 @@ I.switchToPreviousTab(2);
 
 *   `num` **[number][20]**  
 
+### switchToTab
+
+Switch focus to a particular tab by its number. It waits tabs loading and then switch tab
+
+```js
+I.switchToTab(2);
+```
+
+#### Parameters
+
+*   `num` &#x20;
+*   `number` &#x20;
+
 ### type
 
 Types out the given text into an active field.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,6 +1,6 @@
 ---
 permalink: plugins
-sidebarDepth:
+sidebarDepth: 
 sidebar: auto
 title: Plugins
 ---
@@ -24,42 +24,42 @@ exports.config = {
       enabled: true,
       clusterize: 5,
       analyze: 2,
-      vision: false,
-    },
-  },
+      vision: false
+    }
+  }
 }
 ```
 
 #### Configuration
 
-- `clusterize` (number) - minimum number of failures to trigger clustering analysis. Default: 5
-- `analyze` (number) - maximum number of individual test failures to analyze in detail. Default: 2
-- `vision` (boolean) - enables visual analysis of test screenshots. Default: false
-- `categories` (array) - list of failure categories for classification. Defaults to:
-  - Browser connection error / browser crash
-  - Network errors (server error, timeout, etc)
-  - HTML / page elements (not found, not visible, etc)
-  - Navigation errors (404, etc)
-  - Code errors (syntax error, JS errors, etc)
-  - Library & framework errors
-  - Data errors (password incorrect, invalid format, etc)
-  - Assertion failures
-  - Other errors
-- `prompts` (object) - customize AI prompts for analysis
-  - `clusterize` - prompt for clustering analysis
-  - `analyze` - prompt for individual test analysis
+*   `clusterize` (number) - minimum number of failures to trigger clustering analysis. Default: 5
+*   `analyze` (number) - maximum number of individual test failures to analyze in detail. Default: 2
+*   `vision` (boolean) - enables visual analysis of test screenshots. Default: false
+*   `categories` (array) - list of failure categories for classification. Defaults to:
+    *   Browser connection error / browser crash
+    *   Network errors (server error, timeout, etc)
+    *   HTML / page elements (not found, not visible, etc)
+    *   Navigation errors (404, etc)
+    *   Code errors (syntax error, JS errors, etc)
+    *   Library & framework errors
+    *   Data errors (password incorrect, invalid format, etc)
+    *   Assertion failures
+    *   Other errors
+*   `prompts` (object) - customize AI prompts for analysis
+    *   `clusterize` - prompt for clustering analysis
+    *   `analyze` - prompt for individual test analysis
 
 #### Features
 
-- Groups similar failures when number of failures >= clusterize value
-- Provides detailed analysis of individual failures
-- Analyzes screenshots if vision=true and screenshots are available
-- Classifies failures into predefined categories
-- Suggests possible causes and solutions
+*   Groups similar failures when number of failures >= clusterize value
+*   Provides detailed analysis of individual failures
+*   Analyzes screenshots if vision=true and screenshots are available
+*   Classifies failures into predefined categories
+*   Suggests possible causes and solutions
 
 ### Parameters
 
-- `config` **[Object][1]** Plugin configuration (optional, default `{}`)
+*   `config` **[Object][1]** Plugin configuration (optional, default `{}`)
 
 Returns **void**&#x20;
 
@@ -81,28 +81,28 @@ If a session expires automatically logs in again.
 ```js
 // inside a test file
 // use login to inject auto-login function
-Feature('Login')
+Feature('Login');
 
 Before(({ login }) => {
-  login('user') // login using user session
-})
+   login('user'); // login using user session
+});
 
 // Alternatively log in for one scenario.
-Scenario('log me in', ({ I, login }) => {
-  login('admin')
-  I.see('I am logged in')
-})
+Scenario('log me in', ( { I, login } ) => {
+   login('admin');
+   I.see('I am logged in');
+});
 ```
 
 #### Configuration
 
-- `saveToFile` (default: false) - save cookies to file. Allows to reuse session between execution.
-- `inject` (default: `login`) - name of the login function to use
-- `users` - an array containing different session names and functions to:
-  - `login` - sign in into the system
-  - `check` - check that user is logged in
-  - `fetch` - to get current cookies (by default `I.grabCookie()`)
-  - `restore` - to set cookies (by default `I.amOnPage('/'); I.setCookie(cookie)`)
+*   `saveToFile` (default: false) - save cookies to file. Allows to reuse session between execution.
+*   `inject` (default: `login`) - name of the login function to use
+*   `users` - an array containing different session names and functions to:
+    *   `login` - sign in into the system
+    *   `check` - check that user is logged in
+    *   `fetch` - to get current cookies (by default `I.grabCookie()`)
+    *   `restore` - to set cookies (by default `I.amOnPage('/'); I.setCookie(cookie)`)
 
 #### How It Works
 
@@ -253,7 +253,7 @@ auth: {
 ```
 
 ```js
-Scenario('login', async ({ I, login }) => {
+Scenario('login', async ( {I, login} ) => {
   await login('admin') // you should use `await`
 })
 ```
@@ -287,14 +287,14 @@ auth: {
 ```
 
 ```js
-Scenario('login', async ({ I, login }) => {
+Scenario('login', async ( {I, login} ) => {
   await login('admin') // you should use `await`
 })
 ```
 
 ### Parameters
 
-- `config` &#x20;
+*   `config` &#x20;
 
 ## autoDelay
 
@@ -309,32 +309,32 @@ It puts a tiny delay for before and after action commands.
 
 Commands affected (by default):
 
-- `click`
-- `fillField`
-- `checkOption`
-- `pressKey`
-- `doubleClick`
-- `rightClick`
+*   `click`
+*   `fillField`
+*   `checkOption`
+*   `pressKey`
+*   `doubleClick`
+*   `rightClick`
 
 #### Configuration
 
 ```js
 plugins: {
-  autoDelay: {
-    enabled: true
-  }
+   autoDelay: {
+     enabled: true
+   }
 }
 ```
 
 Possible config options:
 
-- `methods`: list of affected commands. Can be overridden
-- `delayBefore`: put a delay before a command. 100ms by default
-- `delayAfter`: put a delay after a command. 200ms by default
+*   `methods`: list of affected commands. Can be overridden
+*   `delayBefore`: put a delay before a command. 100ms by default
+*   `delayAfter`: put a delay after a command. 200ms by default
 
 ### Parameters
 
-- `config` &#x20;
+*   `config` &#x20;
 
 ## commentStep
 
@@ -343,16 +343,16 @@ This plugin is **deprecated**, use `Section` instead.
 Add descriptive nested steps for your tests:
 
 ```js
-Scenario('project update test', async I => {
-  __`Given`
-  const projectId = await I.have('project')
+Scenario('project update test', async (I) => {
+  __`Given`;
+  const projectId = await I.have('project');
 
-  __`When`
-  projectPage.update(projectId, { title: 'new title' })
+  __`When`;
+  projectPage.update(projectId, { title: 'new title' });
 
-  __`Then`
-  projectPage.open(projectId)
-  I.see('new title', 'h1')
+  __`Then`;
+  projectPage.open(projectId);
+  I.see('new title', 'h1');
 })
 ```
 
@@ -372,8 +372,8 @@ This plugin can be used
 
 ### Config
 
-- `enabled` - (default: false) enable a plugin
-- `registerGlobal` - (default: false) register `__` template literal function globally. You can override function global name by providing a name as a value.
+*   `enabled` - (default: false) enable a plugin
+*   `registerGlobal` - (default: false) register `__` template literal function globally. You can override function global name by providing a name as a value.
 
 ### Examples
 
@@ -414,11 +414,11 @@ For instance, you can prepare Given/When/Then functions to use them inside tests
 
 ```js
 // inside a test
-const step = codeceptjs.container.plugins('commentStep')
+const step = codeceptjs.container.plugins('commentStep');
 
-const Given = () => step`Given`
-const When = () => step`When`
-const Then = () => step`Then`
+const Given = () => step`Given`;
+const When = () => step`When`;
+const Then = () => step`Then`;
 ```
 
 Scenario('project update test', async (I) => {
@@ -434,12 +434,11 @@ I.see('new title', 'h1');
 });
 
 ```
-
 ```
 
 ### Parameters
 
-- `config` &#x20;
+*   `config` &#x20;
 
 ## consolidateWorkerJsonResults
 
@@ -447,7 +446,7 @@ Consolidates JSON reports from multiple workers into a single HTML report
 
 ### Parameters
 
-- `config` &#x20;
+*   `config` &#x20;
 
 ## coverage
 
@@ -468,15 +467,15 @@ plugins: {
 
 Possible config options, More could be found at [monocart-coverage-reports][2]
 
-- `debug`: debug info. By default, false.
-- `name`: coverage report name.
-- `outputDir`: path to coverage report.
-- `sourceFilter`: filter the source files.
-- `sourcePath`: option to resolve a custom path.
+*   `debug`: debug info. By default, false.
+*   `name`: coverage report name.
+*   `outputDir`: path to coverage report.
+*   `sourceFilter`: filter the source files.
+*   `sourcePath`: option to resolve a custom path.
 
 ### Parameters
 
-- `config` &#x20;
+*   `config` &#x20;
 
 ## customLocator
 
@@ -496,11 +495,11 @@ This plugin will create a valid XPath locator for you.
 
 #### Configuration
 
-- `enabled` (default: `false`) should a locator be enabled
-- `prefix` (default: `$`) sets a prefix for a custom locator.
-- `attribute` (default: `data-test-id`) to set an attribute to be matched.
-- `strategy` (default: `xpath`) actual locator strategy to use in query (`css` or `xpath`).
-- `showActual` (default: false) show in the output actually produced XPath or CSS locator. By default shows custom locator value.
+*   `enabled` (default: `false`) should a locator be enabled
+*   `prefix` (default: `$`) sets a prefix for a custom locator.
+*   `attribute` (default: `data-test-id`) to set an attribute to be matched.
+*   `strategy` (default: `xpath`) actual locator strategy to use in query (`css` or `xpath`).
+*   `showActual` (default: false) show in the output actually produced XPath or CSS locator. By default shows custom locator value.
 
 #### Examples:
 
@@ -519,8 +518,8 @@ plugins: {
 In a test:
 
 ```js
-I.seeElement('$user') // matches => [data-test=user]
-I.click('$sign-up') // matches => [data-test=sign-up]
+I.seeElement('$user'); // matches => [data-test=user]
+I.click('$sign-up'); // matches => [data-test=sign-up]
 ```
 
 Using `data-qa` attribute with `=` prefix:
@@ -539,8 +538,8 @@ plugins: {
 In a test:
 
 ```js
-I.seeElement('=user') // matches => [data-qa=user]
-I.click('=sign-up') // matches => [data-qa=sign-up]
+I.seeElement('=user'); // matches => [data-qa=user]
+I.click('=sign-up'); // matches => [data-qa=sign-up]
 ```
 
 Using `data-qa` OR `data-test` attribute with `=` prefix:
@@ -560,8 +559,8 @@ plugins: {
 In a test:
 
 ```js
-I.seeElement('=user') // matches => //*[@data-qa=user or @data-test=user]
-I.click('=sign-up') // matches => //*[data-qa=sign-up or @data-test=sign-up]
+I.seeElement('=user'); // matches => //*[@data-qa=user or @data-test=user]
+I.click('=sign-up'); // matches => //*[data-qa=sign-up or @data-test=sign-up]
 ```
 
 ```js
@@ -579,13 +578,13 @@ plugins: {
 In a test:
 
 ```js
-I.seeElement('=user') // matches => [data-qa=user],[data-test=user]
-I.click('=sign-up') // matches => [data-qa=sign-up],[data-test=sign-up]
+I.seeElement('=user'); // matches => [data-qa=user],[data-test=user]
+I.click('=sign-up'); // matches => [data-qa=sign-up],[data-test=sign-up]
 ```
 
 ### Parameters
 
-- `config` &#x20;
+*   `config` &#x20;
 
 ## customReporter
 
@@ -593,7 +592,7 @@ Sample custom reporter for CodeceptJS.
 
 ### Parameters
 
-- `config` &#x20;
+*   `config` &#x20;
 
 ## eachElement
 
@@ -601,17 +600,17 @@ Provides `eachElement` global function to iterate over found elements to perform
 
 `eachElement` takes following args:
 
-- `purpose` - the goal of an action. A comment text that will be displayed in output.
-- `locator` - a CSS/XPath locator to match elements
-- `fn(element, index)` - **asynchronous** function which will be executed for each matched element.
+*   `purpose` - the goal of an action. A comment text that will be displayed in output.
+*   `locator` - a CSS/XPath locator to match elements
+*   `fn(element, index)` - **asynchronous** function which will be executed for each matched element.
 
 Example of usage:
 
 ```js
 // this example works with Playwright and Puppeteer helper
-await eachElement('click all checkboxes', 'form input[type=checkbox]', async el => {
-  await el.click()
-})
+await eachElement('click all checkboxes', 'form input[type=checkbox]', async (el) => {
+  await el.click();
+});
 ```
 
 Click odd elements:
@@ -619,18 +618,18 @@ Click odd elements:
 ```js
 // this example works with Playwright and Puppeteer helper
 await eachElement('click odd buttons', '.button-select', async (el, index) => {
-  if (index % 2) await el.click()
-})
+  if (index % 2) await el.click();
+});
 ```
 
 Check all elements for visibility:
 
 ```js
 // this example works with Playwright and Puppeteer helper
-const assert = require('assert')
-await eachElement('check all items are visible', '.item', async el => {
-  assert(await el.isVisible())
-})
+const assert = require('assert');
+await eachElement('check all items are visible', '.item', async (el) => {
+  assert(await el.isVisible());
+});
 ```
 
 This method works with WebDriver, Playwright, Puppeteer, Appium helpers.
@@ -638,25 +637,25 @@ This method works with WebDriver, Playwright, Puppeteer, Appium helpers.
 Function parameter `el` represents a matched element.
 Depending on a helper API of `el` can be different. Refer to API of corresponding browser testing engine for a complete API list:
 
-- [Playwright ElementHandle][4]
-- [Puppeteer][5]
-- [webdriverio element][6]
+*   [Playwright ElementHandle][4]
+*   [Puppeteer][5]
+*   [webdriverio element][6]
 
 #### Configuration
 
-- `registerGlobal` - to register `eachElement` function globally, true by default
+*   `registerGlobal` - to register `eachElement` function globally, true by default
 
 If `registerGlobal` is false you can use eachElement from the plugin:
 
 ```js
-const eachElement = codeceptjs.container.plugins('eachElement')
+const eachElement = codeceptjs.container.plugins('eachElement');
 ```
 
 ### Parameters
 
-- `purpose` **[string][7]**&#x20;
-- `locator` **CodeceptJS.LocatorOrString**&#x20;
-- `fn` **[Function][8]**&#x20;
+*   `purpose` **[string][7]**&#x20;
+*   `locator` **CodeceptJS.LocatorOrString**&#x20;
+*   `fn` **[Function][8]**&#x20;
 
 Returns **([Promise][9]\<any> | [undefined][10])**&#x20;
 
@@ -669,7 +668,7 @@ to avoid conflicts and provide predictable behavior.
 
 ### Parameters
 
-- `config` &#x20;
+*   `config` &#x20;
 
 ## fakerTransform
 
@@ -689,9 +688,9 @@ Add this plugin to config file:
 
 ```js
 plugins: {
-  fakerTransform: {
-    enabled: true
-  }
+   fakerTransform: {
+     enabled: true
+   }
 }
 ```
 
@@ -709,7 +708,7 @@ Scenario Outline: ...
 
 ### Parameters
 
-- `config` &#x20;
+*   `config` &#x20;
 
 ## heal
 
@@ -727,11 +726,11 @@ plugins: {
 
 More config options are available:
 
-- `healLimit` - how many steps can be healed in a single test (default: 2)
+*   `healLimit` - how many steps can be healed in a single test (default: 2)
 
 ### Parameters
 
-- `config` (optional, default `{}`)
+*   `config`   (optional, default `{}`)
 
 ## htmlReporter
 
@@ -739,10 +738,10 @@ HTML Reporter Plugin for CodeceptJS
 
 Generates comprehensive HTML reports showing:
 
-- Test statistics
-- Feature/Scenario details
-- Individual step results
-- Test artifacts (screenshots, etc.)
+*   Test statistics
+*   Feature/Scenario details
+*   Individual step results
+*   Test artifacts (screenshots, etc.)
 
 ## Configuration
 
@@ -769,7 +768,7 @@ Generates comprehensive HTML reports showing:
 
 ### Parameters
 
-- `config` &#x20;
+*   `config` &#x20;
 
 ## pageInfo
 
@@ -790,12 +789,12 @@ plugins: {
 
 Additional config options:
 
-- `errorClasses` - list of classes to search for errors (default: `['error', 'warning', 'alert', 'danger']`)
-- `browserLogs` - list of types of errors to search for in browser logs (default: `['error']`)
+*   `errorClasses` - list of classes to search for errors (default: `['error', 'warning', 'alert', 'danger']`)
+*   `browserLogs` - list of types of errors to search for in browser logs (default: `['error']`)
 
 ### Parameters
 
-- `config` (optional, default `{}`)
+*   `config`   (optional, default `{}`)
 
 ## pauseOnFail
 
@@ -827,9 +826,9 @@ Add this plugin to config file:
 
 ```js
 plugins: {
-  retryFailedStep: {
-    enabled: true
-  }
+    retryFailedStep: {
+       enabled: true
+    }
 }
 ```
 
@@ -839,22 +838,22 @@ Run tests with plugin enabled:
 
 #### Configuration:
 
-- `retries` - number of retries (by default 3),
-- `when` - function, when to perform a retry (accepts error as parameter)
-- `factor` - The exponential factor to use. Default is 1.5.
-- `minTimeout` - The number of milliseconds before starting the first retry. Default is 1000.
-- `maxTimeout` - The maximum number of milliseconds between two retries. Default is Infinity.
-- `randomize` - Randomizes the timeouts by multiplying with a factor from 1 to 2. Default is false.
-- `defaultIgnoredSteps` - an array of steps to be ignored for retry. Includes:
-  - `amOnPage`
-  - `wait*`
-  - `send*`
-  - `execute*`
-  - `run*`
-  - `have*`
-- `ignoredSteps` - an array for custom steps to ignore on retry. Use it to append custom steps to ignored list.
-  You can use step names or step prefixes ending with `*`. As such, `wait*` will match all steps starting with `wait`.
-  To append your own steps to ignore list - copy and paste a default steps list. Regexp values are accepted as well.
+*   `retries` - number of retries (by default 3),
+*   `when` - function, when to perform a retry (accepts error as parameter)
+*   `factor` - The exponential factor to use. Default is 1.5.
+*   `minTimeout` - The number of milliseconds before starting the first retry. Default is 1000.
+*   `maxTimeout` - The maximum number of milliseconds between two retries. Default is Infinity.
+*   `randomize` - Randomizes the timeouts by multiplying with a factor from 1 to 2. Default is false.
+*   `defaultIgnoredSteps` - an array of steps to be ignored for retry. Includes:
+    *   `amOnPage`
+    *   `wait*`
+    *   `send*`
+    *   `execute*`
+    *   `run*`
+    *   `have*`
+*   `ignoredSteps` - an array for custom steps to ignore on retry. Use it to append custom steps to ignored list.
+    You can use step names or step prefixes ending with `*`. As such, `wait*` will match all steps starting with `wait`.
+    To append your own steps to ignore list - copy and paste a default steps list. Regexp values are accepted as well.
 
 #### Example
 
@@ -878,13 +877,13 @@ Use scenario configuration to disable plugin for a test
 
 ```js
 Scenario('scenario tite', { disableRetryFailedStep: true }, () => {
-  // test goes here
+   // test goes here
 })
 ```
 
 ### Parameters
 
-- `config` &#x20;
+*   `config` &#x20;
 
 ## safeJsonStringify
 
@@ -892,7 +891,7 @@ Safely serialize data to JSON, handling circular references
 
 ### Parameters
 
-- `data` &#x20;
+*   `data` &#x20;
 
 ## screenshotOnFail
 
@@ -908,20 +907,20 @@ Configuration can either be taken from a corresponding helper (deprecated) or a 
 
 ```js
 plugins: {
-  screenshotOnFail: {
-    enabled: true
-  }
+   screenshotOnFail: {
+     enabled: true
+   }
 }
 ```
 
 Possible config options:
 
-- `uniqueScreenshotNames`: use unique names for screenshot. Default: false.
-- `fullPageScreenshots`: make full page screenshots. Default: false.
+*   `uniqueScreenshotNames`: use unique names for screenshot. Default: false.
+*   `fullPageScreenshots`: make full page screenshots. Default: false.
 
 ### Parameters
 
-- `config` &#x20;
+*   `config` &#x20;
 
 ## selenoid
 
@@ -978,7 +977,7 @@ This is especially useful for Continous Integration server as you can configure 
 1.  Create `browsers.json` file in the same directory `codecept.conf.js` is located
     [Refer to Selenoid documentation][16] to know more about browsers.json.
 
-_Sample browsers.json_
+*Sample browsers.json*
 
 ```js
 {
@@ -1038,7 +1037,7 @@ When `allure` plugin is enabled a video is attached to report automatically.
 
 ### Parameters
 
-- `config` &#x20;
+*   `config` &#x20;
 
 ## stepByStepReport
 
@@ -1064,17 +1063,17 @@ Run tests with plugin enabled:
 
 Possible config options:
 
-- `deleteSuccessful`: do not save screenshots for successfully executed tests. Default: true.
-- `animateSlides`: should animation for slides to be used. Default: true.
-- `ignoreSteps`: steps to ignore in report. Array of RegExps is expected. Recommended to skip `grab*` and `wait*` steps.
-- `fullPageScreenshots`: should full page screenshots be used. Default: false.
-- `output`: a directory where reports should be stored. Default: `output`.
-- `screenshotsForAllureReport`: If Allure plugin is enabled this plugin attaches each saved screenshot to allure report. Default: false.
-- \`disableScreenshotOnFail : Disables the capturing of screeshots after the failed step. Default: true.
+*   `deleteSuccessful`: do not save screenshots for successfully executed tests. Default: true.
+*   `animateSlides`: should animation for slides to be used. Default: true.
+*   `ignoreSteps`: steps to ignore in report. Array of RegExps is expected. Recommended to skip `grab*` and `wait*` steps.
+*   `fullPageScreenshots`: should full page screenshots be used. Default: false.
+*   `output`: a directory where reports should be stored. Default: `output`.
+*   `screenshotsForAllureReport`: If Allure plugin is enabled this plugin attaches each saved screenshot to allure report. Default: false.
+*   \`disableScreenshotOnFail : Disables the capturing of screeshots after the failed step. Default: true.
 
 ### Parameters
 
-- `config` **any**&#x20;
+*   `config` **any**&#x20;
 
 ## stepTimeout
 
@@ -1084,9 +1083,9 @@ Add this plugin to config file:
 
 ```js
 plugins: {
-  stepTimeout: {
-    enabled: true
-  }
+    stepTimeout: {
+       enabled: true
+    }
 }
 ```
 
@@ -1096,18 +1095,19 @@ Run tests with plugin enabled:
 
 #### Configuration:
 
-- `timeout` - global step timeout, default 150 seconds
+*   `timeout` - global step timeout, default 150 seconds
 
-- `overrideStepLimits` - whether to use timeouts set in plugin config to override step timeouts set in code with I.limitTime(x).action(...), default false
+*   `overrideStepLimits` - whether to use timeouts set in plugin config to override step timeouts set in code with I.limitTime(x).action(...), default false
 
-- `noTimeoutSteps` - an array of steps with no timeout. Default:
-  - `amOnPage`
-  - `wait*`
+*   `noTimeoutSteps` - an array of steps with no timeout. Default:
 
-  you could set your own noTimeoutSteps which would replace the default one.
+    *   `amOnPage`
+    *   `wait*`
 
-- `customTimeoutSteps` - an array of step actions with custom timeout. Use it to override or extend noTimeoutSteps.
-  You can use step names or step prefixes ending with `*`. As such, `wait*` will match all steps starting with `wait`.
+    you could set your own noTimeoutSteps which would replace the default one.
+
+*   `customTimeoutSteps` - an array of step actions with custom timeout. Use it to override or extend noTimeoutSteps.
+    You can use step names or step prefixes ending with `*`. As such, `wait*` will match all steps starting with `wait`.
 
 #### Example
 
@@ -1130,7 +1130,7 @@ plugins: {
 
 ### Parameters
 
-- `config` &#x20;
+*   `config` &#x20;
 
 ## subtitles
 
@@ -1140,9 +1140,9 @@ Automatically captures steps as subtitle, and saves it as an artifact when a vid
 
 ```js
 plugins: {
-  subtitles: {
-    enabled: true
-  }
+ subtitles: {
+   enabled: true
+ }
 }
 ```
 
@@ -1152,11 +1152,11 @@ Webdriverio services runner.
 
 This plugin allows to run webdriverio services like:
 
-- selenium-standalone
-- sauce
-- testingbot
-- browserstack
-- appium
+*   selenium-standalone
+*   sauce
+*   testingbot
+*   browserstack
+*   appium
 
 A complete list of all available services can be found on [webdriverio website][20].
 
@@ -1204,38 +1204,59 @@ plugins: {
 }
 ```
 
----
+***
 
 In the same manner additional services from webdriverio can be installed, enabled, and configured.
 
 #### Configuration
 
-- `services` - list of enabled services
-- ... - additional configuration passed into services.
+*   `services` - list of enabled services
+*   ... - additional configuration passed into services.
 
 ### Parameters
 
-- `config` &#x20;
+*   `config` &#x20;
 
 [1]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
+
 [2]: https://github.com/cenfun/monocart-coverage-reports?tab=readme-ov-file#default-options
+
 [3]: https://codecept.io/locators#custom-locators
+
 [4]: https://playwright.dev/docs/api/class-elementhandle
+
 [5]: https://pptr.dev/#?product=Puppeteer&show=api-class-elementhandle
+
 [6]: https://webdriver.io/docs/api
+
 [7]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
+
 [8]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function
+
 [9]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise
+
 [10]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/undefined
+
 [11]: https://codecept.io/heal/
+
 [12]: /basics/#pause
+
 [13]: https://aerokube.com/selenoid/
+
 [14]: https://aerokube.com/cm/latest/
+
 [15]: https://hub.docker.com/u/selenoid
+
 [16]: https://aerokube.com/selenoid/latest/#_prepare_configuration
+
 [17]: https://aerokube.com/selenoid/latest/#_option_2_start_selenoid_container
+
 [18]: https://docs.docker.com/engine/reference/commandline/create/
+
 [19]: https://codecept.io/img/codeceptjs-slideshow.gif
+
 [20]: https://webdriver.io
+
 [21]: https://webdriver.io/docs/selenium-standalone-service.html
+
 [22]: https://webdriver.io/docs/sauce-service.html

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -1517,6 +1517,31 @@ class Playwright extends Helper {
    * Switch focus to a particular tab by its number. It waits tabs loading and then switch tab
    *
    * ```js
+   * I.switchToTab(2);
+   * ```
+   *
+   * @param {number}
+   */
+  async switchToTab(num) {
+    if (this.isElectron) {
+      throw new Error('Cannot switch tabs inside an Electron container')
+    }
+    const pages = await this.browserContext.pages()
+    this.withinLocator = null
+    const page = pages[num]
+
+    if (!page) {
+      throw new Error(`There is no ability to switch to tab with index ${num}`)
+    }
+
+    await this._setPage(page)
+    return this._waitForAction()
+  }
+
+  /**
+   * Switch focus to a particular tab by its number. It waits tabs loading and then switch tab
+   *
+   * ```js
    * I.switchToNextTab();
    * I.switchToNextTab(2);
    * ```

--- a/test/helper/Playwright_test.js
+++ b/test/helper/Playwright_test.js
@@ -286,6 +286,29 @@ describe('Playwright', function () {
         .then(() => I.grabNumberOfOpenTabs())
         .then(numPages => assert.equal(numPages, 1)))
 
+    it('should switch to tab', () =>
+      I.amOnPage('/info')
+        .then(() => I.wait(1))
+        .then(() => I.grabNumberOfOpenTabs())
+        .then(numPages => assert.equal(numPages, 1))
+        .then(() => I.click('New tab'))
+        .then(() => I.switchToTab(2))
+        .then(() => I.wait(2))
+        .then(() => I.seeCurrentUrlEquals('/login'))
+        .then(() => I.grabNumberOfOpenTabs())
+        .then(numPages => assert.equal(numPages, 2)))
+
+    it('should assert when there is no ability to switch to tab', () =>
+      I.amOnPage('/')
+        .then(() => I.click('More info'))
+        .then(() => I.wait(1)) // Wait is required because the url is change by previous statement (maybe related to #914)
+        .then(() => I.switchToTab(2))
+        .then(() => I.wait(2))
+        .then(() => assert.equal(true, false, 'Throw an error if it gets this far (which it should not)!'))
+        .catch(e => {
+          assert.equal(e.message, 'There is no ability to switch to tab with index 2')
+        }))
+
     it('should switch to next tab', () =>
       I.amOnPage('/info')
         .then(() => I.wait(1))
@@ -1573,6 +1596,17 @@ describe('Playwright - Electron', () => {
         throw Error('It should never get this far')
       } catch (e) {
         e.message.should.include('Cannot open new tabs inside an Electron container')
+      }
+    })
+  })
+
+  describe('#switchToTab', () => {
+    it('should throw an error', async () => {
+      try {
+        await I.switchToTab()
+        throw Error('It should never get this far')
+      } catch (e) {
+        e.message.should.include('Cannot switch tabs inside an Electron container')
       }
     })
   })


### PR DESCRIPTION
## Add method to switch to tab

Our app open a window and in this window we call `window.close()` after clicking on button.

The problem is that `switchToPreviousTab()` need a active tab. In our app the window/tab is already close by our application.

So with the new method `switchToTab` you can switch to any open tab.

Applicable helpers:

- [x] Playwright

## Type of change

- [x] :rocket: New functionality
- [x] :bug: Bug fix

## Checklist:

- [x] Tests have been added
- [x] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)

## Question

`switchToNextTab` also call `await targetCreatedHandler.call(this, page)` but `switchToPreviousTab` not. I am not shure if `switchToTab` should also call `await targetCreatedHandler.call(this, page)`?

We can also remove the duplicate code and use `switchTotTab` in `switchToPreviousTab()` and `switchToNextTab()`