### PR TITLE
fix(playwright): replace constructor.name checks with stable public API (#5559)

### DIFF
--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -2683,7 +2683,7 @@ class Playwright extends Helper {
     if (arg && typeof arg.evaluate === 'function' && typeof arg.locator === 'function') {
       return arg.evaluate(fn)
     }
-    if (this.context && this.context.constructor.name === 'FrameLocator') {
+    if (this.context && typeof this.context.url !== 'function' && typeof this.context.innerText !== 'function') {
       return this.context.locator(':root').evaluate(fn, arg)
     }
     return this.page.evaluate.apply(this.page, [fn, arg])
@@ -3420,7 +3420,7 @@ class Playwright extends Helper {
   }
 
   async _getContext() {
-    if ((this.context && this.context.constructor.name === 'FrameLocator') || this.context) {
+    if (this.context) {
       return this.context
     }
     if (this.frame) {
@@ -4359,7 +4359,9 @@ async function proceedSee(assertType, text, context, strict = false) {
   if (!context) {
     const el = await this.context
 
-    allText = el.constructor.name !== 'Locator' ? [await el.locator('body').innerText()] : [await el.innerText()]
+    allText = typeof el.url !== 'function' && typeof el.innerText === 'function'
+      ? [await el.innerText()]
+      : [await el.locator('body').innerText()]
 
     description = 'web application'
   } else {

--- a/test/helper/webapi.js
+++ b/test/helper/webapi.js
@@ -1659,6 +1659,13 @@ export function tests() {
         if (!err) assert.fail('seen "Information"')
       }
     })
+
+    it('within on css locator should use locator scope in see without explicit context', async function () {
+      await I.amOnPage('/form/example4')
+      await I._withinBegin({ css: '#register' })
+      await I.see('E-Mail')
+      await I.dontSee('Toggle navigation')
+    })
   })
 
   describe('scroll: #scrollTo, #scrollPageToTop, #scrollPageToBottom', () => {


### PR DESCRIPTION
## Summary

Fixes #5559.

Playwright 1.60 switched its distribution from individual compiled files to a single esbuild bundle. esbuild prefixes class names with `_` to avoid naming conflicts, so `Locator` silently became `_Locator` and `FrameLocator` likely `_FrameLocator`. This broke all `constructor.name` checks in `Playwright.js`.

Three fixes, all replacing fragile `constructor.name` checks with duck-typing on stable public-API methods:

| Context type | `url()` | `innerText()` | Correct branch |
|---|---|---|---|
| `Page` | ✓ | ✓ | `locator('body').innerText()` |
| `Frame` | ✓ | ✓ | `locator('body').innerText()` |
| `FrameLocator` | ✗ | ✗ | `locator('body').innerText()` |
| `Locator` | ✗ | ✓ | `el.innerText()` |

- **`proceedSee`**: `el.constructor.name !== 'Locator'` → `typeof el.url !== 'function' && typeof el.innerText === 'function'` (the main bug — caused `within()` + `I.see()` to time out)
- **`executeScript`**: `constructor.name === 'FrameLocator'` → `typeof el.url !== 'function' && typeof el.innerText !== 'function'`
- **`_getContext`**: `(this.context && constructor.name === 'FrameLocator') || this.context` → `this.context` (the FrameLocator sub-check was logically redundant)

## Test plan

- Added a new unit test: `within on css locator should use locator scope in see without explicit context` — calls `I.see()` with no context arg while `this.context` is a Playwright `Locator` (the exact path that timed out)
- Verified **without the fix + Playwright 1.60**: test fails with `locator.innerText: Timeout exceeded — waiting for locator('#register').first().locator('body')`
- Verified **with the fix + Playwright 1.60**: 24/24 within tests pass
- Verified **with the fix + Playwright 1.59**: 24/24 within tests pass (fully backward-compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)