### PR TITLE
docs: fix typo in detox.md

### DIFF
--- a/docs/detox.md
+++ b/docs/detox.md
@@ -60,7 +60,7 @@ As you see, CodeceptJS test is shorter and easier to follow. By simplifying the 
 
 ## Setup
 
-It is important to follow [Detox guide](https://github.com/wix/Detox/blob/master/docs/Introduction.GettingStarted.md) to build an application with Detox test instrouments included.
+It is important to follow [Detox guide](https://github.com/wix/Detox/blob/master/docs/Introduction.GettingStarted.md) to build an application with Detox test instruments included.
 
 After you install Detox, create configuration and build an application using `detox build` command, you are ready to integrate Detox with CodeceptJS.
 


### PR DESCRIPTION
## Motivation/Description of the PR
fixes a simpe typo error in Detox documentation 

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] 🧹 Chore
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [x] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

