### PR TITLE
feat: fillField supports rich text editors

### DIFF
--- a/lib/element/WebElement.js
+++ b/lib/element/WebElement.js
@@ -306,8 +306,15 @@ class WebElement {
       case 'playwright':
       case 'puppeteer':
         return this.helper.page.keyboard.type(s, options)
-      case 'webdriver':
-        return this.helper.browser.keys(s)
+      case 'webdriver': {
+        const ENTER = '\uE007'
+        const parts = s.split('\n')
+        for (let i = 0; i < parts.length; i++) {
+          if (parts[i]) await this.helper.browser.keys(parts[i])
+          if (i < parts.length - 1) await this.helper.browser.keys(ENTER)
+        }
+        return
+      }
       default:
         throw new Error(`Unsupported helper type: ${this.helperType}`)
     }
@@ -364,12 +371,12 @@ class WebElement {
       }
       case 'webdriver': {
         const browser = this.helper.browser
-        await browser.switchToFrame(this.element)
+        await browser.switchFrame(this.element)
         try {
           const body = await browser.$('body')
           return await fn(new WebElement(body, this.helper))
         } finally {
-          await browser.switchToParentFrame()
+          await browser.switchFrame(null)
         }
       }
       default:

--- a/lib/element/WebElement.js
+++ b/lib/element/WebElement.js
@@ -257,6 +257,125 @@ class WebElement {
   }
 
   /**
+   * Run a function in the browser with this element as the first argument.
+   * @param {Function} fn Browser-side function. Receives the element, then extra args.
+   * @param {...any} args Additional arguments passed to the function
+   * @returns {Promise<any>} Value returned by fn
+   */
+  async evaluate(fn, ...args) {
+    switch (this.helperType) {
+      case 'playwright':
+      case 'puppeteer':
+        return this.element.evaluate(fn, ...args)
+      case 'webdriver':
+        return this.helper.executeScript(fn, this.element, ...args)
+      default:
+        throw new Error(`Unsupported helper type: ${this.helperType}`)
+    }
+  }
+
+  /**
+   * Focus the element.
+   * @returns {Promise<void>}
+   */
+  async focus() {
+    switch (this.helperType) {
+      case 'playwright':
+        return this.element.focus()
+      case 'puppeteer':
+        if (this.element.focus) return this.element.focus()
+        return this.element.evaluate(el => el.focus())
+      case 'webdriver':
+        return this.helper.executeScript(el => el.focus(), this.element)
+      default:
+        throw new Error(`Unsupported helper type: ${this.helperType}`)
+    }
+  }
+
+  /**
+   * Type characters via the page/browser keyboard into the focused element.
+   * Unlike `type()`, this does not call `.fill()`/`.setValue()`, so it works
+   * with contenteditable nodes, iframe bodies, and editor-owned hidden textareas.
+   * @param {string} text Text to send
+   * @param {Object} [options] Options (e.g. `{ delay }`)
+   * @returns {Promise<void>}
+   */
+  async typeText(text, options = {}) {
+    const s = String(text)
+    switch (this.helperType) {
+      case 'playwright':
+      case 'puppeteer':
+        return this.helper.page.keyboard.type(s, options)
+      case 'webdriver':
+        return this.element.keys(s.split(''))
+      default:
+        throw new Error(`Unsupported helper type: ${this.helperType}`)
+    }
+  }
+
+  /**
+   * Select all content in the focused field and delete it via keyboard input.
+   * Sends Ctrl+A and Meta+A (so it works across platforms) followed by Backspace.
+   * @returns {Promise<void>}
+   */
+  async selectAllAndDelete() {
+    switch (this.helperType) {
+      case 'playwright':
+        await this.helper.page.keyboard.press('Control+a').catch(() => {})
+        await this.helper.page.keyboard.press('Meta+a').catch(() => {})
+        await this.helper.page.keyboard.press('Backspace')
+        return
+      case 'puppeteer':
+        for (const mod of ['Control', 'Meta']) {
+          try {
+            await this.helper.page.keyboard.down(mod)
+            await this.helper.page.keyboard.press('KeyA')
+            await this.helper.page.keyboard.up(mod)
+          } catch (e) {}
+        }
+        await this.helper.page.keyboard.press('Backspace')
+        return
+      case 'webdriver':
+        await this.element.keys(['Control', 'a'])
+        await this.element.keys(['Meta', 'a'])
+        await this.element.keys(['Backspace'])
+        return
+      default:
+        throw new Error(`Unsupported helper type: ${this.helperType}`)
+    }
+  }
+
+  /**
+   * Treat this element as an iframe; invoke `fn` with a WebElement wrapping
+   * the iframe body. For WebDriver this switches the browser into the frame
+   * for the duration of the callback and switches back on exit.
+   * @param {(body: WebElement) => Promise<any>} fn
+   * @returns {Promise<any>} Return value of fn
+   */
+  async inIframe(fn) {
+    switch (this.helperType) {
+      case 'playwright':
+      case 'puppeteer': {
+        const frame = await this.element.contentFrame()
+        const body = await frame.$('body')
+        return fn(new WebElement(body, this.helper))
+      }
+      case 'webdriver': {
+        const browser = this.helper.browser
+        await browser.switchToFrame(this.element)
+        try {
+          const body = await browser.$('body')
+          return await fn(new WebElement(body, this.helper))
+        } finally {
+          await browser.switchToParentFrame()
+        }
+      }
+      default:
+        throw new Error(`Unsupported helper type: ${this.helperType}`)
+    }
+  }
+
+  /**
    * Find first child element matching the locator
    * @param {string|Object} locator Element locator
    * @returns {Promise<WebElement|null>} WebElement instance or null if not found

--- a/lib/element/WebElement.js
+++ b/lib/element/WebElement.js
@@ -307,7 +307,7 @@ class WebElement {
       case 'puppeteer':
         return this.helper.page.keyboard.type(s, options)
       case 'webdriver':
-        return this.element.keys(s.split(''))
+        return this.helper.browser.keys(s)
       default:
         throw new Error(`Unsupported helper type: ${this.helperType}`)
     }
@@ -335,11 +335,13 @@ class WebElement {
         }
         await this.helper.page.keyboard.press('Backspace')
         return
-      case 'webdriver':
-        await this.element.keys(['Control', 'a'])
-        await this.element.keys(['Meta', 'a'])
-        await this.element.keys(['Backspace'])
+      case 'webdriver': {
+        const b = this.helper.browser
+        await b.keys(['Control', 'a']).catch(() => {})
+        await b.keys(['Meta', 'a']).catch(() => {})
+        await b.keys(['Backspace'])
         return
+      }
       default:
         throw new Error(`Unsupported helper type: ${this.helperType}`)
     }

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -40,6 +40,7 @@ import { findReact, findVue, findByPlaywrightLocator } from './extras/Playwright
 import { dropFile } from './scripts/dropFile.js'
 import WebElement from '../element/WebElement.js'
 import { selectElement } from './extras/elementSelection.js'
+import { fillRichEditor } from './extras/richTextEditor.js'
 
 let playwright
 let perfTiming
@@ -2283,10 +2284,14 @@ class Playwright extends Helper {
     assertElementExists(els, field, 'Field')
     const el = selectElement(els, field, this)
 
+    await highlightActiveElement.call(this, el)
+
+    if (await fillRichEditor(this, el, value)) {
+      return this._waitForAction()
+    }
+
     await el.clear()
     if (store.debugMode) this.debugSection('Focused', await elToString(el, 1))
-
-    await highlightActiveElement.call(this, el)
 
     await el.type(value.toString(), { delay: this.options.pressKeyDelay })
 

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -45,6 +45,7 @@ import { dontSeeElementError, seeElementError, dontSeeElementInDOMError, seeElem
 import { dontSeeTraffic, seeTraffic, grabRecordedNetworkTraffics, stopRecordingTraffic, flushNetworkTraffics } from './network/actions.js'
 import WebElement from '../element/WebElement.js'
 import { selectElement } from './extras/elementSelection.js'
+import { fillRichEditor } from './extras/richTextEditor.js'
 
 let puppeteer
 
@@ -1595,9 +1596,18 @@ class Puppeteer extends Helper {
    * {{ react }}
    */
   async fillField(field, value, context = null) {
-    const els = await findVisibleFields.call(this, field, context)
+    let els = await findVisibleFields.call(this, field, context)
+    if (!els.length) {
+      els = await findFields.call(this, field, context)
+    }
     assertElementExists(els, field, 'Field')
     const el = selectElement(els, field, this)
+
+    if (await fillRichEditor(this, el, value)) {
+      highlightActiveElement.call(this, el, await this._getContext())
+      return this._waitForAction()
+    }
+
     const tag = await el.getProperty('tagName').then(el => el.jsonValue())
     const editable = await el.getProperty('contenteditable').then(el => el.jsonValue())
     if (tag === 'INPUT' || tag === 'TEXTAREA') {

--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -42,6 +42,7 @@ import { dropFile } from './scripts/dropFile.js'
 import { dontSeeTraffic, seeTraffic, grabRecordedNetworkTraffics, stopRecordingTraffic, flushNetworkTraffics } from './network/actions.js'
 import WebElement from '../element/WebElement.js'
 import { selectElement } from './extras/elementSelection.js'
+import { fillRichEditor } from './extras/richTextEditor.js'
 
 const SHADOW = 'shadow'
 const webRoot = 'body'
@@ -1279,6 +1280,11 @@ class WebDriver extends Helper {
     assertElementExists(res, field, 'Field')
     const elem = selectElement(res, field, this)
     highlightActiveElement.call(this, elem)
+
+    if (await fillRichEditor(this, elem, value)) {
+      return
+    }
+
     try {
       await elem.clearValue()
     } catch (err) {

--- a/lib/helper/extras/richTextEditor.js
+++ b/lib/helper/extras/richTextEditor.js
@@ -96,7 +96,6 @@ export async function fillRichEditor(helper, el, value) {
 
   if (kind === EDITOR.IFRAME) {
     await target.inIframe(async body => {
-      await body.click({ force: true })
       await body.evaluate(selectAllInEditable)
       await body.typeText(value, { delay })
     })

--- a/lib/helper/extras/richTextEditor.js
+++ b/lib/helper/extras/richTextEditor.js
@@ -1,0 +1,115 @@
+import WebElement from '../../element/WebElement.js'
+
+const MARKER = 'data-codeceptjs-rte-target'
+
+const EDITOR = {
+  STANDARD: 'standard',
+  IFRAME: 'iframe',
+  CONTENTEDITABLE: 'contenteditable',
+  HIDDEN_TEXTAREA: 'hidden-textarea',
+}
+
+function detectAndMark(el, opts) {
+  const marker = opts.marker
+  const kinds = opts.kinds
+  const CE = '[contenteditable="true"], [contenteditable=""]'
+
+  function mark(kind, target) {
+    document.querySelectorAll('[' + marker + ']').forEach(n => n.removeAttribute(marker))
+    if (target && target.nodeType === 1) target.setAttribute(marker, '1')
+    return kind
+  }
+
+  if (!el || el.nodeType !== 1) return mark(kinds.STANDARD, el)
+
+  const tag = el.tagName
+  if (tag === 'IFRAME') return mark(kinds.IFRAME, el)
+  if (el.isContentEditable) return mark(kinds.CONTENTEDITABLE, el)
+
+  if (tag !== 'INPUT' && tag !== 'TEXTAREA') {
+    const iframe = el.querySelector('iframe')
+    if (iframe) return mark(kinds.IFRAME, iframe)
+    const ce = el.querySelector(CE)
+    if (ce) return mark(kinds.CONTENTEDITABLE, ce)
+    const textarea = el.querySelector('textarea')
+    if (textarea) return mark(kinds.HIDDEN_TEXTAREA, textarea)
+  }
+
+  const style = window.getComputedStyle(el)
+  const hidden =
+    el.offsetParent === null ||
+    (el.offsetWidth === 0 && el.offsetHeight === 0) ||
+    style.display === 'none' ||
+    style.visibility === 'hidden'
+
+  if (hidden) {
+    let scope = el.parentElement
+    while (scope) {
+      const iframeNear = scope.querySelector('iframe')
+      if (iframeNear) return mark(kinds.IFRAME, iframeNear)
+      const ceNear = scope.querySelector(CE)
+      if (ceNear) return mark(kinds.CONTENTEDITABLE, ceNear)
+      for (const t of scope.querySelectorAll('textarea')) {
+        if (t !== el) return mark(kinds.HIDDEN_TEXTAREA, t)
+      }
+      if (scope === document.body) break
+      scope = scope.parentElement
+    }
+  }
+
+  return mark(kinds.STANDARD, el)
+}
+
+function selectAllInEditable(el) {
+  const doc = el.ownerDocument
+  const win = doc.defaultView
+  el.focus()
+  const range = doc.createRange()
+  range.selectNodeContents(el)
+  const sel = win.getSelection()
+  sel.removeAllRanges()
+  sel.addRange(range)
+}
+
+function unmarkAll(marker) {
+  document.querySelectorAll('[' + marker + ']').forEach(n => n.removeAttribute(marker))
+}
+
+async function findMarked(helper) {
+  const root = helper.page || helper.browser
+  const raw = await root.$('[' + MARKER + ']')
+  return new WebElement(raw, helper)
+}
+
+async function clearMarker(helper) {
+  if (helper.page) return helper.page.evaluate(unmarkAll, MARKER)
+  return helper.executeScript(unmarkAll, MARKER)
+}
+
+export async function fillRichEditor(helper, el, value) {
+  const source = el instanceof WebElement ? el : new WebElement(el, helper)
+  const kind = await source.evaluate(detectAndMark, { marker: MARKER, kinds: EDITOR })
+  if (kind === EDITOR.STANDARD) return false
+
+  const target = await findMarked(helper)
+  const delay = helper.options.pressKeyDelay
+
+  if (kind === EDITOR.IFRAME) {
+    await target.inIframe(async body => {
+      await body.click({ force: true })
+      await body.evaluate(selectAllInEditable)
+      await body.typeText(value, { delay })
+    })
+  } else if (kind === EDITOR.HIDDEN_TEXTAREA) {
+    await target.focus()
+    await target.selectAllAndDelete()
+    await target.typeText(value, { delay })
+  } else if (kind === EDITOR.CONTENTEDITABLE) {
+    await target.click()
+    await target.evaluate(selectAllInEditable)
+    await target.typeText(value, { delay })
+  }
+
+  await clearMarker(helper)
+  return true
+}

--- a/lib/helper/extras/richTextEditor.js
+++ b/lib/helper/extras/richTextEditor.js
@@ -13,6 +13,7 @@ function detectAndMark(el, opts) {
   const marker = opts.marker
   const kinds = opts.kinds
   const CE = '[contenteditable="true"], [contenteditable=""]'
+  const MAX_HIDDEN_ASCENT = 3
 
   function mark(kind, target) {
     document.querySelectorAll('[' + marker + ']').forEach(n => n.removeAttribute(marker))
@@ -26,7 +27,8 @@ function detectAndMark(el, opts) {
   if (tag === 'IFRAME') return mark(kinds.IFRAME, el)
   if (el.isContentEditable) return mark(kinds.CONTENTEDITABLE, el)
 
-  if (tag !== 'INPUT' && tag !== 'TEXTAREA') {
+  const canSearchDescendants = tag !== 'INPUT' && tag !== 'TEXTAREA'
+  if (canSearchDescendants) {
     const iframe = el.querySelector('iframe')
     if (iframe) return mark(kinds.IFRAME, iframe)
     const ce = el.querySelector(CE)
@@ -36,25 +38,24 @@ function detectAndMark(el, opts) {
   }
 
   const style = window.getComputedStyle(el)
-  const hidden =
+  const isHidden =
     el.offsetParent === null ||
     (el.offsetWidth === 0 && el.offsetHeight === 0) ||
     style.display === 'none' ||
     style.visibility === 'hidden'
+  if (!isHidden) return mark(kinds.STANDARD, el)
 
-  if (hidden) {
-    let scope = el.parentElement
-    while (scope) {
-      const iframeNear = scope.querySelector('iframe')
-      if (iframeNear) return mark(kinds.IFRAME, iframeNear)
-      const ceNear = scope.querySelector(CE)
-      if (ceNear) return mark(kinds.CONTENTEDITABLE, ceNear)
-      for (const t of scope.querySelectorAll('textarea')) {
-        if (t !== el) return mark(kinds.HIDDEN_TEXTAREA, t)
-      }
-      if (scope === document.body) break
-      scope = scope.parentElement
-    }
+  const isFormHidden = tag === 'INPUT' && el.type === 'hidden'
+  if (isFormHidden) return mark(kinds.STANDARD, el)
+
+  let scope = el.parentElement
+  for (let depth = 0; scope && depth < MAX_HIDDEN_ASCENT; depth++, scope = scope.parentElement) {
+    const iframeNear = scope.querySelector('iframe')
+    if (iframeNear) return mark(kinds.IFRAME, iframeNear)
+    const ceNear = scope.querySelector(CE)
+    if (ceNear) return mark(kinds.CONTENTEDITABLE, ceNear)
+    const textareaNear = [...scope.querySelectorAll('textarea')].find(t => t !== el)
+    if (textareaNear) return mark(kinds.HIDDEN_TEXTAREA, textareaNear)
   }
 
   return mark(kinds.STANDARD, el)

--- a/test/data/app/controllers.php
+++ b/test/data/app/controllers.php
@@ -319,3 +319,12 @@ class basic_auth {
         include __DIR__.'/view/basic_auth.php';
     }
 }
+
+class richtext_submit {
+    function POST() {
+        $content = isset($_POST['content']) ? $_POST['content'] : '';
+        echo '<!DOCTYPE html><html><head><meta charset="UTF-8"><title>Submitted</title></head><body>';
+        echo '<pre id="result">' . htmlspecialchars($content, ENT_QUOTES | ENT_HTML5, 'UTF-8') . '</pre>';
+        echo '</body></html>';
+    }
+}

--- a/test/data/app/index.php
+++ b/test/data/app/index.php
@@ -46,7 +46,8 @@ $urls = array(
     '/download' => 'download',
     '/basic_auth' => 'basic_auth',
     '/image' => 'basic_image',
-    '/invisible_elements' => 'invisible_elements'
+    '/invisible_elements' => 'invisible_elements',
+    '/richtext_submit' => 'richtext_submit'
 );
 
 glue::stick($urls);

--- a/test/data/app/view/form/richtext.php
+++ b/test/data/app/view/form/richtext.php
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Rich Text Editors</title>
+</head>
+<body>
+    <h1>Rich Text Editors</h1>
+    <p>Test pages for fillField against rich text editors.</p>
+    <ul>
+        <li><a href="/form/richtext/prosemirror">ProseMirror</a> — contenteditable</li>
+        <li><a href="/form/richtext/quill">Quill</a> — contenteditable (.ql-editor)</li>
+        <li><a href="/form/richtext/ckeditor5">CKEditor 5</a> — contenteditable (.ck-editor__editable)</li>
+        <li><a href="/form/richtext/ckeditor4">CKEditor 4</a> — iframe</li>
+        <li><a href="/form/richtext/tinymce-modern">TinyMCE (inline)</a> — contenteditable</li>
+        <li><a href="/form/richtext/tinymce-legacy">TinyMCE (iframe)</a> — iframe</li>
+        <li><a href="/form/richtext/monaco">Monaco</a> — hidden textarea</li>
+        <li><a href="/form/richtext/ace">ACE</a> — hidden textarea</li>
+        <li><a href="/form/richtext/codemirror5">CodeMirror 5</a> — hidden textarea</li>
+        <li><a href="/form/richtext/codemirror6">CodeMirror 6</a> — contenteditable (.cm-content)</li>
+        <li><a href="/form/richtext/trix">Trix</a> — contenteditable (trix-editor)</li>
+        <li><a href="/form/richtext/summernote">Summernote</a> — contenteditable (.note-editable)</li>
+    </ul>
+</body>
+</html>

--- a/test/data/app/view/form/richtext/ace.php
+++ b/test/data/app/view/form/richtext/ace.php
@@ -1,0 +1,29 @@
+<?php $initial = isset($_GET['initial']) ? $_GET['initial'] : ''; ?>
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>ACE</title>
+</head>
+<body>
+    <h1>ACE</h1>
+    <form id="richtext-form" method="post" action="/richtext_submit">
+        <div id="editor" style="height: 300px; border: 1px solid #ccc;"></div>
+        <input type="hidden" name="content" id="content-sync">
+        <button type="submit" id="submit">Submit</button>
+    </form>
+    <script src="https://cdn.jsdelivr.net/npm/ace-builds@1.32.7/src-noconflict/ace.js"></script>
+    <script>
+        const editor = ace.edit('editor');
+        const initial = <?php echo json_encode($initial, JSON_UNESCAPED_UNICODE); ?>;
+        editor.setValue(initial, -1);
+        window.__editor = editor;
+        window.__editorContent = () => editor.getValue();
+        window.__editorReady = true;
+
+        document.getElementById('richtext-form').addEventListener('submit', function() {
+            document.getElementById('content-sync').value = window.__editorContent ? window.__editorContent() : '';
+        });
+    </script>
+</body>
+</html>

--- a/test/data/app/view/form/richtext/ckeditor4.php
+++ b/test/data/app/view/form/richtext/ckeditor4.php
@@ -1,0 +1,32 @@
+<?php $initial = isset($_GET['initial']) ? $_GET['initial'] : ''; ?>
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>CKEditor 4</title>
+</head>
+<body>
+    <h1>CKEditor 4</h1>
+    <form id="richtext-form" method="post" action="/richtext_submit">
+        <textarea id="editor"><?php echo htmlspecialchars($initial, ENT_QUOTES | ENT_HTML5, 'UTF-8'); ?></textarea>
+        <input type="hidden" name="content" id="content-sync">
+        <button type="submit" id="submit">Submit</button>
+    </form>
+    <script src="https://cdn.ckeditor.com/4.22.1/standard/ckeditor.js"></script>
+    <script>
+        CKEDITOR.replace('editor');
+        CKEDITOR.on('instanceReady', function(e) {
+            window.__editor = e.editor;
+            window.__editorContent = () => {
+                const div = document.createElement('div');
+                div.innerHTML = e.editor.getData() || '';
+                return (div.textContent || '').replace(/\u00a0/g, ' ').trim();
+            };
+            window.__editorReady = true;
+        });
+        document.getElementById('richtext-form').addEventListener('submit', function() {
+            document.getElementById('content-sync').value = window.__editorContent ? window.__editorContent() : '';
+        });
+    </script>
+</body>
+</html>

--- a/test/data/app/view/form/richtext/ckeditor5.php
+++ b/test/data/app/view/form/richtext/ckeditor5.php
@@ -1,0 +1,33 @@
+<?php $initial = isset($_GET['initial']) ? $_GET['initial'] : ''; ?>
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>CKEditor 5</title>
+</head>
+<body>
+    <h1>CKEditor 5</h1>
+    <form id="richtext-form" method="post" action="/richtext_submit">
+        <textarea id="editor"><?php echo htmlspecialchars($initial, ENT_QUOTES | ENT_HTML5, 'UTF-8'); ?></textarea>
+        <input type="hidden" name="content" id="content-sync">
+        <button type="submit" id="submit">Submit</button>
+    </form>
+    <script src="https://cdn.ckeditor.com/ckeditor5/41.4.2/classic/ckeditor.js"></script>
+    <script>
+        ClassicEditor.create(document.querySelector('#editor'), {
+            removePlugins: ['TextTransformation']
+        }).then(editor => {
+            window.__editor = editor;
+            window.__editorContent = () => {
+                const div = document.createElement('div');
+                div.innerHTML = editor.getData() || '';
+                return (div.textContent || '').replace(/\u00a0/g, ' ').trim();
+            };
+            window.__editorReady = true;
+        });
+        document.getElementById('richtext-form').addEventListener('submit', function() {
+            document.getElementById('content-sync').value = window.__editorContent ? window.__editorContent() : '';
+        });
+    </script>
+</body>
+</html>

--- a/test/data/app/view/form/richtext/codemirror5.php
+++ b/test/data/app/view/form/richtext/codemirror5.php
@@ -1,0 +1,29 @@
+<?php $initial = isset($_GET['initial']) ? $_GET['initial'] : ''; ?>
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>CodeMirror 5</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/codemirror@5.65.16/lib/codemirror.css">
+    <style>.CodeMirror { border: 1px solid #ccc; height: 200px; }</style>
+</head>
+<body>
+    <h1>CodeMirror 5</h1>
+    <form id="richtext-form" method="post" action="/richtext_submit">
+        <textarea id="editor"><?php echo htmlspecialchars($initial, ENT_QUOTES | ENT_HTML5, 'UTF-8'); ?></textarea>
+        <input type="hidden" name="content" id="content-sync">
+        <button type="submit" id="submit">Submit</button>
+    </form>
+    <script src="https://cdn.jsdelivr.net/npm/codemirror@5.65.16/lib/codemirror.js"></script>
+    <script>
+        const editor = CodeMirror.fromTextArea(document.getElementById('editor'), {});
+        window.__editor = editor;
+        window.__editorContent = () => editor.getValue();
+        window.__editorReady = true;
+
+        document.getElementById('richtext-form').addEventListener('submit', function() {
+            document.getElementById('content-sync').value = window.__editorContent ? window.__editorContent() : '';
+        });
+    </script>
+</body>
+</html>

--- a/test/data/app/view/form/richtext/codemirror6.php
+++ b/test/data/app/view/form/richtext/codemirror6.php
@@ -1,0 +1,34 @@
+<?php $initial = isset($_GET['initial']) ? $_GET['initial'] : ''; ?>
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>CodeMirror 6</title>
+    <style>#editor { border: 1px solid #ccc; }</style>
+</head>
+<body>
+    <h1>CodeMirror 6</h1>
+    <form id="richtext-form" method="post" action="/richtext_submit">
+        <div id="editor"></div>
+        <input type="hidden" name="content" id="content-sync">
+        <button type="submit" id="submit">Submit</button>
+    </form>
+    <script type="module">
+        import { EditorView, minimalSetup } from 'https://esm.sh/codemirror@6.0.1'
+        const initial = <?php echo json_encode($initial, JSON_UNESCAPED_UNICODE); ?>;
+        const view = new EditorView({
+            doc: initial,
+            parent: document.getElementById('editor'),
+            extensions: [minimalSetup]
+        });
+        window.__editor = view;
+        window.__editorContent = () => view.state.doc.toString();
+        window.__editorReady = true;
+    </script>
+    <script>
+        document.getElementById('richtext-form').addEventListener('submit', function() {
+            document.getElementById('content-sync').value = window.__editorContent ? window.__editorContent() : '';
+        });
+    </script>
+</body>
+</html>

--- a/test/data/app/view/form/richtext/monaco.php
+++ b/test/data/app/view/form/richtext/monaco.php
@@ -1,0 +1,34 @@
+<?php $initial = isset($_GET['initial']) ? $_GET['initial'] : ''; ?>
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Monaco</title>
+</head>
+<body>
+    <h1>Monaco</h1>
+    <form id="richtext-form" method="post" action="/richtext_submit">
+        <div id="editor" style="height: 300px; border: 1px solid #ccc;"></div>
+        <input type="hidden" name="content" id="content-sync">
+        <button type="submit" id="submit">Submit</button>
+    </form>
+    <script src="https://cdn.jsdelivr.net/npm/monaco-editor@0.45.0/min/vs/loader.js"></script>
+    <script>
+        require.config({ paths: { vs: 'https://cdn.jsdelivr.net/npm/monaco-editor@0.45.0/min/vs' }});
+        require(['vs/editor/editor.main'], function () {
+            const initial = <?php echo json_encode($initial, JSON_UNESCAPED_UNICODE); ?>;
+            const editor = monaco.editor.create(document.getElementById('editor'), {
+                value: initial,
+                language: 'plaintext',
+                automaticLayout: true
+            });
+            window.__editor = editor;
+            window.__editorContent = () => editor.getValue();
+            window.__editorReady = true;
+        });
+        document.getElementById('richtext-form').addEventListener('submit', function() {
+            document.getElementById('content-sync').value = window.__editorContent ? window.__editorContent() : '';
+        });
+    </script>
+</body>
+</html>

--- a/test/data/app/view/form/richtext/prosemirror.php
+++ b/test/data/app/view/form/richtext/prosemirror.php
@@ -1,0 +1,42 @@
+<?php $initial = isset($_GET['initial']) ? $_GET['initial'] : ''; ?>
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>ProseMirror</title>
+    <style>
+        #editor { border: 1px solid #ccc; padding: 10px; min-height: 120px; }
+        .ProseMirror:focus { outline: none; }
+    </style>
+</head>
+<body>
+    <h1>ProseMirror</h1>
+    <form id="richtext-form" method="post" action="/richtext_submit">
+        <div id="editor"></div>
+        <input type="hidden" name="content" id="content-sync">
+        <button type="submit" id="submit">Submit</button>
+    </form>
+    <script type="module">
+        import { EditorState } from 'https://esm.sh/prosemirror-state@1'
+        import { EditorView } from 'https://esm.sh/prosemirror-view@1'
+        import { schema } from 'https://esm.sh/prosemirror-schema-basic@1'
+        import { keymap } from 'https://esm.sh/prosemirror-keymap@1'
+        import { baseKeymap } from 'https://esm.sh/prosemirror-commands@1'
+
+        const initial = <?php echo json_encode($initial, JSON_UNESCAPED_UNICODE); ?>;
+        const doc = initial
+          ? schema.node('doc', null, initial.split(/\n{2,}/).map(p => p ? schema.node('paragraph', null, schema.text(p)) : schema.node('paragraph')))
+          : undefined
+        const state = EditorState.create({ schema, doc, plugins: [keymap(baseKeymap)] })
+        const view = new EditorView(document.querySelector('#editor'), { state })
+        window.__editor = view
+        window.__editorContent = () => view.state.doc.textContent
+        window.__editorReady = true
+    </script>
+    <script>
+        document.getElementById('richtext-form').addEventListener('submit', function() {
+            document.getElementById('content-sync').value = window.__editorContent ? window.__editorContent() : ''
+        })
+    </script>
+</body>
+</html>

--- a/test/data/app/view/form/richtext/quill.php
+++ b/test/data/app/view/form/richtext/quill.php
@@ -1,0 +1,30 @@
+<?php $initial = isset($_GET['initial']) ? $_GET['initial'] : ''; ?>
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Quill</title>
+    <link href="https://cdn.jsdelivr.net/npm/quill@2/dist/quill.snow.css" rel="stylesheet">
+</head>
+<body>
+    <h1>Quill</h1>
+    <form id="richtext-form" method="post" action="/richtext_submit">
+        <div id="editor" style="height: 200px;"></div>
+        <input type="hidden" name="content" id="content-sync">
+        <button type="submit" id="submit">Submit</button>
+    </form>
+    <script src="https://cdn.jsdelivr.net/npm/quill@2/dist/quill.js"></script>
+    <script>
+        const quill = new Quill('#editor', { theme: 'snow' });
+        const initial = <?php echo json_encode($initial, JSON_UNESCAPED_UNICODE); ?>;
+        if (initial) quill.setText(initial);
+        window.__editor = quill;
+        window.__editorContent = () => quill.getText().replace(/\n+$/, '');
+        window.__editorReady = true;
+
+        document.getElementById('richtext-form').addEventListener('submit', function() {
+            document.getElementById('content-sync').value = window.__editorContent();
+        });
+    </script>
+</body>
+</html>

--- a/test/data/app/view/form/richtext/summernote.php
+++ b/test/data/app/view/form/richtext/summernote.php
@@ -1,0 +1,36 @@
+<?php $initial = isset($_GET['initial']) ? $_GET['initial'] : ''; ?>
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Summernote</title>
+    <link href="https://cdn.jsdelivr.net/npm/summernote@0.9.0/dist/summernote-lite.min.css" rel="stylesheet">
+</head>
+<body>
+    <h1>Summernote</h1>
+    <form id="richtext-form" method="post" action="/richtext_submit">
+        <div id="editor"></div>
+        <input type="hidden" name="content" id="content-sync">
+        <button type="submit" id="submit">Submit</button>
+    </form>
+    <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/summernote@0.9.0/dist/summernote-lite.min.js"></script>
+    <script>
+        $(document).ready(function() {
+            $('#editor').summernote({ height: 150 });
+            const initial = <?php echo json_encode($initial, JSON_UNESCAPED_UNICODE); ?>;
+            if (initial) $('#editor').summernote('code', initial.split(/\n{2,}/).map(p => '<p>' + p.replace(/</g, '&lt;') + '</p>').join(''));
+            window.__editor = $('#editor');
+            window.__editorContent = () => {
+                const div = document.createElement('div');
+                div.innerHTML = $('#editor').summernote('code') || '';
+                return (div.textContent || '').replace(/\u00a0/g, ' ').trim();
+            };
+            window.__editorReady = true;
+        });
+        document.getElementById('richtext-form').addEventListener('submit', function() {
+            document.getElementById('content-sync').value = window.__editorContent ? window.__editorContent() : '';
+        });
+    </script>
+</body>
+</html>

--- a/test/data/app/view/form/richtext/tinymce-legacy.php
+++ b/test/data/app/view/form/richtext/tinymce-legacy.php
@@ -1,0 +1,34 @@
+<?php $initial = isset($_GET['initial']) ? $_GET['initial'] : ''; ?>
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>TinyMCE (iframe)</title>
+</head>
+<body>
+    <h1>TinyMCE (iframe)</h1>
+    <form id="richtext-form" method="post" action="/richtext_submit">
+        <textarea id="editor"><?php echo htmlspecialchars($initial, ENT_QUOTES | ENT_HTML5, 'UTF-8'); ?></textarea>
+        <input type="hidden" name="content" id="content-sync">
+        <button type="submit" id="submit">Submit</button>
+    </form>
+    <script src="https://cdn.jsdelivr.net/npm/tinymce@6/tinymce.min.js" referrerpolicy="origin"></script>
+    <script>
+        tinymce.init({
+            selector: '#editor',
+            license_key: 'gpl',
+            promotion: false,
+            setup: function(editor) {
+                editor.on('init', function() {
+                    window.__editor = editor;
+                    window.__editorContent = () => editor.getContent({ format: 'text' }).trim();
+                    window.__editorReady = true;
+                });
+            }
+        });
+        document.getElementById('richtext-form').addEventListener('submit', function() {
+            document.getElementById('content-sync').value = window.__editorContent ? window.__editorContent() : '';
+        });
+    </script>
+</body>
+</html>

--- a/test/data/app/view/form/richtext/tinymce-modern.php
+++ b/test/data/app/view/form/richtext/tinymce-modern.php
@@ -1,0 +1,38 @@
+<?php $initial = isset($_GET['initial']) ? $_GET['initial'] : ''; ?>
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>TinyMCE (inline)</title>
+    <style>
+        #editor { border: 1px solid #ccc; padding: 10px; min-height: 120px; }
+    </style>
+</head>
+<body>
+    <h1>TinyMCE (inline / contenteditable)</h1>
+    <form id="richtext-form" method="post" action="/richtext_submit">
+        <div id="editor"><?php echo htmlspecialchars($initial, ENT_QUOTES | ENT_HTML5, 'UTF-8'); ?></div>
+        <input type="hidden" name="content" id="content-sync">
+        <button type="submit" id="submit" style="position: fixed; bottom: 20px; right: 20px; z-index: 99999;">Submit</button>
+    </form>
+    <script src="https://cdn.jsdelivr.net/npm/tinymce@6/tinymce.min.js" referrerpolicy="origin"></script>
+    <script>
+        tinymce.init({
+            selector: '#editor',
+            inline: true,
+            license_key: 'gpl',
+            promotion: false,
+            setup: function(editor) {
+                editor.on('init', function() {
+                    window.__editor = editor;
+                    window.__editorContent = () => editor.getContent({ format: 'text' }).trim();
+                    window.__editorReady = true;
+                });
+            }
+        });
+        document.getElementById('richtext-form').addEventListener('submit', function() {
+            document.getElementById('content-sync').value = window.__editorContent ? window.__editorContent() : '';
+        });
+    </script>
+</body>
+</html>

--- a/test/data/app/view/form/richtext/trix.php
+++ b/test/data/app/view/form/richtext/trix.php
@@ -1,0 +1,31 @@
+<?php $initial = isset($_GET['initial']) ? $_GET['initial'] : ''; ?>
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Trix</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/trix@2/dist/trix.css">
+</head>
+<body>
+    <h1>Trix</h1>
+    <form id="richtext-form" method="post" action="/richtext_submit">
+        <input id="trix-input" type="hidden">
+        <trix-editor input="trix-input"></trix-editor>
+        <input type="hidden" name="content" id="content-sync">
+        <button type="submit" id="submit">Submit</button>
+    </form>
+    <script src="https://cdn.jsdelivr.net/npm/trix@2/dist/trix.umd.min.js"></script>
+    <script>
+        document.addEventListener('trix-initialize', function(e) {
+            const initial = <?php echo json_encode($initial, JSON_UNESCAPED_UNICODE); ?>;
+            if (initial) e.target.editor.insertString(initial);
+            window.__editor = e.target;
+            window.__editorContent = () => e.target.innerText.replace(/\s+$/, '');
+            window.__editorReady = true;
+        });
+        document.getElementById('richtext-form').addEventListener('submit', function() {
+            document.getElementById('content-sync').value = window.__editorContent ? window.__editorContent() : '';
+        });
+    </script>
+</body>
+</html>

--- a/test/data/richtext-long.txt
+++ b/test/data/richtext-long.txt
@@ -1,0 +1,8 @@
+Opening paragraph discusses the rationale for robust editor testing, covering typed input, clipboard round-trips, and multi-line content flow through the DOM.
+A follow-up sentence ensures the first paragraph has enough substance for the editor to wrap, break, or reformat as needed.
+
+Middle paragraph exists to verify that paragraph breaks survive the fill operation intact across rich-text, code, and iframe-backed editors.
+It also exercises mixed punctuation: commas, periods, semicolons, and the occasional colon turn up here to keep the tokenizer honest.
+
+Closing paragraph caps the fixture with a third block of prose to confirm that longer payloads get typed and submitted without truncation.
+A final line restates the intent so that assertions on the last paragraph can key off distinctive phrasing.

--- a/test/helper/webapi.js
+++ b/test/helper/webapi.js
@@ -828,6 +828,75 @@ export function tests() {
     })
   })
 
+  describe('#fillField - rich text editors', function () {
+    this.timeout(60000)
+
+    const longContent = fs.readFileSync(path.join(__dirname, '../data/richtext-long.txt'), 'utf8').trim()
+
+    const editors = [
+      { name: 'ProseMirror',    page: 'prosemirror',    selector: '#editor' },
+      { name: 'Quill',          page: 'quill',          selector: '#editor' },
+      { name: 'CKEditor 5',     page: 'ckeditor5',      selector: '#editor' },
+      { name: 'TinyMCE inline', page: 'tinymce-modern', selector: '#editor' },
+      { name: 'CodeMirror 6',   page: 'codemirror6',    selector: '#editor' },
+      { name: 'Trix',           page: 'trix',           selector: 'trix-editor' },
+      { name: 'Summernote',     page: 'summernote',     selector: '#editor' },
+      { name: 'Monaco',         page: 'monaco',         selector: '#editor' },
+      { name: 'ACE',            page: 'ace',            selector: '#editor' },
+      { name: 'CodeMirror 5',   page: 'codemirror5',    selector: '#editor' },
+      { name: 'TinyMCE legacy', page: 'tinymce-legacy', selector: '#editor' },
+      { name: 'CKEditor 4',     page: 'ckeditor4',      selector: '#editor' },
+    ]
+
+    async function open(page, initial) {
+      const q = initial != null ? `?initial=${encodeURIComponent(initial)}` : ''
+      await I.amOnPage(`/form/richtext/${page}${q}`)
+      await I.waitForFunction(() => window.__editorReady === true, [], 30)
+    }
+
+    async function submitAndGrab() {
+      await I.click('#submit')
+      await I.waitForElement('#result', 15)
+      return I.grabTextFrom('#result')
+    }
+
+    for (const ed of editors) {
+      describe(ed.name, () => {
+        it('submits filled value', async () => {
+          await open(ed.page)
+          await I.fillField(ed.selector, 'Hello rich text world')
+          expect(await submitAndGrab()).to.include('Hello rich text world')
+        })
+
+        it('rewrites pre-populated content', async () => {
+          await open(ed.page, 'PREVIOUSLY ENTERED DATA')
+          await I.fillField(ed.selector, 'fresh replacement text')
+          const submitted = await submitAndGrab()
+          expect(submitted).to.include('fresh replacement text')
+          expect(submitted).to.not.include('PREVIOUSLY ENTERED DATA')
+        })
+
+        it('preserves special characters', async () => {
+          await open(ed.page)
+          await I.fillField(ed.selector, 'Test: "quotes", & ampersand, 100% done!')
+          const submitted = await submitAndGrab()
+          expect(submitted).to.include('"quotes"')
+          expect(submitted).to.include('& ampersand')
+          expect(submitted).to.include('100%')
+        })
+
+        it('fills large multi-paragraph content', async () => {
+          await open(ed.page)
+          await I.fillField(ed.selector, longContent)
+          const submitted = await submitAndGrab()
+          expect(submitted).to.include('Opening paragraph')
+          expect(submitted).to.include('Middle paragraph')
+          expect(submitted).to.include('Closing paragraph')
+        })
+      })
+    }
+  })
+
   describe('#clearField', () => {
     it('should clear a given element', async () => {
       await I.amOnPage('/form/field')


### PR DESCRIPTION
## Summary

- Extends `fillField` in Playwright, Puppeteer, and WebDriver helpers to detect and fill rich text editors automatically — no per-editor selectors hardcoded
- Detection covers three structural shapes: contenteditable (incl. descendants), hidden-textarea (editor-owned inputs), and iframe-based editors; standard `<input>`/`<textarea>` stays on the original fast path
- Verified against 12 real-world editors: ProseMirror, Quill, CKEditor 4/5, TinyMCE inline/legacy, CodeMirror 5/6, Monaco, ACE, Trix, Summernote
- Shared logic lives in `lib/helper/extras/richTextEditor.js`; cross-helper primitives (`evaluate`, `focus`, `typeText`, `selectAllAndDelete`, `inIframe`) added to `WebElement` so a single implementation serves all three helpers
- 48 scenarios added to `test/helper/webapi.js` (4 scenarios × 12 editors) — fill, rewrite pre-populated content, preserve special characters, fill multi-paragraph content — automatically exercised by Playwright/Puppeteer/WebDriver helper test suites

## Test plan

- [x] `BROWSER=chromium node_modules/.bin/mocha test/helper/Playwright_test.js --grep "rich text editors"` — 48/48 passing
- [ ] Puppeteer helper suite picks up the same scenarios via `webApiTests.tests()`
- [ ] WebDriver helper suite picks up the same scenarios via `webApiTests.tests()`
- [ ] No regression in existing Playwright acceptance suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)