### PR TITLE
refactor(step): rename Step.name to Step.title for consistency

### DIFF
--- a/lib/actor.js
+++ b/lib/actor.js
@@ -94,7 +94,7 @@ export default function (obj = {}, container) {
             actor[action] = actor[actionAlias] = function () {
               const step = new Step(helper, action)
               if (translation.loaded) {
-                step.name = actionAlias
+                step.title = actionAlias
                 step.actor = translation.I
               }
               // add methods to promise chain

--- a/lib/heal.js
+++ b/lib/heal.js
@@ -49,12 +49,12 @@ class Heal {
   }
 
   hasCorrespondingRecipes(step) {
-    return matchRecipes(this.recipes, this.contextName).filter(r => !r.steps || r.steps.includes(step.name)).length > 0
+    return matchRecipes(this.recipes, this.contextName).filter(r => !r.steps || r.steps.includes(step.title)).length > 0
   }
 
   async getCodeSuggestions(context) {
     const suggestions = []
-    const stepName = context.step?.name
+    const stepName = context.step?.title
     const recipes = matchRecipes(this.recipes, this.contextName)
       .filter(r => !r.steps || !stepName || r.steps.includes(stepName))
 

--- a/lib/plugin/aiTrace.js
+++ b/lib/plugin/aiTrace.js
@@ -195,7 +195,7 @@ export default function (config = {}) {
     } else {
       if (stepNum === -1) return
       if (isStepIgnored(step)) return
-      if (step.metaStep && step.metaStep.name === 'BeforeSuite') return
+      if (step.metaStep && step.metaStep.title === 'BeforeSuite') return
 
       const stepPrefix = generateStepPrefix(step, stepNum)
       stepNum++
@@ -247,7 +247,7 @@ export default function (config = {}) {
   async function persistStep(step) {
     if (stepNum === -1) return
     if (isStepIgnored(step)) return
-    if (step.metaStep && step.metaStep.name === 'BeforeSuite') return
+    if (step.metaStep && step.metaStep.title === 'BeforeSuite') return
 
     const stepKey = step.toString()
 
@@ -437,8 +437,9 @@ export default function (config = {}) {
 
   function isStepIgnored(step) {
     if (!config.ignoreSteps) return false
+    if (!step.title) return false
     for (const pattern of config.ignoreSteps || []) {
-      if (step.name.match(pattern)) return true
+      if (step.title.match(pattern)) return true
     }
     return false
   }

--- a/lib/plugin/junitReporter.js
+++ b/lib/plugin/junitReporter.js
@@ -242,7 +242,7 @@ function stepLogLine(entry) {
 
 function stepText(step) {
   if (step && typeof step.toString === 'function' && step.toString !== Object.prototype.toString) return step.toString()
-  return (step && (step.title || step.name)) || 'step'
+  return (step && step.title) || 'step'
 }
 
 function stepDuration(step) {

--- a/lib/plugin/retryFailedStep.js
+++ b/lib/plugin/retryFailedStep.js
@@ -111,11 +111,12 @@ export default function (config) {
   }
 
   event.dispatcher.on(event.step.started, step => {
+    if (!step.title) return
     for (const ignored of config.ignoredSteps) {
-      if (step.name === ignored) return
+      if (step.title === ignored) return
       if (ignored instanceof RegExp) {
-        if (step.name.match(ignored)) return
-      } else if (ignored.indexOf('*') && step.name.startsWith(ignored.slice(0, -1))) return
+        if (step.title.match(ignored)) return
+      } else if (ignored.indexOf('*') && step.title.startsWith(ignored.slice(0, -1))) return
     }
     enableRetry = true
   })

--- a/lib/plugin/screencast.js
+++ b/lib/plugin/screencast.js
@@ -258,7 +258,7 @@ function formatTimestamp(timestampInMs) {
 }
 
 function stepTitle(step) {
-  let title = `${step.actor}.${step.name}(${step.args ? step.args.join(',') : ''})`
+  let title = `${step.actor}.${step.title}(${step.args ? step.args.join(',') : ''})`
   if (title.length > 100) title = `${title.substring(0, 100)}...`
   return title
 }

--- a/lib/plugin/screenshot.js
+++ b/lib/plugin/screenshot.js
@@ -325,7 +325,7 @@ function wireSlides(options, trigger) {
     if (stepNum === -1) return
     if (savedStep === step) return
     if (scenarioFailed) return
-    if (step.metaStep && step.metaStep.name === 'BeforeSuite') return
+    if (step.metaStep && step.metaStep.title === 'BeforeSuite') return
     if (!currentTest) return
     if (!stepFilter(step)) return
     if (isStepIgnored(step, options.ignoreSteps)) return
@@ -404,7 +404,7 @@ function makeStepFilter(trigger, options) {
 function isStepIgnored(step, patterns) {
   if (!patterns || !patterns.length) return false
   for (const pattern of patterns) {
-    if (step.name && step.name.match(pattern)) return true
+    if (step.title && step.title.match(pattern)) return true
   }
   return false
 }

--- a/lib/plugin/stepTimeout.js
+++ b/lib/plugin/stepTimeout.js
@@ -68,6 +68,7 @@ export default function(config) {
   config.customTimeoutSteps = config.customTimeoutSteps.concat(config.noTimeoutSteps).concat(config.customTimeoutSteps)
 
   event.dispatcher.on(event.step.before, step => {
+    if (!step.title) return
     let stepTimeout
     for (let stepRule of config.customTimeoutSteps) {
       let customTimeout = 0
@@ -75,7 +76,7 @@ export default function(config) {
         if (stepRule.length > 1) customTimeout = stepRule[1]
         stepRule = stepRule[0]
       }
-      if (stepRule instanceof RegExp ? step.name.match(stepRule) : step.name === stepRule || (stepRule.indexOf('*') && step.name.startsWith(stepRule.slice(0, -1)))) {
+      if (stepRule instanceof RegExp ? step.title.match(stepRule) : step.title === stepRule || (stepRule.indexOf('*') && step.title.startsWith(stepRule.slice(0, -1)))) {
         stepTimeout = customTimeout
         break
       }

--- a/lib/step/base.js
+++ b/lib/step/base.js
@@ -10,12 +10,12 @@ const STACK_LINE = 5
 /**
  * Each command in test executed through `I.` object is wrapped in Step.
  * Step allows logging executed commands and triggers hook before and after step execution.
- * @param {string} name
+ * @param {string} title
  */
 class Step {
-  constructor(name) {
+  constructor(title) {
     /** @member {string} */
-    this.name = name
+    this.title = title
     /** @member {Map<number, number>} */
     this.timeouts = new Map()
 
@@ -43,7 +43,7 @@ class Step {
     /** @member {any} */
     this.helper = null
     /** @member {string} */
-    this.helperMethod = name
+    this.helperMethod = title
 
     this.startTime = 0
     this.endTime = 0
@@ -103,7 +103,7 @@ class Step {
 
   /** @return {string} */
   humanize() {
-    return humanizeString(this.name)
+    return humanizeString(this.title)
   }
 
   /** @return {string} */
@@ -180,7 +180,7 @@ class Step {
 
   /** @return {string} */
   toCode() {
-    return `${this.prefix}${this.actor}.${this.name}(${this.humanizeArgs()})${this.suffix}`
+    return `${this.prefix}${this.actor}.${this.title}(${this.humanizeArgs()})${this.suffix}`
   }
 
   isMetaStep() {
@@ -223,7 +223,7 @@ class Step {
 
     return {
       opts: step.opts || {},
-      title: step.name,
+      title: step.title,
       args: args,
       status: step.status,
       startTime: step.startTime,

--- a/lib/step/comment.js
+++ b/lib/step/comment.js
@@ -1,8 +1,8 @@
 import FuncStep from './func.js'
 
 class CommentStep extends FuncStep {
-  constructor(name, comment) {
-    super(name)
+  constructor(title, comment) {
+    super(title)
     this.fn = () => {}
   }
 }

--- a/lib/step/helper.js
+++ b/lib/step/helper.js
@@ -2,12 +2,12 @@ import Step from './base.js'
 import store from '../store.js'
 
 class HelperStep extends Step {
-  constructor(helper, name) {
-    super(name)
+  constructor(helper, title) {
+    super(title)
     /** @member {CodeceptJS.Helper} helper corresponding helper */
     this.helper = helper
-    /** @member {string} helperMethod name of method to be executed */
-    this.helperMethod = name
+    /** @member {string} helperMethod title of method to be executed */
+    this.helperMethod = title
   }
 
   /**

--- a/lib/step/meta.js
+++ b/lib/step/meta.js
@@ -29,7 +29,7 @@ class MetaStep extends Step {
     const actorText = this.actor
 
     if (this.isBDD()) {
-      return `${this.prefix}${actorText} ${this.name} "${this.humanizeArgs()}${this.suffix}"`
+      return `${this.prefix}${actorText} ${this.title} "${this.humanizeArgs()}${this.suffix}"`
     }
 
     if (actorText === 'I') {
@@ -37,14 +37,14 @@ class MetaStep extends Step {
     }
 
     if (!this.actor) {
-      return `${this.name} ${this.humanizeArgs()}${this.suffix}`.trim()
+      return `${this.title} ${this.humanizeArgs()}${this.suffix}`.trim()
     }
 
     return `On ${this.prefix}${actorText}: ${this.humanize()} ${this.humanizeArgs()}${this.suffix}`.trim()
   }
 
   humanize() {
-    return humanizeString(this.name)
+    return humanizeString(this.title)
   }
 
   setTrace() {}

--- a/lib/step/record.js
+++ b/lib/step/record.js
@@ -16,12 +16,12 @@ function recordStep(step, args) {
     const { opts, timeout, retry } = stepConfig.getConfig()
 
     if (opts) {
-      output.debug(`Step ${step.name}: options applied ${JSON.stringify(opts)}`)
+      output.debug(`Step ${step.title}: options applied ${JSON.stringify(opts)}`)
       store.stepOptions = opts
       step.opts = opts
     }
     if (timeout) {
-      output.debug(`Step ${step.name} timeout ${timeout}s`)
+      output.debug(`Step ${step.title} timeout ${timeout}s`)
       step.setTimeout(timeout * 1000, TIMEOUT_ORDER.codeLimitTime)
     }
     if (retry) retryStep(retry)
@@ -31,7 +31,7 @@ function recordStep(step, args) {
   // run async before step hooks
   event.emit(event.step.before, step)
 
-  const task = `${step.name}: ${step.humanizeArgs()}`
+  const task = `${step.title}: ${step.humanizeArgs()}`
   let val
 
   // run step inside promise

--- a/test/unit/heal_test.js
+++ b/test/unit/heal_test.js
@@ -26,7 +26,7 @@ describe('heal', () => {
       },
     })
 
-    expect(heal.hasCorrespondingRecipes({ name: 'click' })).to.be.true
+    expect(heal.hasCorrespondingRecipes({ title: 'click' })).to.be.true
   })
 
   it('should respect the priority of recipes', async () => {
@@ -58,7 +58,7 @@ describe('heal', () => {
   it('should have corresponding recipes', () => {
     heal.recipes = { test: { steps: ['step1', 'step2'], fn: () => {} } }
     heal.contextName = 'TestSuite'
-    const result = heal.hasCorrespondingRecipes({ name: 'step1' })
+    const result = heal.hasCorrespondingRecipes({ title: 'step1' })
     expect(result).to.be.true
   })
 
@@ -95,9 +95,9 @@ describe('heal', () => {
     })
 
     heal.contextName = 'TestSuite @slow'
-    expect(heal.hasCorrespondingRecipes({ name: 'step1' })).to.be.true
+    expect(heal.hasCorrespondingRecipes({ title: 'step1' })).to.be.true
     heal.contextName = 'TestSuite @fast'
-    expect(heal.hasCorrespondingRecipes({ name: 'step1' })).not.to.be.true
+    expect(heal.hasCorrespondingRecipes({ title: 'step1' })).not.to.be.true
   })
 
   it('should contain info', async () => {

--- a/test/unit/listener/steps_issue_4619_test.js
+++ b/test/unit/listener/steps_issue_4619_test.js
@@ -59,7 +59,7 @@ describe('Steps Listener - Issue Fix #4619', () => {
     const stepCountAfter = currentTest.steps.length
 
     // The manually emitted step should not appear in the main test trace
-    const stepNames = currentTest.steps.map(step => step.name)
+    const stepNames = currentTest.steps.map(step => step.title)
     expect(stepNames).to.not.include('optionalAction')
 
     return recorder.promise()
@@ -72,7 +72,7 @@ describe('Steps Listener - Issue Fix #4619', () => {
     })
 
     // The manually emitted step should not appear in the main test trace
-    const stepNames = currentTest.steps.map(step => step.name)
+    const stepNames = currentTest.steps.map(step => step.title)
     expect(stepNames).to.not.include('softAssertion')
 
     return recorder.promise()
@@ -83,7 +83,7 @@ describe('Steps Listener - Issue Fix #4619', () => {
     const regularStep = new Step({ normalAction: () => 'done' }, 'normalAction')
     event.emit(event.step.started, regularStep)
 
-    const stepNames = currentTest.steps.map(step => step.name)
+    const stepNames = currentTest.steps.map(step => step.title)
     expect(stepNames).to.include('normalAction')
   })
 
@@ -104,7 +104,7 @@ describe('Steps Listener - Issue Fix #4619', () => {
     const anotherRegularStep = new Step({ anotherRegularAction: () => 'done' }, 'anotherRegularAction')
     event.emit(event.step.started, anotherRegularStep)
 
-    const stepNames = currentTest.steps.map(step => step.name)
+    const stepNames = currentTest.steps.map(step => step.title)
 
     // Regular steps should be present
     expect(stepNames).to.include('regularAction')

--- a/test/unit/plugin/aiTrace_test.js
+++ b/test/unit/plugin/aiTrace_test.js
@@ -51,7 +51,7 @@ describe('aiTrace plugin', () => {
     await recorder.promise()
 
     const step = {
-      name: 'amOnPage',
+      title: 'amOnPage',
       toString: () => 'I am on page',
       meta: { url: 'https://example.com' },
       status: 'success',
@@ -81,7 +81,7 @@ describe('aiTrace plugin', () => {
     await recorder.promise()
 
     const step = {
-      name: 'see',
+      title: 'see',
       toString: () => 'I see test',
       status: 'success',
       startTime: Date.now(),
@@ -114,7 +114,7 @@ describe('aiTrace plugin', () => {
     await recorder.promise()
 
     const step = {
-      name: 'see',
+      title: 'see',
       toString: () => 'I see test',
       status: 'failed',
       startTime: Date.now(),
@@ -142,7 +142,7 @@ describe('aiTrace plugin', () => {
     await recorder.promise()
 
     const step = {
-      name: 'grabText',
+      title: 'grabText',
       toString: () => 'I grab text',
       status: 'success',
       startTime: Date.now(),
@@ -165,7 +165,7 @@ describe('aiTrace plugin', () => {
     await recorder.promise()
 
     const step = {
-      name: 'see',
+      title: 'see',
       toString: () => 'I see test',
       status: 'success',
       startTime: Date.now(),
@@ -228,7 +228,7 @@ describe('aiTrace plugin', () => {
       await recorder.promise()
 
       const step = {
-        name: 'amOnPage',
+        title: 'amOnPage',
         toString: () => 'I am on page',
         status: 'success',
         startTime: Date.now(),
@@ -253,7 +253,7 @@ describe('aiTrace plugin', () => {
       await recorder.promise()
 
       const step = {
-        name: 'amOnPage',
+        title: 'amOnPage',
         toString: () => 'I am on page',
         status: 'success',
         startTime: Date.now(),
@@ -278,7 +278,7 @@ describe('aiTrace plugin', () => {
       await recorder.promise()
 
       const step = {
-        name: 'amOnPage',
+        title: 'amOnPage',
         toString: () => 'I am on page',
         status: 'success',
         startTime: Date.now(),
@@ -309,7 +309,7 @@ describe('aiTrace plugin', () => {
       await recorder.promise()
 
       const step1 = {
-        name: 'see',
+        title: 'see',
         toString: () => 'I see success',
         status: 'success',
         startTime: Date.now(),
@@ -317,7 +317,7 @@ describe('aiTrace plugin', () => {
       }
 
       const step2 = {
-        name: 'click',
+        title: 'click',
         toString: () => 'I click button',
         status: 'failed',
         startTime: Date.now() + 100,
@@ -325,7 +325,7 @@ describe('aiTrace plugin', () => {
       }
 
       const step3 = {
-        name: 'fillField',
+        title: 'fillField',
         toString: () => 'I fill field',
         status: 'queued',
         startTime: Date.now() + 200,
@@ -363,7 +363,7 @@ describe('aiTrace plugin', () => {
       await recorder.promise()
 
       const step = {
-        name: 'see',
+        title: 'see',
         toString: () => 'I see "Test Element"',
         status: 'success',
         startTime: Date.now(),
@@ -396,7 +396,7 @@ describe('aiTrace plugin', () => {
       await recorder.promise()
 
       const step = {
-        name: 'see',
+        title: 'see',
         toString: () => 'I see test',
         status: 'success',
         startTime: Date.now(),

--- a/test/unit/plugin/retryFailedStep_test.js
+++ b/test/unit/plugin/retryFailedStep_test.js
@@ -29,7 +29,7 @@ describe('retryFailedStep', () => {
   it.skip('should retry failed step', async () => {
     retryFailedStep({ retries: 2, minTimeout: 1 })
     event.dispatcher.emit(event.test.before, createTest('test'))
-    event.dispatcher.emit(event.step.started, { name: 'click' })
+    event.dispatcher.emit(event.step.started, { title: 'click' })
 
     let counter = 0
     await recorder.add(
@@ -53,7 +53,7 @@ describe('retryFailedStep', () => {
     event.dispatcher.emit(event.test.before, test)
 
     let counter = 0
-    event.dispatcher.emit(event.step.started, { name: 'click' })
+    event.dispatcher.emit(event.step.started, { title: 'click' })
     try {
       within('foo', () => {
         recorder.add(
@@ -81,7 +81,7 @@ describe('retryFailedStep', () => {
     event.dispatcher.emit(event.test.before, createTest('test'))
 
     let counter = 0
-    event.dispatcher.emit(event.step.started, { name: 'waitForElement' })
+    event.dispatcher.emit(event.step.started, { title: 'waitForElement' })
     try {
       await recorder.add(
         () => {
@@ -108,7 +108,7 @@ describe('retryFailedStep', () => {
     event.dispatcher.emit(event.test.before, createTest('test'))
 
     let counter = 0
-    event.dispatcher.emit(event.step.started, { name: 'amOnPage' })
+    event.dispatcher.emit(event.step.started, { title: 'amOnPage' })
     try {
       await recorder.add(
         () => {
@@ -135,7 +135,7 @@ describe('retryFailedStep', () => {
     event.dispatcher.emit(event.test.before, createTest('test'))
 
     let counter = 0
-    event.dispatcher.emit(event.step.started, { name: 'somethingNew' })
+    event.dispatcher.emit(event.step.started, { title: 'somethingNew' })
     try {
       await recorder.add(
         () => {
@@ -162,7 +162,7 @@ describe('retryFailedStep', () => {
     event.dispatcher.emit(event.test.before, createTest('test'))
 
     let counter = 0
-    event.dispatcher.emit(event.step.started, { name: 'somethingNew' })
+    event.dispatcher.emit(event.step.started, { title: 'somethingNew' })
     try {
       await recorder.add(
         () => {
@@ -188,7 +188,7 @@ describe('retryFailedStep', () => {
   it.skip('should not retry session', async () => {
     retryFailedStep({ retries: 1, minTimeout: 1 })
     event.dispatcher.emit(event.test.before, createTest('test'))
-    event.dispatcher.emit(event.step.started, { name: 'click' })
+    event.dispatcher.emit(event.step.started, { title: 'click' })
     let counter = 0
 
     try {
@@ -258,7 +258,7 @@ describe('retryFailedStep', () => {
     let counter = 0
 
     // without tryTo effect
-    event.dispatcher.emit(event.step.started, { name: 'click' })
+    event.dispatcher.emit(event.step.started, { title: 'click' })
     recorder.add('failed step', () => {
       counter++
       if (counter < 3) throw new Error('Ups')
@@ -270,7 +270,7 @@ describe('retryFailedStep', () => {
 
     // with tryTo effect
     let res = await tryTo(async () => {
-      event.dispatcher.emit(event.step.started, { name: 'click' })
+      event.dispatcher.emit(event.step.started, { title: 'click' })
       recorder.add('failed step', () => {
         counter++
         throw new Error('Ups')

--- a/test/unit/plugin/screencast_test.js
+++ b/test/unit/plugin/screencast_test.js
@@ -63,7 +63,7 @@ describe('screencast', () => {
     store.outputDir = outputDirOriginal
   })
 
-  const aStep = () => ({ name: 'click', actor: 'I', args: ['x'] })
+  const aStep = () => ({ title: 'click', actor: 'I', args: ['x'] })
 
   it('on=test keeps the file on pass and sets test.artifacts.screencast', async () => {
     const sc = makeFakeScreencast()
@@ -167,7 +167,7 @@ describe('screencast', () => {
     event.dispatcher.emit(event.test.started, test)
     await recorder.promise()
 
-    const step = { name: 'click', actor: 'I', args: ['Continue'] }
+    const step = { title: 'click', actor: 'I', args: ['Continue'] }
     event.dispatcher.emit(event.step.started, step)
     event.dispatcher.emit(event.step.finished, step)
     event.dispatcher.emit(event.test.after, test)
@@ -190,7 +190,7 @@ describe('screencast', () => {
 
     event.dispatcher.emit(event.test.before, test)
     event.dispatcher.emit(event.test.started, test)
-    const step = { name: 'see', actor: 'I', args: ['Github'] }
+    const step = { title: 'see', actor: 'I', args: ['Github'] }
     event.dispatcher.emit(event.step.started, step)
     event.dispatcher.emit(event.step.finished, step)
     event.dispatcher.emit(event.test.after, test)

--- a/test/unit/steps_test.js
+++ b/test/unit/steps_test.js
@@ -26,8 +26,8 @@ describe('Steps', () => {
       step = new Step({ doSomething: action }, 'doSomething')
     })
 
-    it('has name', () => {
-      expect(step.name).eql('doSomething')
+    it('has title', () => {
+      expect(step.title).eql('doSomething')
     })
 
     it('should convert method names for output', () => {


### PR DESCRIPTION
## Problem

`retryFailedStep` plugin crashes workers in `run-workers` mode:

```
TypeError: Cannot read properties of undefined (reading 'startsWith')
    at retryFailedStep.js:118:52
```

The plugin reads `step.name`, but in worker mode steps are serialized via `simplify()` which renames `name` → `title`. So the master process receives `{ title: "click" }` instead of `{ name: "click" }` — and `step.name` is `undefined`.

## Solution

Rename `Step.name` → `Step.title` everywhere. Now full Step objects and serialized ones use the same field — no more mismatch.

This is a **breaking change** for custom plugins that read `step.name` — they need to switch to `step.title`.

## Related

- #5562 — workaround approach (`step.name || step.title` fallback)
- testomatio/e2e-tests#139 — original report