### PR TITLE
fix(gherkin): emit test.before/after with real current test

### DIFF
--- a/lib/mocha/asyncWrapper.js
+++ b/lib/mocha/asyncWrapper.js
@@ -199,7 +199,7 @@ export function setup(suite) {
     recorder.startUnlessRunning()
     import('./test.js').then(testModule => {
       const { enhanceMochaTest } = testModule.default || testModule
-      event.emit(event.test.before, enhanceMochaTest(suite?.ctx?.currentTest))
+      event.emit(event.test.before, enhanceMochaTest(suite?.currentTest ?? suite?.ctx?.currentTest))
       recorder.add(() => doneFn())
     })
   }
@@ -211,7 +211,7 @@ export function teardown(suite) {
     recorder.startUnlessRunning()
     import('./test.js').then(testModule => {
       const { enhanceMochaTest } = testModule.default || testModule
-      event.emit(event.test.after, enhanceMochaTest(suite?.ctx?.currentTest))
+      event.emit(event.test.after, enhanceMochaTest(suite?.currentTest ?? suite?.ctx?.currentTest))
       recorder.add(() => doneFn())
     })
   }

--- a/lib/mocha/gherkin.js
+++ b/lib/mocha/gherkin.js
@@ -42,13 +42,12 @@ const gherkinParser = (text, file) => {
   suite.file = file
   suite.timeout(0)
 
-  suite.beforeEach('codeceptjs.before', function () {
-    // In Mocha, 'this' refers to the current test in beforeEach/afterEach hooks
-    setup(this)(() => {})
+  suite.beforeEach('codeceptjs.before', function (done) {
+    // In Mocha, 'this' is the hook Context; currentTest is the running scenario
+    setup(this)(done)
   })
-  suite.afterEach('codeceptjs.after', function () {
-    // In Mocha, 'this' refers to the current test in beforeEach/afterEach hooks
-    teardown(this)(() => {})
+  suite.afterEach('codeceptjs.after', function (done) {
+    teardown(this)(done)
   })
   suite.beforeAll('codeceptjs.beforeSuite', suiteSetup(suite))
   suite.afterAll('codeceptjs.afterSuite', suiteTeardown(suite))


### PR DESCRIPTION
Gherkin beforeEach/afterEach pass Mocha hook Context into setup/teardown, but asyncWrapper read suite.ctx.currentTest (undefined on Context), so event.test.before received a placeholder test (title "...", empty tags).

Also forward Mocha's done callback instead of no-op () => {}, so event.test.before completes before scenario Background Before hooks run.

## Motivation/Description of the PR
- Description of this PR, which problem it solves
- Resolves #issueId (if applicable).

Applicable helpers:

- [ ] Playwright
- [ ] Puppeteer
- [ ] WebDriver
- [ ] REST
- [ ] FileHelper
- [ ] Appium

Applicable plugins:

- [ ] aiTrace
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pause
- [ ] coverage
- [ ] heal
- [ ] retryFailedStep
- [ ] screenshot
- [ ] selenoid
- [ ] stepTimeout
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] 🧹 Chore
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
