### PR TITLE
fix(plugins): resolve async race conditions in aiTrace, analyze, screencast, pageInfo, heal

### DIFF
--- a/lib/heal.js
+++ b/lib/heal.js
@@ -54,7 +54,9 @@ class Heal {
 
   async getCodeSuggestions(context) {
     const suggestions = []
+    const stepName = context.step?.name
     const recipes = matchRecipes(this.recipes, this.contextName)
+      .filter(r => !r.steps || !stepName || r.steps.includes(stepName))
 
     debug('Recipes', recipes)
 

--- a/lib/plugin/aiTrace.js
+++ b/lib/plugin/aiTrace.js
@@ -92,6 +92,7 @@ export default function (config = {}) {
   let testStartTime
   let currentUrl = null
   let testFailed = false
+  let pendingArtifactCapture = null
   let firstFailedStepSaved = false
 
   const reportDir = config.output ? path.resolve(store.codeceptDir, config.output) : defaultConfig.output
@@ -129,6 +130,7 @@ export default function (config = {}) {
     currentUrl = null
     testFailed = false
     firstFailedStepSaved = false
+    pendingArtifactCapture = null
   })
 
   event.dispatcher.on(event.step.after, step => {
@@ -162,13 +164,12 @@ export default function (config = {}) {
       return
     }
 
-    const stepPersistPromise = persistStep(step).catch(err => {
+    recorder.add(`aiTrace step persistence: ${step.toString()}`, () => persistStep(step).catch(err => {
       output.debug(`aiTrace: Error saving step: ${err.message}`)
-    })
-    recorder.add(`wait aiTrace step persistence: ${step.toString()}`, () => stepPersistPromise, true)
+    }), true)
   })
 
-  event.dispatcher.on(event.step.failed, async step => {
+  event.dispatcher.on(event.step.failed, step => {
     if (!currentTest) return
     if (step.status === 'queued' && testFailed) {
       output.debug(`aiTrace: Skipping queued failed step "${step.toString()}" - testFailed: ${testFailed}`)
@@ -188,11 +189,9 @@ export default function (config = {}) {
       }
       existingStep.status = 'failed'
 
-      try {
-        await captureArtifactsForStep(step, existingStep, existingStep.prefix)
-      } catch (err) {
+      pendingArtifactCapture = captureArtifactsForStep(step, existingStep, existingStep.prefix).catch(err => {
         output.debug(`aiTrace: Error updating failed step: ${err.message}`)
-      }
+      })
     } else {
       if (stepNum === -1) return
       if (isStepIgnored(step)) return
@@ -218,11 +217,9 @@ export default function (config = {}) {
       steps.push(stepData)
       firstFailedStepSaved = true
 
-      try {
-        await captureArtifactsForStep(step, stepData, stepPrefix)
-      } catch (err) {
+      pendingArtifactCapture = captureArtifactsForStep(step, stepData, stepPrefix).catch(err => {
         output.debug(`aiTrace: Error capturing failed step artifacts: ${err.message}`)
-      }
+      })
     }
   })
 
@@ -238,7 +235,13 @@ export default function (config = {}) {
     if (hookName === 'BeforeSuite' || hookName === 'AfterSuite') {
       return
     }
-    persist(test, 'failed')
+    recorder.add('aiTrace:persist failed', async () => {
+      if (pendingArtifactCapture) {
+        await pendingArtifactCapture
+        pendingArtifactCapture = null
+      }
+      persist(test, 'failed')
+    }, true)
   })
 
   async function persistStep(step) {

--- a/lib/plugin/analyze.js
+++ b/lib/plugin/analyze.js
@@ -234,7 +234,12 @@ export default function (config = {}) {
       return
     }
 
-    printReport(result)
+    process.env.CODECEPT_DISABLE_AUTO_EXIT = '1'
+    try {
+      await printReport(result)
+    } finally {
+      process.exit(process.exitCode || 0)
+    }
   })
 
   event.dispatcher.on(event.workers.result, async result => {
@@ -248,7 +253,12 @@ export default function (config = {}) {
       return
     }
 
-    printReport(result)
+    process.env.CODECEPT_DISABLE_AUTO_EXIT = '1'
+    try {
+      await printReport(result)
+    } finally {
+      process.exit(process.exitCode || 0)
+    }
   })
 
   async function printReport(result) {
@@ -294,7 +304,7 @@ export default function (config = {}) {
       console.error('Error analyzing failed tests', err)
     }
 
-    if (!Object.keys(container.plugins()).includes('pageInfo')) {
+    if (!Object.keys(Container.plugins()).includes('pageInfo')) {
       console.log('To improve analysis, enable pageInfo plugin to get more context for failed tests.')
     }
   }

--- a/lib/plugin/heal.js
+++ b/lib/plugin/heal.js
@@ -80,6 +80,7 @@ export default function (config = {}) {
   event.dispatcher.on(event.test.before, test => {
     currentTest = test
     healedSteps = 0
+    healTries = 0
     caughtError = null
   })
 
@@ -94,7 +95,9 @@ export default function (config = {}) {
     if (trigger.on === 'file' && !matchStepFile(step, trigger.path, trigger.line)) return
 
     recorder.catchWithoutStop(async err => {
+      if (healTries >= config.healLimit) throw err
       isHealing = true
+      healTries++
       if (caughtError === err) throw err // avoid double handling
       caughtError = err
 
@@ -120,8 +123,6 @@ export default function (config = {}) {
       debug('Self-healing started', step.toCode())
 
       await heal.healStep(step, err, { test })
-
-      healTries++
 
       recorder.add('close healing session', () => {
         recorder.reset()

--- a/lib/plugin/pageInfo.js
+++ b/lib/plugin/pageInfo.js
@@ -40,10 +40,10 @@ const defaultConfig = {
 export default function (config = {}) {
   config = Object.assign(defaultConfig, config)
 
-  const helper = pickActingHelper(Container.helpers())
-  if (!helper) return
-
   event.dispatcher.on(event.test.failed, test => {
+    const helper = pickActingHelper(Container.helpers())
+    if (!helper) return
+
     const pageState = {}
 
     recorder.add('pageInfo capture', async () => {
@@ -60,8 +60,6 @@ export default function (config = {}) {
         if (captured.html) {
           const htmlPath = path.join(store.outputDir, captured.html)
           pageState.htmlSnapshot = htmlPath
-          // Scan raw HTML (pre-cleanHtml) so error classes containing digits
-          // or trash-class prefixes aren't stripped before detection.
           const htmlForScan = captured.htmlRaw || (() => {
             try { return fs.readFileSync(htmlPath, 'utf8') } catch { return '' }
           })()
@@ -90,7 +88,7 @@ export default function (config = {}) {
           } catch {}
         }
       } catch {}
-    })
+    }, true)
 
     recorder.add('Save page info', () => {
       test.addNote('pageInfo', pageStateToMarkdown(pageState))
@@ -99,7 +97,7 @@ export default function (config = {}) {
       fs.writeFileSync(pageStateFileName, pageStateToMarkdown(pageState))
       test.artifacts.pageInfo = pageStateFileName
       return pageState
-    })
+    }, true)
   })
 }
 

--- a/lib/plugin/screencast.js
+++ b/lib/plugin/screencast.js
@@ -106,6 +106,12 @@ function wireScreencast(mode, options) {
     state.startedAt = options.subtitles ? Date.now() : null
   })
 
+  event.dispatcher.on(event.test.started, test => {
+    if (!options.video || state.startQueued) return
+    state.startQueued = true
+    recorder.add('screencast:start', async () => startScreencast(state.test, options, state), true)
+  })
+
   event.dispatcher.on(event.step.started, step => {
     if (state.steps) {
       const at = Date.now()
@@ -116,10 +122,6 @@ function wireScreencast(mode, options) {
         title: stepTitle(step),
       }
     }
-    if (!options.video || state.startQueued || !state.test) return
-    state.startQueued = true
-    const test = state.test
-    recorder.add('screencast:start', async () => startScreencast(test, options, state), true)
   })
 
   if (options.subtitles) {

--- a/lib/workers.js
+++ b/lib/workers.js
@@ -501,6 +501,26 @@ class Workers extends EventEmitter {
     return runHook(this.codecept.config.teardownAll, 'teardownAll')
   }
 
+  /**
+   * Resolves the overall `run-workers` timeout in milliseconds.
+   *
+   * Resolution order:
+   * 1. `CODECEPT_WORKERS_TIMEOUT` env var (numeric, ms)
+   * 2. `workersTimeout` in codecept.conf (ms)
+   * 3. Default: 600000 (10 minutes)
+   *
+   * Set the value to `0` (or any non-positive number) to disable the timeout entirely.
+   *
+   * @returns {number} timeout in milliseconds
+   */
+  _getWorkersTimeoutMs() {
+    const envTimeout = parseInt(process.env.CODECEPT_WORKERS_TIMEOUT, 10)
+    if (Number.isFinite(envTimeout)) return envTimeout
+    const configTimeout = this.codecept?.config?.workersTimeout
+    if (Number.isFinite(configTimeout)) return configTimeout
+    return 600000
+  }
+
   async run() {
     await this._ensureInitialized()
     recorder.startUnlessRunning()
@@ -521,22 +541,27 @@ class Workers extends EventEmitter {
       // Workers are already running, this is just a placeholder step
     })
 
-    // Add overall timeout to prevent infinite hanging
-    const overallTimeout = setTimeout(() => {
-      console.error('[Main] Overall timeout reached (10 minutes). Force terminating remaining workers...')
-      workerThreads.forEach(w => {
-        try {
-          w.terminate()
-        } catch (e) {
-          // ignore
-        }
-      })
-      this._finishRun()
-    }, 600000) // 10 minutes
+    // Overall timeout to prevent infinite hanging. See _getWorkersTimeoutMs() for resolution rules.
+    const overallTimeoutMs = this._getWorkersTimeoutMs()
+    let overallTimeout
+    if (overallTimeoutMs > 0) {
+      overallTimeout = setTimeout(() => {
+        const minutes = (overallTimeoutMs / 60000).toFixed(1)
+        console.error(`[Main] Overall timeout reached (${minutes} minutes). Force terminating remaining workers...`)
+        workerThreads.forEach(w => {
+          try {
+            w.terminate()
+          } catch (e) {
+            // ignore
+          }
+        })
+        this._finishRun()
+      }, overallTimeoutMs)
+    }
 
     return new Promise(resolve => {
       this.on('end', () => {
-        clearTimeout(overallTimeout)
+        if (overallTimeout) clearTimeout(overallTimeout)
         resolve()
       })
     })

--- a/lib/workers.js
+++ b/lib/workers.js
@@ -27,6 +27,8 @@ import { createRuns } from './command/run-multiple/collection.js'
 
 const pathToWorker = path.join(__dirname, 'command', 'workers', 'runTests.js')
 
+const WORKER_TIMEOUT_MINUTES = 10
+
 const initializeCodecept = async (configPath, options = {}) => {
   const config = await mainConfig.load(configPath || '.')
   const codecept = new Codecept(config, { ...options, skipDefaultListeners: true })
@@ -518,7 +520,7 @@ class Workers extends EventEmitter {
     if (Number.isFinite(envTimeout)) return envTimeout
     const configTimeout = this.codecept?.config?.workersTimeout
     if (Number.isFinite(configTimeout)) return configTimeout
-    return 600000
+    return WORKER_TIMEOUT_MINUTES * 60 * 1000
   }
 
   async run() {

--- a/test/unit/worker_test.js
+++ b/test/unit/worker_test.js
@@ -382,4 +382,55 @@ describe('Workers', function () {
 
     workers.run()
   })
+
+  describe('_getWorkersTimeoutMs', () => {
+    let savedEnv
+    let workers
+
+    beforeEach(() => {
+      savedEnv = process.env.CODECEPT_WORKERS_TIMEOUT
+      delete process.env.CODECEPT_WORKERS_TIMEOUT
+      workers = new Workers(1, { by: 'test', testConfig: './test/data/sandbox/codecept.workers.conf.js' })
+      // Stub the codecept config so we don't need to await initialization for this pure-logic test
+      workers.codecept = { config: {} }
+    })
+
+    afterEach(() => {
+      if (savedEnv === undefined) {
+        delete process.env.CODECEPT_WORKERS_TIMEOUT
+      } else {
+        process.env.CODECEPT_WORKERS_TIMEOUT = savedEnv
+      }
+    })
+
+    it('returns default 10 minutes when nothing is configured', () => {
+      expect(workers._getWorkersTimeoutMs()).to.equal(600000)
+    })
+
+    it('uses CODECEPT_WORKERS_TIMEOUT env var when set', () => {
+      process.env.CODECEPT_WORKERS_TIMEOUT = '90000'
+      expect(workers._getWorkersTimeoutMs()).to.equal(90000)
+    })
+
+    it('uses workersTimeout from config when env is not set', () => {
+      workers.codecept.config.workersTimeout = 120000
+      expect(workers._getWorkersTimeoutMs()).to.equal(120000)
+    })
+
+    it('env var takes precedence over config', () => {
+      process.env.CODECEPT_WORKERS_TIMEOUT = '15000'
+      workers.codecept.config.workersTimeout = 999999
+      expect(workers._getWorkersTimeoutMs()).to.equal(15000)
+    })
+
+    it('returns 0 when env var is "0" so the timeout can be disabled in run()', () => {
+      process.env.CODECEPT_WORKERS_TIMEOUT = '0'
+      expect(workers._getWorkersTimeoutMs()).to.equal(0)
+    })
+
+    it('falls back to default when env var is non-numeric', () => {
+      process.env.CODECEPT_WORKERS_TIMEOUT = 'not-a-number'
+      expect(workers._getWorkersTimeoutMs()).to.equal(600000)
+    })
+  })
 })

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -360,6 +360,13 @@ declare namespace CodeceptJS {
      */
     teardownAll?: (() => Promise<void>) | boolean | string
 
+    /**
+     * Overall timeout for `run-workers` (milliseconds). After this time, any worker
+     * still running is force-terminated and the run finishes. Default: `600000` (10 min).
+     * Set to `0` to disable. Can also be overridden via `CODECEPT_WORKERS_TIMEOUT` env var.
+     */
+    workersTimeout?: number
+
     /** Enable [localized test commands](https://codecept.io/translation/) */
     translation?: string
 


### PR DESCRIPTION
## Summary

Fix 8 bugs across 6 plugin files where async operations outside the recorder chain, missing force flags, and incorrect filtering caused silent data loss, premature process exit, and broken healing limits.

- **aiTrace**: artifacts now captured inside recorder chain; `on:fail` mode awaits pending captures before writing trace.md
- **analyze**: `printReport()` properly awaited with auto-exit prevention; fixed `container` → `Container` typo
- **screencast**: recording starts at `event.test.started` (after page init, before steps) so failing tests get video
- **pageInfo**: `recorder.add()` with `force=true` + lazy helper re-resolution
- **heal**: `getCodeSuggestions()` filters recipes by step name; `healLimit` enforced inside catch handler; counter reset per test

Reproduction project: https://github.com/gololdf1sh/codeceptjs-plugins-test