### PR TITLE
fix(locator): prevent click(text, container) from matching the container itself

### DIFF
--- a/lib/locator.js
+++ b/lib/locator.js
@@ -591,13 +591,24 @@ Locator.clickable = {
       `.//*[@title = ${literal}]`,
       `.//*[@aria-labelledby = //*[@id][normalize-space(string(.)) = ${literal}]/@id ]`,
       `.//*[@role='button'][normalize-space(.)=${literal}]`,
+      `.//*[@role='tab' or @role='link' or @role='menuitem' or @role='menuitemcheckbox' or @role='menuitemradio' or @role='option' or @role='treeitem'][contains(normalize-space(string(.)), ${literal})]`,
     ]),
 
   /**
    * @param {string} literal
    * @returns {string}
    */
-  self: literal => `./self::*[contains(normalize-space(string(.)), ${literal}) or contains(normalize-space(@value), ${literal})]`,
+  self: literal => {
+    // Narrowest-match: prefer the deepest descendant whose string-value contains the literal.
+    // Falling back to `self` without the `not(descendant...)` guard would match a container
+    // whose concatenated text happens to include the literal (e.g. a <ul role="tablist"> whose
+    // tab labels all sit in its string-value) and click the container itself.
+    const narrowest = `contains(normalize-space(string(.)), ${literal}) and not(.//*[contains(normalize-space(string(.)), ${literal})])`
+    return xpathLocator.combine([
+      `.//*[${narrowest}]`,
+      `./self::*[${narrowest} or contains(normalize-space(@value), ${literal})]`,
+    ])
+  },
 }
 
 Locator.field = {

--- a/test/data/app/view/form/tablist.php
+++ b/test/data/app/view/form/tablist.php
@@ -1,0 +1,33 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Tablist click regression (#5530)</title>
+    <style>
+      ul[role="tablist"] { display: flex; list-style: none; padding: 0; margin: 0; border-bottom: 1px solid #ccc; }
+      ul[role="tablist"] li[role="tab"] { padding: 8px 16px; cursor: pointer; }
+      ul[role="tablist"] li[aria-selected="true"] { background: #eef; font-weight: bold; }
+    </style>
+  </head>
+  <body>
+    <h1>Tablist</h1>
+    <ul role="tablist" id="tabs" class="tab-list">
+      <li role="tab" data-tab="description" aria-selected="true"><span class="tab-text">Description</span></li>
+      <li role="tab" data-tab="code" aria-selected="false"><span class="tab-text">Code template</span></li>
+      <li role="tab" data-tab="attachments" aria-selected="false"><span class="tab-text">Attachments</span></li>
+      <li role="tab" data-tab="runs" aria-selected="false"><span class="tab-text">Runs</span></li>
+      <li role="tab" data-tab="history" aria-selected="false"><span class="tab-text">History</span></li>
+    </ul>
+    <div id="selected-tab">description</div>
+    <script>
+      document.querySelectorAll('[role="tab"]').forEach(function (li) {
+        li.addEventListener('click', function () {
+          document.querySelectorAll('[role="tab"]').forEach(function (x) {
+            x.setAttribute('aria-selected', 'false');
+          });
+          li.setAttribute('aria-selected', 'true');
+          document.getElementById('selected-tab').textContent = li.dataset.tab;
+        });
+      });
+    </script>
+  </body>
+</html>

--- a/test/helper/Playwright_test.js
+++ b/test/helper/Playwright_test.js
@@ -1192,6 +1192,36 @@ describe('Playwright', function () {
       I.see('Information')
     })
   })
+
+  describe('#click - with tag selector as context', () => {
+    it('clicks <a><span>text</span></a> when context is the tag "a"', async () => {
+      await I.amOnPage('/form/example7')
+      await I.click('Buy Chocolate Bar', 'a')
+      await I.seeCurrentUrlEquals('/')
+    })
+  })
+
+  describe('#click - tablist regression', () => {
+    // https://github.com/codeceptjs/CodeceptJS — click(text, container) was matching
+    // the container itself when its concatenated string-value contained the text,
+    // clicking the <ul role="tablist"> center instead of the intended <li role="tab">.
+    it('clicks the correct tab by text when container has many text-bearing children', async () => {
+      await I.amOnPage('/form/tablist')
+      await I.seeTextEquals('description', '#selected-tab')
+
+      await I.click('History', 'ul[role="tablist"]')
+      await I.seeTextEquals('history', '#selected-tab')
+
+      await I.click('Description', 'ul[role="tablist"]')
+      await I.seeTextEquals('description', '#selected-tab')
+
+      await I.click('Runs', 'ul[role="tablist"]')
+      await I.seeTextEquals('runs', '#selected-tab')
+
+      await I.click('Code template', 'ul[role="tablist"]')
+      await I.seeTextEquals('code', '#selected-tab')
+    })
+  })
 })
 
 let remoteBrowser

--- a/test/unit/locator_test.js
+++ b/test/unit/locator_test.js
@@ -714,4 +714,85 @@ describe('Locator', () => {
     const nodes = xpath.select(l.toXPath(), doc)
     expect(nodes).to.have.length(1, l.toXPath())
   })
+
+  describe('Locator.clickable.self', () => {
+    it('picks deepest descendant, not a container whose string-value merely concatenates the literal (tablist regression)', () => {
+      const tabsXml = `<root>
+        <ul role="tablist" id="tabs">
+          <li role="tab" data-tab="description"><span class="tab-text">Description</span></li>
+          <li role="tab" data-tab="code"><span class="tab-text">Code template</span></li>
+          <li role="tab" data-tab="attachments"><span class="tab-text">Attachments</span></li>
+          <li role="tab" data-tab="runs"><span class="tab-text">Runs</span></li>
+          <li role="tab" data-tab="history"><span class="tab-text">History</span></li>
+        </ul>
+      </root>`
+      const tabsDoc = new DOMParser().parseFromString(tabsXml, 'text/xml')
+      const ul = xpath.select1('//ul', tabsDoc)
+      const xp = Locator.clickable.self("'Description'")
+      const nodes = xpath.select(xp, ul)
+
+      expect(nodes).to.have.length(1, xp)
+      expect(nodes[0].tagName).to.eql('span')
+      expect(nodes[0].textContent.trim()).to.eql('Description')
+    })
+
+    it('matches self when context element has the literal in direct text and no descendants contain it', () => {
+      const leafXml = '<root><div id="btn">Submit</div></root>'
+      const leafDoc = new DOMParser().parseFromString(leafXml, 'text/xml')
+      const div = xpath.select1('//div', leafDoc)
+      const xp = Locator.clickable.self("'Submit'")
+      const nodes = xpath.select(xp, div)
+
+      expect(nodes).to.have.length(1, xp)
+      expect(nodes[0].getAttribute('id')).to.eql('btn')
+    })
+
+    it('matches self when @value attribute contains the literal', () => {
+      const inputXml = '<root><input type="submit" value="Submit" id="inp"/></root>'
+      const inputDoc = new DOMParser().parseFromString(inputXml, 'text/xml')
+      const input = xpath.select1('//input', inputDoc)
+      const xp = Locator.clickable.self("'Submit'")
+      const nodes = xpath.select(xp, input)
+
+      expect(nodes).to.have.length(1, xp)
+      expect(nodes[0].getAttribute('id')).to.eql('inp')
+    })
+  })
+
+  describe('Locator.clickable.wide', () => {
+    it('matches an ARIA widget role (tab) by text within a container', () => {
+      const tabsXml = `<root>
+        <ul role="tablist" id="tabs">
+          <li role="tab" data-tab="description"><span class="tab-text">Description</span></li>
+          <li role="tab" data-tab="code"><span class="tab-text">Code template</span></li>
+          <li role="tab" data-tab="attachments"><span class="tab-text">Attachments</span></li>
+          <li role="tab" data-tab="runs"><span class="tab-text">Runs</span></li>
+          <li role="tab" data-tab="history"><span class="tab-text">History</span></li>
+        </ul>
+      </root>`
+      const tabsDoc = new DOMParser().parseFromString(tabsXml, 'text/xml')
+      const ul = xpath.select1('//ul', tabsDoc)
+      const xp = Locator.clickable.wide("'Description'")
+      const nodes = xpath.select(xp, ul)
+
+      const tabMatches = nodes.filter(n => n.getAttribute && n.getAttribute('role') === 'tab')
+      expect(tabMatches).to.have.length(1, xp)
+      expect(tabMatches[0].getAttribute('data-tab')).to.eql('description')
+    })
+
+    it('matches role="menuitem" by text', () => {
+      const menuXml = `<root>
+        <ul role="menu">
+          <li role="menuitem" id="save">Save</li>
+          <li role="menuitem" id="rename">Rename</li>
+        </ul>
+      </root>`
+      const menuDoc = new DOMParser().parseFromString(menuXml, 'text/xml')
+      const menu = xpath.select1('//ul', menuDoc)
+      const nodes = xpath.select(Locator.clickable.wide("'Rename'"), menu)
+      const items = nodes.filter(n => n.getAttribute && n.getAttribute('role') === 'menuitem')
+      expect(items).to.have.length(1)
+      expect(items[0].getAttribute('id')).to.eql('rename')
+    })
+  })
 })


### PR DESCRIPTION
## Summary

- **Bug**: `I.click("Description", 'ul[role="tablist"]')` clicked the `<ul>` itself instead of the intended `<li role="tab">`. Playwright landed the click on whatever child sat at the container's geometric center, so the wrong tab activated while the step still passed — a silent misleading failure.
- **Root cause**: `Locator.clickable.self` used `./self::*[contains(normalize-space(string(.)), literal) …]`. A container's concatenated string-value always contains every child's text, so the scope element itself matched.
- **Fix**: narrow `self` to prefer the *deepest descendant* whose string-value contains the literal, and only match self when self **is** that deepest element (or when `@value` matches — preserves the `<input value="…">` case).
- **Bonus**: extend `Locator.clickable.wide` with ARIA widget roles (`tab`, `link`, `menuitem`, `menuitemcheckbox`, `menuitemradio`, `option`, `treeitem`) so clicks hit the semantic element directly rather than relying on bubble-up.

Shared with Puppeteer and WebDriver helpers — both consume `Locator.clickable.self` unchanged, so they inherit the fix.

## Test plan

- [x] Unit suite: `npm run test:unit` — **597 passed, 0 failed** (incl. 5 new `clickable.self` / `clickable.wide` xpath tests).
- [x] Playwright helper: `npx mocha test/helper/Playwright_test.js --grep "#click"` — **15/15 passing** (9 pre-existing + `#clickXY` 3 + invisible 1 + 2 new regressions).
- [x] Puppeteer helper: `npx mocha test/helper/Puppeteer_test.js --grep "#click"` — **12/12 passing** (shares `Locator.clickable.self`).
- [x] Full Playwright helper suite: **424 passed, 4 failing** — the 4 failures are `#makeApiRequest` (network) and `Video & Trace & HAR` (Playwright tracing), both unrelated to the click/locator paths.
- [x] Reproduced the bug on this branch *before* applying the fix: the new `#click - tablist regression` test fails, confirming the reproduction.

### Scenarios covered

- Container with many text-bearing children (the tablist): click now lands on the correct tab — `History`, `Description`, `Runs`, `Code template` each verified via `#selected-tab`.
- `<a><span>Buy Chocolate Bar</span></a>` clicked with `'a'` as context: still works (handled first by `getByRole('link')`, `self` fallback never reached).
- `<div>Submit</div>` and `<input value="Submit">` with context-is-the-target: `self` branch still matches.
- `[role="tab"]` / `[role="menuitem"]` directly matched by `wide` — semantic click target, no reliance on event bubbling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)