### PR TITLE
Fix recorder: stop mutating shared defaultRetryOptions

### DIFF
--- a/lib/recorder.js
+++ b/lib/recorder.js
@@ -217,7 +217,7 @@ export default {
       }
 
       const retryRules = this.retries.slice().reverse()
-      return promiseRetry(Object.assign(defaultRetryOptions, retryOpts), (retry, number) => {
+      return promiseRetry(Object.assign({}, defaultRetryOptions, retryOpts), (retry, number) => {
         if (number > 1) output.log(`${currentQueue()}Retrying... Attempt #${number}`)
         const [promise, timer] = getTimeoutPromise(timeout, taskName)
         return Promise.race([promise, Promise.resolve(res).then(fn)])

--- a/test/unit/recorder_test.js
+++ b/test/unit/recorder_test.js
@@ -95,6 +95,54 @@ describe('Recorder', () => {
       return recorder.promise()
     })
 
+    it('should not leak custom minTimeout to subsequent recorder runs', async function () {
+      // Regression: Object.assign(defaultRetryOptions, retryOpts) mutated the
+      // module-level defaultRetryOptions object. A custom minTimeout in one run
+      // leaked into the defaults for every later run.
+      this.timeout(5000)
+
+      let attempts = []
+      recorder.retry({ retries: 1, minTimeout: 800, factor: 1, maxTimeout: 1000 })
+      recorder.add(
+        () => {
+          attempts.push(Date.now())
+          if (attempts.length < 2) throw new Error('first run')
+        },
+        undefined,
+        undefined,
+        true,
+      )
+      try {
+        await recorder.promise()
+      } catch (e) {
+        await recorder.catchWithoutStop(err => err)
+      }
+
+      expect(attempts[1] - attempts[0]).to.be.greaterThan(700, 'first retry should honor minTimeout=800')
+
+      // Fresh recorder, do not pass minTimeout — should fall back to default (150ms),
+      // not 800 leaked from the previous run.
+      recorder.start()
+      attempts = []
+      recorder.retry({ retries: 1, factor: 1, maxTimeout: 1000 })
+      recorder.add(
+        () => {
+          attempts.push(Date.now())
+          if (attempts.length < 2) throw new Error('second run')
+        },
+        undefined,
+        undefined,
+        true,
+      )
+      try {
+        await recorder.promise()
+      } catch (e) {
+        await recorder.catchWithoutStop(err => err)
+      }
+
+      expect(attempts[1] - attempts[0]).to.be.lessThan(500, 'second retry must use default minTimeout, not leaked 800ms')
+    })
+
     it('should prefer opts for non-when retry when possible', () => {
       let counter = 0
       const errorText = 'noerror'


### PR DESCRIPTION
## Problem

In [`lib/recorder.js:220`](https://github.com/codeceptjs/CodeceptJS/blob/4.x/lib/recorder.js#L220):

```js
return promiseRetry(Object.assign(defaultRetryOptions, retryOpts), (retry, number) => { ... })
```

`Object.assign(target, source)` mutates `target` and returns the same reference. By passing the module-level `defaultRetryOptions` as the target, every custom option (`minTimeout`, `factor`, `maxTimeout`, `retries`) gets merged into the shared defaults and persists for the lifetime of the process.

Subsequent `recorder.retry()` calls inherit those leaked values, even when they explicitly omit them.

## Reproduction

```js
// Scenario 1: explicit custom backoff
Scenario('s1', ({ I }) => {
  I.retry({ retries: 3, minTimeout: 1000, factor: 1.5 }).seeElement('[data-test-id="non-existent"]');
});

// Scenario 2: expects default minTimeout (~150ms)
Scenario('s2', ({ I }) => {
  I.retry(3).seeElement('[data-test-id="non-existent"]');
});
```

Instrumentation around the `Object.assign` call:

```
Scenario 1:
BEFORE: defaultRetryOptions={"retries":0,"minTimeout":150,"maxTimeout":10000}
AFTER:  defaultRetryOptions={"retries":3,"minTimeout":1000,"factor":1.5,...}  sameRef=true

Scenario 2:
BEFORE: defaultRetryOptions={"retries":2,"minTimeout":1000,...}  ← leaked from S1
```

Scenario 2 fails in ~5s instead of the expected ~700ms because it inherits `minTimeout=1000` from the previous scenario.

## Fix

Pass a fresh `{}` as the first arg so a new merged object is produced each call without touching the shared defaults:

```diff
-return promiseRetry(Object.assign(defaultRetryOptions, retryOpts), (retry, number) => {
+return promiseRetry(Object.assign({}, defaultRetryOptions, retryOpts), (retry, number) => {
```

## Repro project

[gololdf1sh/codeceptjs-retry-test](https://github.com/gololdf1sh/codeceptjs-retry-test). 
