### PR TITLE
fix(playwright): reset cleanup state at start of _afterSuite to prevent worker crashes

### DIFF
--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -755,6 +755,11 @@ class Playwright extends Helper {
   }
 
   async _afterSuite() {
+    // Reset leftover test-level cleanup state (e.g. screenshot failures)
+    // so only errors from this suite teardown are evaluated below.
+    this.hasCleanupError = false
+    this.testFailures = []
+
     // Stop browser after suite completes
     // For restart strategies: stop after each suite
     // For session mode (restart:false): stop after the last suite


### PR DESCRIPTION
## Problem

When running tests with `run-workers`, workers can crash silently due to stale cleanup state leaking from test-level hooks into `_afterSuite()`.

### Root cause

1. A test fails → the `screenshot` plugin calls `saveScreenshot()`
2. If the screenshot also fails (timeout, closed page, protocol error), `saveScreenshot()` sets `this.hasCleanupError = true` and pushes to `this.testFailures[]` ([Playwright.js L2991-2992](https://github.com/codeceptjs/CodeceptJS/blob/4.x/lib/helper/Playwright.js#L2991-L2992))
3. The error is caught and the method returns gracefully — the test runner continues
4. `hasCleanupError` / `testFailures` are reset per-test in `_beforeTest()` ([L567-568](https://github.com/codeceptjs/CodeceptJS/blob/4.x/lib/helper/Playwright.js#L567-L568)), but **not** at the start of `_afterSuite()`
5. When the **last** test in a suite has a screenshot failure, the stale state carries into `_afterSuite()`
6. At the end of `_afterSuite()`, the guard clause `if (this.hasCleanupError && this.testFailures.length > 0)` evaluates to `true` and **throws** ([L841-844](https://github.com/codeceptjs/CodeceptJS/blob/4.x/lib/helper/Playwright.js#L841-L844)) — even if the suite's own cleanup completed successfully
7. In a `run-workers` context, this throw kills the worker thread. All remaining test files assigned to that worker are **silently dropped** — they never execute and never appear in the results

## Fix

Reset `hasCleanupError` and `testFailures` at the **top** of `_afterSuite()`, before any suite-level cleanup runs. This ensures the guard clause at L841 only evaluates errors from `_afterSuite`'s own cleanup operations, not leftover test-level errors.

```diff
  async _afterSuite() {
+   // Reset leftover test-level cleanup state (e.g. screenshot failures)
+   // so only errors from this suite teardown are evaluated below.
+   this.hasCleanupError = false
+   this.testFailures = []
+
    // Stop browser after suite completes
```