### PR TITLE
Fix: (index.d.ts) remove globals, add missing exports

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -524,24 +524,11 @@ type RetryTo = (fn: (tries: number) => Promise<void> | void, maxTries: number, p
 // Globals
 declare const codecept_dir: string
 declare const output_dir: string
-declare const tryTo: TryTo
-declare const retryTo: RetryTo
-declare const hopeThat: HopeThat
 
-declare const actor: CodeceptJS.actor
-declare const codecept_actor: CodeceptJS.actor
-declare const Helper: typeof CodeceptJS.Helper
-declare const codecept_helper: typeof CodeceptJS.Helper
 declare const pause: typeof CodeceptJS.pause
-declare const within: typeof CodeceptJS.within
-declare const session: typeof CodeceptJS.session
-declare const DataTable: typeof CodeceptJS.DataTable
-declare const DataTableArgument: typeof CodeceptJS.DataTableArgument
 declare const codeceptjs: typeof CodeceptJS
-declare const locate: typeof CodeceptJS.Locator.build
 declare function inject(): CodeceptJS.SupportObject
 declare function inject<T extends keyof CodeceptJS.SupportObject>(name: T): CodeceptJS.SupportObject[T]
-declare const secret: typeof CodeceptJS.Secret.secret
 
 // BDD
 declare const Given: typeof CodeceptJS.addStep
@@ -579,21 +566,8 @@ declare namespace NodeJS {
     codecept_dir: typeof codecept_dir
     output_dir: typeof output_dir
 
-    actor: typeof actor
-    codecept_actor: typeof codecept_actor
-    Helper: typeof Helper
-    codecept_helper: typeof codecept_helper
     pause: typeof pause
-    within: typeof within
-    session: typeof session
-    DataTable: typeof DataTable
-    DataTableArgument: typeof DataTableArgument
-    locate: typeof locate
     inject: typeof inject
-    secret: typeof secret
-    // plugins
-    tryTo: typeof tryTo
-    retryTo: typeof retryTo
 
     // BDD
     Given: typeof Given
@@ -729,6 +703,12 @@ declare module 'codeceptjs' {
    * Create a secret value
    */
   export const secret: typeof CodeceptJS.Secret.secret
+
+  export const session: typeof CodeceptJS.session
+
+  export const inject: typeof globalThis.inject
+
+  export const locate: typeof CodeceptJS.Locator.build
 }
 
 declare module '@codeceptjs/helper' {

--- a/typings/tests/global-variables.types.ts
+++ b/typings/tests/global-variables.types.ts
@@ -107,17 +107,3 @@ expectType<CodeceptJS.HookConfig>(
     expectType<CodeceptJS.I>(args.I)
   }),
 )
-
-// @ts-ignore
-expectType<Promise<boolean>>(
-  tryTo(() => {
-    return true
-  }),
-)
-
-// @ts-ignore
-expectType<Promise<boolean>>(
-  tryTo(async () => {
-    return false
-  }),
-)


### PR DESCRIPTION
## Motivation/Description of the PR

Fixes for `typings/index.d.ts`:
- remove global declarations removed in v4
- add missing named exports added in v4 (session, inject, locate).

Applicable helpers:

- [ ] Playwright
- [ ] Puppeteer
- [ ] WebDriver
- [ ] REST
- [ ] FileHelper
- [ ] Appium

Applicable plugins:

- [ ] aiTrace
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pause
- [ ] coverage
- [ ] heal
- [ ] retryFailedStep
- [ ] screenshot
- [ ] selenoid
- [ ] stepTimeout
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [x] 🧹 Chore
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [x] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
