### PR TITLE
fix(plugins): resolve async race conditions in aiTrace, analyze, screencast, pageInfo, heal

### DIFF
--- a/lib/heal.js
+++ b/lib/heal.js
@@ -54,7 +54,9 @@ class Heal {
 
   async getCodeSuggestions(context) {
     const suggestions = []
+    const stepName = context.step?.name
     const recipes = matchRecipes(this.recipes, this.contextName)
+      .filter(r => !r.steps || !stepName || r.steps.includes(stepName))
 
     debug('Recipes', recipes)
 

--- a/lib/plugin/aiTrace.js
+++ b/lib/plugin/aiTrace.js
@@ -92,6 +92,7 @@ export default function (config = {}) {
   let testStartTime
   let currentUrl = null
   let testFailed = false
+  let pendingArtifactCapture = null
   let firstFailedStepSaved = false
 
   const reportDir = config.output ? path.resolve(store.codeceptDir, config.output) : defaultConfig.output
@@ -129,6 +130,7 @@ export default function (config = {}) {
     currentUrl = null
     testFailed = false
     firstFailedStepSaved = false
+    pendingArtifactCapture = null
   })
 
   event.dispatcher.on(event.step.after, step => {
@@ -162,13 +164,12 @@ export default function (config = {}) {
       return
     }
 
-    const stepPersistPromise = persistStep(step).catch(err => {
+    recorder.add(`aiTrace step persistence: ${step.toString()}`, () => persistStep(step).catch(err => {
       output.debug(`aiTrace: Error saving step: ${err.message}`)
-    })
-    recorder.add(`wait aiTrace step persistence: ${step.toString()}`, () => stepPersistPromise, true)
+    }), true)
   })
 
-  event.dispatcher.on(event.step.failed, async step => {
+  event.dispatcher.on(event.step.failed, step => {
     if (!currentTest) return
     if (step.status === 'queued' && testFailed) {
       output.debug(`aiTrace: Skipping queued failed step "${step.toString()}" - testFailed: ${testFailed}`)
@@ -188,11 +189,9 @@ export default function (config = {}) {
       }
       existingStep.status = 'failed'
 
-      try {
-        await captureArtifactsForStep(step, existingStep, existingStep.prefix)
-      } catch (err) {
+      pendingArtifactCapture = captureArtifactsForStep(step, existingStep, existingStep.prefix).catch(err => {
         output.debug(`aiTrace: Error updating failed step: ${err.message}`)
-      }
+      })
     } else {
       if (stepNum === -1) return
       if (isStepIgnored(step)) return
@@ -218,11 +217,9 @@ export default function (config = {}) {
       steps.push(stepData)
       firstFailedStepSaved = true
 
-      try {
-        await captureArtifactsForStep(step, stepData, stepPrefix)
-      } catch (err) {
+      pendingArtifactCapture = captureArtifactsForStep(step, stepData, stepPrefix).catch(err => {
         output.debug(`aiTrace: Error capturing failed step artifacts: ${err.message}`)
-      }
+      })
     }
   })
 
@@ -238,7 +235,13 @@ export default function (config = {}) {
     if (hookName === 'BeforeSuite' || hookName === 'AfterSuite') {
       return
     }
-    persist(test, 'failed')
+    recorder.add('aiTrace:persist failed', async () => {
+      if (pendingArtifactCapture) {
+        await pendingArtifactCapture
+        pendingArtifactCapture = null
+      }
+      persist(test, 'failed')
+    }, true)
   })
 
   async function persistStep(step) {

--- a/lib/plugin/analyze.js
+++ b/lib/plugin/analyze.js
@@ -234,7 +234,12 @@ export default function (config = {}) {
       return
     }
 
-    printReport(result)
+    process.env.CODECEPT_DISABLE_AUTO_EXIT = '1'
+    try {
+      await printReport(result)
+    } finally {
+      process.exit(process.exitCode || 0)
+    }
   })
 
   event.dispatcher.on(event.workers.result, async result => {
@@ -248,7 +253,12 @@ export default function (config = {}) {
       return
     }
 
-    printReport(result)
+    process.env.CODECEPT_DISABLE_AUTO_EXIT = '1'
+    try {
+      await printReport(result)
+    } finally {
+      process.exit(process.exitCode || 0)
+    }
   })
 
   async function printReport(result) {
@@ -294,7 +304,7 @@ export default function (config = {}) {
       console.error('Error analyzing failed tests', err)
     }
 
-    if (!Object.keys(container.plugins()).includes('pageInfo')) {
+    if (!Object.keys(Container.plugins()).includes('pageInfo')) {
       console.log('To improve analysis, enable pageInfo plugin to get more context for failed tests.')
     }
   }

--- a/lib/plugin/heal.js
+++ b/lib/plugin/heal.js
@@ -80,6 +80,7 @@ export default function (config = {}) {
   event.dispatcher.on(event.test.before, test => {
     currentTest = test
     healedSteps = 0
+    healTries = 0
     caughtError = null
   })
 
@@ -94,7 +95,9 @@ export default function (config = {}) {
     if (trigger.on === 'file' && !matchStepFile(step, trigger.path, trigger.line)) return
 
     recorder.catchWithoutStop(async err => {
+      if (healTries >= config.healLimit) throw err
       isHealing = true
+      healTries++
       if (caughtError === err) throw err // avoid double handling
       caughtError = err
 
@@ -120,8 +123,6 @@ export default function (config = {}) {
       debug('Self-healing started', step.toCode())
 
       await heal.healStep(step, err, { test })
-
-      healTries++
 
       recorder.add('close healing session', () => {
         recorder.reset()

--- a/lib/plugin/pageInfo.js
+++ b/lib/plugin/pageInfo.js
@@ -40,10 +40,10 @@ const defaultConfig = {
 export default function (config = {}) {
   config = Object.assign(defaultConfig, config)
 
-  const helper = pickActingHelper(Container.helpers())
-  if (!helper) return
-
   event.dispatcher.on(event.test.failed, test => {
+    const helper = pickActingHelper(Container.helpers())
+    if (!helper) return
+
     const pageState = {}
 
     recorder.add('pageInfo capture', async () => {
@@ -60,8 +60,6 @@ export default function (config = {}) {
         if (captured.html) {
           const htmlPath = path.join(store.outputDir, captured.html)
           pageState.htmlSnapshot = htmlPath
-          // Scan raw HTML (pre-cleanHtml) so error classes containing digits
-          // or trash-class prefixes aren't stripped before detection.
           const htmlForScan = captured.htmlRaw || (() => {
             try { return fs.readFileSync(htmlPath, 'utf8') } catch { return '' }
           })()
@@ -90,7 +88,7 @@ export default function (config = {}) {
           } catch {}
         }
       } catch {}
-    })
+    }, true)
 
     recorder.add('Save page info', () => {
       test.addNote('pageInfo', pageStateToMarkdown(pageState))
@@ -99,7 +97,7 @@ export default function (config = {}) {
       fs.writeFileSync(pageStateFileName, pageStateToMarkdown(pageState))
       test.artifacts.pageInfo = pageStateFileName
       return pageState
-    })
+    }, true)
   })
 }
 

--- a/lib/plugin/screencast.js
+++ b/lib/plugin/screencast.js
@@ -106,6 +106,12 @@ function wireScreencast(mode, options) {
     state.startedAt = options.subtitles ? Date.now() : null
   })
 
+  event.dispatcher.on(event.test.started, test => {
+    if (!options.video || state.startQueued) return
+    state.startQueued = true
+    recorder.add('screencast:start', async () => startScreencast(state.test, options, state), true)
+  })
+
   event.dispatcher.on(event.step.started, step => {
     if (state.steps) {
       const at = Date.now()
@@ -116,10 +122,6 @@ function wireScreencast(mode, options) {
         title: stepTitle(step),
       }
     }
-    if (!options.video || state.startQueued || !state.test) return
-    state.startQueued = true
-    const test = state.test
-    recorder.add('screencast:start', async () => startScreencast(test, options, state), true)
   })
 
   if (options.subtitles) {


### PR DESCRIPTION
Reproduction project: https://github.com/gololdf1sh/codeceptjs-plugins-test

---

## Issue 1 — aiTrace: step artifacts race condition

**Steps to reproduce:**
1. Enable `aiTrace` plugin
2. Run a test that performs multiple steps
3. Check trace.md — artifacts (screenshots, HTML, ARIA) are missing or incomplete for some steps

**Cause:** `persistStep()` was called outside the recorder chain — the async capture ran in parallel with test execution, leading to race conditions.

**Fix:** Moved `persistStep()` inside `recorder.add()` so artifact capture is sequenced with the test flow.

---

## Issue 2 — analyze: AI report silently skipped

**Steps to reproduce:**
1. Enable `analyze` plugin, set `ANTHROPIC_API_KEY`
2. Run tests with `--ai` flag where some tests fail
3. Observe: no AI report is printed

**Cause:** Two issues: (a) `printReport()` is async but was called without `await` — the event handler returned immediately; (b) `process.exit()` in `run.js` fires on a 1-second timeout, killing the process before the AI API response arrives.

**Fix:** Added `await` to `printReport()`, set `CODECEPT_DISABLE_AUTO_EXIT=1` before the report, and call `process.exit()` explicitly after the report finishes.

---

## Issue 3 — screencast: recording starts too late (misses first steps)

**Steps to reproduce:**
1. Enable `screencast` plugin with `on: 'test'`
2. Run a test with navigation + interactions
3. Check the recorded video — the first steps are missing

**Cause:** Recording was triggered on `event.step.started` — the first step's actions could execute before the screencast started.

**Fix:** Moved the recording start to `event.test.started`, which fires after `helper._before()` (page is available) but before any steps execute.

---

## Issue 4 — pageInfo: plugin silently disabled (helper resolved too early)

**Steps to reproduce:**
1. Enable `pageInfo` plugin
2. Run a failing test
3. Observe: no pageInfo artifact is generated, no error message

**Cause:** Two issues: (a) `pickActingHelper()` was called at plugin init time when `Container.helpers()` may not be populated yet — if it returned `null`, the plugin silently exited; (b) `recorder.add()` calls lacked `force=true`, so they were skipped when the recorder was in a rejected state (which it is after a test failure).

**Fix:** Moved helper resolution inside the `event.test.failed` handler (lazy), and added `force=true` to both `recorder.add()` calls.

---

## Issue 5 + Issue 9 — aiTrace: failed step artifacts lost / `event.step.failed` async handler race

**Steps to reproduce:**
1. Enable `aiTrace` plugin
2. Run a test that fails on a specific step
3. Check trace.md — the failed step has no screenshot, HTML, or ARIA snapshot

**Cause:** `event.step.failed` handler was `async` but Node.js `EventEmitter` doesn't await async handlers. The artifact capture promise was fire-and-forget — `event.test.failed` / `persist()` ran before capture finished.

**Fix:** Changed `event.step.failed` to a sync handler that stores the capture promise in `pendingArtifactCapture`. The `event.test.failed` handler awaits this promise (inside `recorder.add` with `force=true`) before persisting the trace.

---

## Issue 6 — heal: `steps` filter in recipes ignored during code suggestions

**Steps to reproduce:**
1. Define a heal recipe with `steps: ['click']` filter
2. Trigger healing on a `fillField` failure
3. Observe: the recipe is used despite the step name not matching

**Cause:** `getCodeSuggestions()` in `heal.js` didn't filter recipes by their `steps` array — it matched only by context name.

**Fix:** Added `.filter(r => !r.steps || !stepName || r.steps.includes(stepName))` after `matchRecipes()` in `getCodeSuggestions()`.

---

## Issue 7 — heal: `healLimit` not enforced correctly

**Steps to reproduce:**
1. Set `healLimit: 2` in heal plugin config
2. Run a test where 4+ steps fail
3. Observe: all steps are healed, limit is ignored

**Cause:** Two issues: (a) `healTries` was never reset between tests; (b) the limit check was outside `recorder.catchWithoutStop` — since `catchWithoutStop` registers a persistent handler, the outer check ran only once at registration time.

**Fix:** Reset `healTries = 0` in `event.test.before`, and moved the limit check inside the `catchWithoutStop` callback so it's evaluated on every caught error.

---

## Issue 10 — analyze: `container` typo (lowercase)

**Steps to reproduce:**
1. Enable `analyze` plugin with `--ai` flag
2. Run tests where some fail
3. Observe: `ReferenceError: container is not defined` in console

**Cause:** Line 297 used `container.plugins()` (lowercase) instead of `Container.plugins()`.

**Fix:** Changed `container` to `Container`.