### PR TITLE
fix(mcp): kill zombie Mocha state when timeout fires before pause()

### DIFF
--- a/bin/mcp-server.js
+++ b/bin/mcp-server.js
@@ -401,14 +401,17 @@ async function cancelRun() {
   abortRun = true
   if (typeof pendingRunCleanup === 'function') { try { pendingRunCleanup() } catch {} }
   if (pausedController) { try { pausedController.resolveContinue() } catch {} ; pausedController = null }
+
+  const mocha = typeof container.mocha === 'function' ? container.mocha() : container.mocha
+  try { mocha?.runner?.abort?.() } catch {}
+
   if (pendingRunPromise) {
-    try { await Promise.race([pendingRunPromise.catch(() => {}), new Promise(r => setTimeout(r, 5000))]) } catch {}
+    try { await pendingRunPromise.catch(() => {}) } catch {}
   }
   pendingRunPromise = null
   pendingRunResults = null
   pendingTestFile = null
   pendingStepInfo = null
-  abortRun = false
   return true
 }
 
@@ -1032,6 +1035,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
               pendingRunCleanup = null
             }
 
+            abortRun = false
             let runError = null
             const runPromise = (async () => {
               try {
@@ -1126,6 +1130,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
               pendingRunCleanup = null
             }
 
+            abortRun = false
             let runError = null
             const runPromise = (async () => {
               try {

--- a/bin/mcp-server.js
+++ b/bin/mcp-server.js
@@ -60,9 +60,7 @@ function aiTraceHint() {
 }
 
 function applyMochaGrep(grep) {
-  if (!grep) return
-  const mocha = typeof container.mocha === 'function' ? container.mocha() : container.mocha
-  if (mocha && typeof mocha.grep === 'function') mocha.grep(grep)
+  if (grep) container.mocha().grep(grep)
 }
 
 function pauseAtMatcher(pauseAt) {
@@ -402,8 +400,7 @@ async function cancelRun() {
   if (typeof pendingRunCleanup === 'function') { try { pendingRunCleanup() } catch {} }
   if (pausedController) { try { pausedController.resolveContinue() } catch {} ; pausedController = null }
 
-  const mocha = typeof container.mocha === 'function' ? container.mocha() : container.mocha
-  try { mocha?.runner?.abort?.() } catch {}
+  try { container.mocha().runner?.abort() } catch {}
 
   if (pendingRunPromise) {
     try { await pendingRunPromise.catch(() => {}) } catch {}

--- a/lib/codecept.js
+++ b/lib/codecept.js
@@ -316,7 +316,7 @@ class Codecept {
 
       try {
         event.emit(event.all.before, this)
-        mocha.run(async (failures) => await done(failures))
+        mocha.runner = mocha.run(async (failures) => await done(failures))
       } catch (e) {
         output.error(e.stack)
         reject(e)


### PR DESCRIPTION
## Summary

Fixes a follow-up case for #5551 reported in [testomatio/e2e-tests#103](https://github.com/testomatio/e2e-tests/issues/103): when `run_test`'s timeout was shorter than the time the test needed to reach `pause()` (e.g. `timeout: 50ms` vs a 30s Playwright helper timeout), Mocha kept running, eventually entered a paused state forever, and every subsequent `run_test` failed with `Mocha instance is currently running`. The only recovery was killing the MCP process.

## Changes

- **`lib/codecept.js`** — capture the Runner returned by `mocha.run()` as `mocha.runner`. Previously the return value was discarded so callers had no clean handle to abort.
- **`bin/mcp-server.js` `cancelRun()`** — call `mocha.runner.abort()` to actually stop Mocha (sets the runner's `_abort` flag, makes the run callback fire fast). Drop the 5s race against `pendingRunPromise` — with `runner.abort()` the promise settles quickly; relying on a short race meant a 30s Playwright step would outlive the cancel and Mocha state stayed `RUNNING`.
- **`abortRun` lifecycle** — stop resetting it inside `cancelRun`. Reset it at the start of each new `run_test` / `run_step_by_step` instead. This way if a late `pause()` fires after `cancelRun` returns (test reached pause asynchronously after the timeout), `setPauseHandler` still rejects it instead of trapping forever.

## Test plan

- [x] `run_test({timeout: 50})` against a Playwright test that needs ≥1s to reach pause → `{ status: "failed", error: "Timeout after 50ms" }` (was: hung response, then permanently broken Mocha).
- [x] Subsequent `run_test({timeout: 60000})` → `stats: { tests: 1, passes: 1 }` — no `Mocha instance is currently running`.
- [x] Normal paused flow still works (timeout > time-to-pause).
- [ ] Reviewer should sanity-check against their MCP client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)