### PR TITLE
fix(step): preserve step.name in simplify() for worker IPC

### DIFF
--- a/lib/plugin/retryFailedStep.js
+++ b/lib/plugin/retryFailedStep.js
@@ -111,6 +111,7 @@ export default function (config) {
   }
 
   event.dispatcher.on(event.step.started, step => {
+    if (!step.name) return
     for (const ignored of config.ignoredSteps) {
       if (step.name === ignored) return
       if (ignored instanceof RegExp) {

--- a/lib/step/base.js
+++ b/lib/step/base.js
@@ -223,6 +223,7 @@ class Step {
 
     return {
       opts: step.opts || {},
+      name: step.name,
       title: step.name,
       args: args,
       status: step.status,


### PR DESCRIPTION
## Problem

`step.simplify()` maps `name` → `title`, dropping `name` from the serialized object sent via IPC from workers to the master process. Any plugin listening to step events in the master process (e.g. `retryFailedStep`) crashes because `step.name` is `undefined`:

```
TypeError: Cannot read properties of undefined (reading 'startsWith')
    at retryFailedStep.js:118:52
```

## Root cause

`simplify()` in `lib/step/base.js` returns `{ title: step.name, ... }` — the field is renamed from `name` to `title`. In sequential mode, plugins receive the full `Step` object with `.name`. In `run-workers` mode, the worker serializes via `simplify()` before IPC, so the master receives an object with `.title` only.

## Fix

1. **`lib/step/base.js`** — add `name: step.name` to `simplify()` output (alongside `title` for backwards compatibility)
2. **`lib/plugin/retryFailedStep.js`** — add null-guard for edge cases where `step.name` is undefined on the full Step object (hook steps)

## Related

- Alternative approach: #5562 (uses `step.name || step.title` fallback in the plugin only)
- Reported in: testomatio/e2e-tests#139

🤖 Generated with [Claude Code](https://claude.com/claude-code)