### PR TITLE
fix(workers): do not exit worker on unhandled rejections

### DIFF
--- a/lib/command/workers/runTests.js
+++ b/lib/command/workers/runTests.js
@@ -54,11 +54,13 @@ process.on('unhandledRejection', (reason, promise) => {
     process.stderr.write(`${reason.stack}\n`)
   }
 
-  // Don't exit on test-related rejections
-  if (msg.includes('expected') || msg.includes('AssertionError')) {
-    return
-  }
-  process.exit(1)
+  // Do not exit on unhandled rejections — log only.
+  // Exiting kills the entire worker process, silently dropping every remaining
+  // test in its queue (no failure report, just missing from the run summary).
+  // Orphaned promises happen routinely in real suites: detached
+  // page.waitForResponse() that times out after the action threw, session-
+  // restore races in auth plugins, etc. Restores 3.x behavior where workers
+  // logged the rejection and continued to the next test.
 })
 
 // hide worker output

--- a/lib/command/workers/runTests.js
+++ b/lib/command/workers/runTests.js
@@ -54,13 +54,7 @@ process.on('unhandledRejection', (reason, promise) => {
     process.stderr.write(`${reason.stack}\n`)
   }
 
-  // Do not exit on unhandled rejections — log only.
-  // Exiting kills the entire worker process, silently dropping every remaining
-  // test in its queue (no failure report, just missing from the run summary).
-  // Orphaned promises happen routinely in real suites: detached
-  // page.waitForResponse() that times out after the action threw, session-
-  // restore races in auth plugins, etc. Restores 3.x behavior where workers
-  // logged the rejection and continued to the next test.
+  // Do not exit — killing the worker silently drops every remaining test from the report.
 })
 
 // hide worker output


### PR DESCRIPTION
## Problem

The `unhandledRejection` handler in `runTests.js` calls `process.exit(1)` for any rejection not matching `expected` / `AssertionError`. This kills the worker and **silently drops every remaining test in its queue** — they simply disappear from the report.

Common triggers (none related to test correctness):
- Orphaned `page.waitForResponse()` that outlives a thrown error and rejects later
- Auth plugin session-restore races between workers
- `video.saveAs` after Playwright context close

## Fix

Remove `process.exit(1)` — log the rejection, continue. `uncaughtException` handler is unchanged (genuinely unrecoverable). Restores 3.x behaviour.