### PR TITLE
fix(analyze): use AI SDK ImagePart format for vision screenshots

### DIFF
--- a/lib/plugin/analyze.js
+++ b/lib/plugin/analyze.js
@@ -155,10 +155,9 @@ const defaultConfig = {
       if (config.vision && test.artifacts.screenshot) {
         debug('Adding screenshot to prompt')
         messages[0].content.push({
-          type: 'image_url',
-          image_url: {
-            url: 'data:image/png;base64,' + base64EncodeFile(test.artifacts.screenshot),
-          },
+          type: 'image',
+          image: base64EncodeFile(test.artifacts.screenshot),
+          mediaType: 'image/png',
         })
       }
 


### PR DESCRIPTION
## Summary

- Fix `analyze` plugin crash when `vision: true` — used OpenAI's `image_url` format instead of AI SDK's `ImagePart` format
- `generateText()` from Vercel AI SDK expects `{ type: 'image', image, mediaType }`, not `{ type: 'image_url', image_url: { url } }`
- Error was: `Invalid prompt: The messages do not match the ModelMessage[] schema`

## Changes

`lib/plugin/analyze.js` lines 157-162:

```diff
- type: 'image_url',
- image_url: {
-   url: 'data:image/png;base64,' + base64EncodeFile(test.artifacts.screenshot),
- },
+ type: 'image',
+ image: base64EncodeFile(test.artifacts.screenshot),
+ mediaType: 'image/png',
```