### PR TITLE
fix: Change event listener from 'passed' to 'finished'

### DIFF
--- a/lib/plugin/retryFailedStep.js
+++ b/lib/plugin/retryFailedStep.js
@@ -121,7 +121,7 @@ export default function (config) {
     enableRetry = true
   })
 
-  event.dispatcher.on(event.step.passed, () => {
+  event.dispatcher.on(event.step.finished, () => {
     enableRetry = false
   })
 

--- a/test/unit/plugin/retryFailedStep_test.js
+++ b/test/unit/plugin/retryFailedStep_test.js
@@ -197,7 +197,7 @@ describe('retryFailedStep', () => {
     event.dispatcher.emit(event.step.started, { title: 'seeElement' })
     expect(retryConfig.when(new Error()), "'seeElement' must not be ignored when only 'see' is configured").to.equal(true)
 
-    event.dispatcher.emit(event.step.passed, {})
+    event.dispatcher.emit(event.step.finished, {})
 
     event.dispatcher.emit(event.step.started, { title: 'see' })
     expect(retryConfig.when(new Error()), "exact match 'see' must still be ignored").to.not.equal(true)


### PR DESCRIPTION
## Motivation/Description of the PR
- Description of this PR, which problem it solves
- Resolves #issueId (if applicable).

Applicable helpers:

- [ ] Playwright
- [ ] Puppeteer
- [ ] WebDriver
- [ ] REST
- [ ] FileHelper
- [ ] Appium

Applicable plugins:

- [ ] aiTrace
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pause
- [ ] coverage
- [ ] heal
- [ ] retryFailedStep
- [ ] screenshot
- [ ] selenoid
- [ ] stepTimeout
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] 🧹 Chore
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
