### PR TITLE
fix(workers): deserialize step events before emitting to master process

### DIFF
--- a/lib/workers.js
+++ b/lib/workers.js
@@ -19,6 +19,7 @@ import output from './output.js'
 import event from './event.js'
 import { deserializeTest } from './mocha/test.js'
 import { deserializeSuite } from './mocha/suite.js'
+import Step from './step/base.js'
 import recorder from './recorder.js'
 import store from './store.js'
 import runHook from './hooks.js'
@@ -102,6 +103,8 @@ const simplifyObject = object => {
       return obj
     }, {})
 }
+
+const deserializeStep = data => Object.assign(new Step(data.title), data)
 
 const createWorkerObjects = (testGroups, config, testRoot, options, selectedRuns) => {
   selectedRuns = options && options.all && config.multiple ? Object.keys(config.multiple) : selectedRuns
@@ -706,20 +709,32 @@ class Workers extends EventEmitter {
           }
           break
         case event.step.finished:
-          this.emit(event.step.finished, message.data)
-          event.dispatcher.emit(event.step.finished, message.data)
+          {
+            const step = deserializeStep(message.data)
+            this.emit(event.step.finished, step)
+            event.dispatcher.emit(event.step.finished, step)
+          }
           break
         case event.step.started:
-          this.emit(event.step.started, message.data)
-          event.dispatcher.emit(event.step.started, message.data)
+          {
+            const step = deserializeStep(message.data)
+            this.emit(event.step.started, step)
+            event.dispatcher.emit(event.step.started, step)
+          }
           break
         case event.step.passed:
-          this.emit(event.step.passed, message.data)
-          event.dispatcher.emit(event.step.passed, message.data)
+          {
+            const step = deserializeStep(message.data)
+            this.emit(event.step.passed, step)
+            event.dispatcher.emit(event.step.passed, step)
+          }
           break
         case event.step.failed:
-          this.emit(event.step.failed, message.data, message.data.error)
-          event.dispatcher.emit(event.step.failed, message.data, message.data.error)
+          {
+            const step = deserializeStep(message.data)
+            this.emit(event.step.failed, step, step.error)
+            event.dispatcher.emit(event.step.failed, step, step.error)
+          }
           break
         case event.hook.failed:
           // Hook failures are already reported as test failures by the worker


### PR DESCRIPTION
## Problem

In `run-workers` mode, step events (`step.started`, `step.finished`, `step.passed`, `step.failed`) are emitted as raw plain objects from IPC serialization. These objects lack Step class methods (`toString()`, `toCliStyled()`), so any plugin or reporter calling `step.toString()` gets `"[object Object]"` instead of the actual step description.

This affects all consumers of step events in worker mode — for example, `@testomatio/reporter` shows:

```
################[ Logs ]################
--- Test ---
[object Object]
 [object Object]
```

Test events already go through `deserializeTest()` which restores a full object with methods. Step events had no equivalent deserialization — this PR adds it.

## Solution

Add `deserializeStep()` — a one-liner that wraps the serialized data in a `Step` instance via `Object.assign(new Step(data.title), data)`, matching the pattern already used inside `deserializeTest` for `test.steps` (see `lib/mocha/test.js:80`).

Apply it to all four step event types before emitting.

## Related

- testomatio/e2e-tests#151 — original report with reproduction steps