### PR TITLE
Fix retryFailedStep ignoredSteps exact-name matching

### DIFF
--- a/lib/plugin/retryFailedStep.js
+++ b/lib/plugin/retryFailedStep.js
@@ -116,7 +116,7 @@ export default function (config) {
       if (step.title === ignored) return
       if (ignored instanceof RegExp) {
         if (step.title.match(ignored)) return
-      } else if (ignored.indexOf('*') && step.title.startsWith(ignored.slice(0, -1))) return
+      } else if (ignored.indexOf('*') !== -1 && step.title.startsWith(ignored.slice(0, -1))) return
     }
     enableRetry = true
   })

--- a/lib/plugin/retryFailedStep.js
+++ b/lib/plugin/retryFailedStep.js
@@ -89,7 +89,7 @@ const RETRY_PRIORITIES = {
  *
  */
 export default function (config) {
-  config = Object.assign(defaultConfig, config)
+  config = Object.assign({}, defaultConfig, config)
   config.ignoredSteps = config.ignoredSteps.concat(config.defaultIgnoredSteps)
   const customWhen = config.when
 

--- a/test/unit/plugin/retryFailedStep_test.js
+++ b/test/unit/plugin/retryFailedStep_test.js
@@ -157,6 +157,36 @@ describe('retryFailedStep', () => {
     // expects to retry only once
   })
 
+  it('should not treat exact-name ignoredSteps entries as wildcard prefixes', async () => {
+    // Regression: ignored.indexOf('*') was used as truthy check.
+    // -1 is truthy, so entries without '*' were matched via startsWith(slice(0, -1)).
+    // ignoredSteps: ['see'] would silently ignore seeElement, seeInField, selectOption, etc.
+    retryFailedStep({ retries: 2, minTimeout: 1, ignoredSteps: ['see'] })
+    event.dispatcher.emit(event.test.before, createTest('test'))
+
+    let counter = 0
+    event.dispatcher.emit(event.step.started, { title: 'seeElement' })
+    try {
+      await recorder.add(
+        () => {
+          counter++
+          if (counter < 3) {
+            throw new Error()
+          }
+        },
+        undefined,
+        undefined,
+        true,
+      )
+      await recorder.promise()
+    } catch (e) {
+      await recorder.catchWithoutStop(err => err)
+    }
+
+    // seeElement is NOT in ignoredSteps (only 'see' is) — should be retried.
+    expect(counter).to.be.greaterThan(1)
+  })
+
   it('should add custom regexp steps to ignore', async () => {
     retryFailedStep({ retries: 2, minTimeout: 1, ignoredSteps: [/somethingNew/] })
     event.dispatcher.emit(event.test.before, createTest('test'))

--- a/test/unit/plugin/retryFailedStep_test.js
+++ b/test/unit/plugin/retryFailedStep_test.js
@@ -157,34 +157,21 @@ describe('retryFailedStep', () => {
     // expects to retry only once
   })
 
-  it('should not treat exact-name ignoredSteps entries as wildcard prefixes', async () => {
+  it('should not treat exact-name ignoredSteps entries as wildcard prefixes', () => {
     // Regression: ignored.indexOf('*') was used as truthy check.
     // -1 is truthy, so entries without '*' were matched via startsWith(slice(0, -1)).
     // ignoredSteps: ['see'] would silently ignore seeElement, seeInField, selectOption, etc.
     retryFailedStep({ retries: 2, minTimeout: 1, ignoredSteps: ['see'] })
-    event.dispatcher.emit(event.test.before, createTest('test'))
+    store.autoRetries = true
+    const retryConfig = recorder.retries[recorder.retries.length - 1]
 
-    let counter = 0
     event.dispatcher.emit(event.step.started, { title: 'seeElement' })
-    try {
-      await recorder.add(
-        () => {
-          counter++
-          if (counter < 3) {
-            throw new Error()
-          }
-        },
-        undefined,
-        undefined,
-        true,
-      )
-      await recorder.promise()
-    } catch (e) {
-      await recorder.catchWithoutStop(err => err)
-    }
+    expect(retryConfig.when(new Error()), "'seeElement' must not be ignored when only 'see' is configured").to.equal(true)
 
-    // seeElement is NOT in ignoredSteps (only 'see' is) — should be retried.
-    expect(counter).to.be.greaterThan(1)
+    event.dispatcher.emit(event.step.passed, {})
+
+    event.dispatcher.emit(event.step.started, { title: 'see' })
+    expect(retryConfig.when(new Error()), "exact match 'see' must still be ignored").to.not.equal(true)
   })
 
   it('should add custom regexp steps to ignore', async () => {


### PR DESCRIPTION
## Problem

In [`lib/plugin/retryFailedStep.js:119`](https://github.com/codeceptjs/CodeceptJS/blob/4.x/lib/plugin/retryFailedStep.js#L119) the wildcard check uses `ignored.indexOf('*')` as a boolean:

```js
} else if (ignored.indexOf('*') && step.title.startsWith(ignored.slice(0, -1))) return
```

`String.prototype.indexOf` returns `-1` when the character is not found. `-1` is **truthy** in JavaScript (only `0` is falsy), so the `startsWith(ignored.slice(0, -1))` branch executes for entries that do not contain `*` too. On top of that, `slice(0, -1)` chops the last character, broadening the match further.

Per the [docs](https://codecept.io/plugins/#retryfailedstep), `ignoredSteps` should support both exact step names and wildcard prefixes (`'wait*'`). The exact-name mode is silently broken.

## Reproduction

```js
// codecept.conf
plugins: {
  retryFailedStep: { enabled: true, retries: 3, ignoredSteps: ['see'] }
}

// Test
Scenario('seeElement is ignored even though only "see" is in ignoredSteps', ({ I }) => {
  I.amOnPage('/index.html');
  I.seeElement('[data-test-id="non-existent"]');
});
```

Expected: `seeElement` is retried (only `see` is in `ignoredSteps`).
Actual: `seeElement` is ignored — single attempt, no retries.

`ignoredSteps: ['see']` also silently ignores `seeElement`, `seeInField`, `seeInTitle`, `selectOption`, `sendPostRequest` — anything starting with `se`.

## Fix

Compare `indexOf('*')` against `-1` explicitly. One-character change in `lib/plugin/retryFailedStep.js:119`:

```diff
-} else if (ignored.indexOf('*') && step.title.startsWith(ignored.slice(0, -1))) return
+} else if (ignored.indexOf('*') !== -1 && step.title.startsWith(ignored.slice(0, -1))) return
```

## Repro project

[gololdf1sh/codeceptjs-retry-test](https://github.com/gololdf1sh/codeceptjs-retry-test).