### PR TITLE
fix(plugin): guard against undefined step.name in retryFailedStep

### DIFF
--- a/lib/plugin/retryFailedStep.js
+++ b/lib/plugin/retryFailedStep.js
@@ -111,11 +111,12 @@ export default function (config) {
   }
 
   event.dispatcher.on(event.step.started, step => {
+    if (!step.title) return
     for (const ignored of config.ignoredSteps) {
-      if (step.name === ignored) return
+      if (step.title === ignored) return
       if (ignored instanceof RegExp) {
-        if (step.name.match(ignored)) return
-      } else if (ignored.indexOf('*') && step.name.startsWith(ignored.slice(0, -1))) return
+        if (step.title.match(ignored)) return
+      } else if (ignored.indexOf('*') && step.title.startsWith(ignored.slice(0, -1))) return
     }
     enableRetry = true
   })


### PR DESCRIPTION
## Problem

`retryFailedStep` plugin crashes workers in `run-workers` mode:

```
TypeError: Cannot read properties of undefined (reading 'startsWith')
```

The plugin reads `step.name`, but in worker mode steps are serialized via `simplify()` which drops `name`.

## Fix

Replace `step.name` → `step.title` in the plugin. Depends on #5564 which renames `Step.name` → `Step.title` across core.

## Related

- #5564 — core rename `Step.name` → `Step.title`
- testomatio/e2e-tests#139 — original report