### PR TITLE
fix(run-multiple): restore plugin loading and per-child reportDir (#5577)

### DIFF
--- a/lib/command/run-multiple.js
+++ b/lib/command/run-multiple.js
@@ -140,6 +140,7 @@ function executeRun(runName, runConfig) {
 
   // tweaking default output directories
   overriddenConfig = replaceValueDeep(overriddenConfig, 'output', path.join(config.output, outputDir))
+  overriddenConfig = replaceValueDeep(overriddenConfig, 'reportDir', path.join(config.output, outputDir))
   overriddenConfig = replaceValueDeep(overriddenConfig, 'mochaFile', path.join(config.output, outputDir, `${browserName}_report.xml`))
 
   // override tests configuration

--- a/lib/container.js
+++ b/lib/container.js
@@ -1,6 +1,7 @@
 import { globSync } from 'glob'
 import path from 'path'
 import fs from 'fs'
+import { isMainThread } from 'worker_threads'
 import debugModule from 'debug'
 const debug = debugModule('codeceptjs:container')
 import { MetaStep } from './step.js'
@@ -731,11 +732,11 @@ async function createPlugins(config, options = {}) {
     const runInWorker = pluginConfig.runInWorker ?? pluginConfig.runInWorkers ?? (pluginName === 'testomatio' ? false : true)
     const runInParent = pluginConfig.runInParent ?? pluginConfig.runInMain ?? true
 
-    if (options.child && !runInWorker) {
+    if (!isMainThread && !runInWorker) {
       continue
     }
 
-    if (!options.child && store.workerMode && !runInParent) {
+    if (isMainThread && store.workerMode && !runInParent) {
       continue
     }
     let module

--- a/test/data/sandbox/codecept.multiple.plugin.runInWorkerFalse.js
+++ b/test/data/sandbox/codecept.multiple.plugin.runInWorkerFalse.js
@@ -1,0 +1,28 @@
+export const config = {
+  tests: './*_test.multiple.js',
+  timeout: 10000,
+  output: './output',
+  helpers: {
+    FakeDriver: {
+      require: '../fake_driver',
+      browser: 'dummy',
+      windowSize: 'maximize',
+    },
+  },
+  multiple: {
+    default: {
+      browsers: ['chrome', 'firefox'],
+    },
+  },
+  plugins: {
+    runInWorkerFalsePlugin: {
+      enabled: true,
+      runInWorker: false,
+      require: './plugin-runInWorkerFalse.js',
+      reportDir: 'output/report',
+    },
+  },
+  bootstrap: false,
+  mocha: {},
+  name: 'sandbox',
+}

--- a/test/data/sandbox/plugin-runInWorkerFalse.js
+++ b/test/data/sandbox/plugin-runInWorkerFalse.js
@@ -1,0 +1,6 @@
+export default function (config) {
+  process.stdout.write('plugin-runInWorkerFalse:loaded\n')
+  if (config.reportDir) {
+    process.stdout.write(`plugin-runInWorkerFalse:reportDir=${config.reportDir}\n`)
+  }
+}

--- a/test/runner/run_multiple_test.js
+++ b/test/runner/run_multiple_test.js
@@ -199,6 +199,23 @@ describe('CodeceptJS Multiple Runner', function () {
     })
   })
 
+  it('should load plugins with runInWorker:false in each child process and give each its own reportDir', done => {
+    exec(`${runner} run-multiple --config ${codecept_dir}/codecept.multiple.plugin.runInWorkerFalse.js default`, (err, stdout) => {
+      // Plugin must be initialised once per forked child (chrome + firefox = 2 times).
+      // Regression: in 4.x the plugin was silently skipped because options.child was
+      // truthy in run-multiple children, same as in worker threads.
+      ;(stdout.match(/plugin-runInWorkerFalse:loaded/g) || []).should.have.lengthOf(2)
+      // reportDir must be replaced per child so each child writes its own report.
+      // Regression: run-multiple.js dropped the replaceValueDeep('reportDir', ...) call
+      // that was present in 3.x, causing all children to overwrite the same file.
+      const dirs = (stdout.match(/plugin-runInWorkerFalse:reportDir=(.+)/g) || []).map(m => m.split('=')[1])
+      dirs.should.have.lengthOf(2)
+      dirs[0].should.not.equal(dirs[1])
+      assert(!err)
+      done()
+    })
+  })
+
   describe('bootstrapAll and teardownAll', () => {
     const _codecept_run = `run-multiple --config ${codecept_dir}`
     it('should be executed from async function in config', done => {


### PR DESCRIPTION
Fixes #5577

Two regressions introduced during the 3.x → 4.x ESM migration caused the testomatio HTML reporter (and any plugin with `runInWorker: false`) to produce no output when using `run-multiple`.

---

## Bug 1 – plugins with `runInWorker:false` silently skipped in child processes

**File:** `lib/container.js`

`options.child` was used to detect "running inside a worker thread" and skipped plugins whose `runInWorker` is `false` (`testomatio` defaults to `false`). But `run-multiple` also sets `--child` on every forked child process, so those plugins were silently skipped there too — no error, no report.

**Fix:** replace `options.child` with `!isMainThread` (from Node's `worker_threads`). A `run-multiple` child is a freshly-forked OS process whose `isMainThread` is `true`, so the gate no longer fires. An actual `run-workers` worker thread has `isMainThread === false`, so the gate still fires as intended.

| Context | `options.child` | `isMainThread` | Before (skipped?) | After |
|---|---|---|---|---|
| `run-workers` worker thread | truthy (index) | `false` | skipped ✓ | skipped ✓ |
| `run-multiple` child process | truthy (string) | `true` | **skipped ✗ (bug)** | loads ✓ |
| normal `run` / parent process | falsy | `true` | loads ✓ | loads ✓ |

---

## Bug 2 – all children write to the same `reportDir`, last one wins

**File:** `lib/command/run-multiple.js`

3.x `run-multiple.js` replaced three per-child directory keys before forking each child:

```js
overriddenConfig = replaceValueDeep(overriddenConfig, 'output',    path.join(config.output, outputDir))
overriddenConfig = replaceValueDeep(overriddenConfig, 'reportDir', path.join(config.output, outputDir))  // ← dropped in 4.x
overriddenConfig = replaceValueDeep(overriddenConfig, 'mochaFile', path.join(config.output, outputDir, `${browserName}_report.xml`))
```

The 4.x port dropped the `reportDir` line, so every child kept the same shared `reportDir` value from the config (e.g. `output/report`) and each child's run overwrote the previous one's HTML file.

**Fix:** restore the missing `replaceValueDeep('reportDir', ...)` call so each child receives its own directory — matching 3.x behaviour.

---

## Result

Before:
```
output/report/testomatio-report.html   ← only webkit's data (chromium overwritten)
```

After:
```
output/dev_chromium_1/testomatio-report.html
output/dev_webkit_2/testomatio-report.html
```

---

## Tests

A regression test is added to `test/runner/run_multiple_test.js` backed by a minimal fixture plugin and config. It verifies both bugs together:
1. A plugin with `runInWorker: false` is initialised **once per child** (not zero times).
2. Each child receives a **distinct `reportDir`** (not the same shared path).

The test fails against the unfixed code and passes with the fix applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)