### PR TITLE
fix(init): missing file ext of step file when using typescript

### DIFF
--- a/lib/command/init.js
+++ b/lib/command/init.js
@@ -317,6 +317,8 @@ export default async function (initPath, options = {}) {
       return
     }
 
+    if (process.env.CODECEPT_TEST) return
+
     const generatedTest = generateTest(testsPath)
     if (!generatedTest) return
     generatedTest.then(() => {

--- a/lib/command/init.js
+++ b/lib/command/init.js
@@ -206,7 +206,7 @@ export default async function (initPath, options = {}) {
     const stepFile = `./steps_file.${extension}`
     fs.writeFileSync(path.join(testsPath, stepFile), extension === 'ts' ? defaultActorTs : defaultActor)
 
-    config.include = { I: isTypeScript ? './steps_file' : stepFile }
+    config.include = { I: isTypeScript ? './steps_file.ts' : stepFile }
 
     print(`Steps file created at ${stepFile}`)
 

--- a/test/runner/init_test.js
+++ b/test/runner/init_test.js
@@ -68,6 +68,14 @@ describe('Init Command', function () {
 
     fs.existsSync(path.join(codecept_dir, 'codecept.conf.js')).should.be.true
     fs.existsSync(path.join(codecept_dir, 'steps_file.js')).should.be.true
+
+    fs.readFile(path.join(codecept_dir, 'codecept.conf.js'), 'utf8', (err, data) => {
+      if (err) {
+        throw Error(err);
+        return;
+      }
+      data.should.contain('./steps_file.js');
+    });
   })
 
   it('should initialize a TS project', async () => {
@@ -87,5 +95,13 @@ describe('Init Command', function () {
 
     fs.existsSync(path.join(codecept_dir, 'codecept.conf.ts')).should.be.true
     fs.existsSync(path.join(codecept_dir, 'steps_file.ts')).should.be.true
+
+    fs.readFile(path.join(codecept_dir, 'codecept.conf.ts'), 'utf8', (err, data) => {
+      if (err) {
+        throw Error(err);
+        return;
+      }
+      data.should.contain('./steps_file.ts');
+    });
   })
 })

--- a/test/runner/init_test.js
+++ b/test/runner/init_test.js
@@ -4,6 +4,9 @@ import path from 'path'
 import fs from 'fs'
 import { mkdirp } from 'mkdirp'
 import { fileURLToPath } from 'url'
+import sinon from 'sinon'
+import inquirer from 'inquirer'
+import * as initModule from '../../lib/command/init.js'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
@@ -13,29 +16,24 @@ const codecept_dir = path.join(__dirname, '/../data/sandbox/configs/init')
 describe('Init Command', function () {
   this.timeout(20000)
 
+  let promptStub;
+
   beforeEach(() => {
     mkdirp.sync(codecept_dir)
     process.env._INIT_DRY_RUN_INSTALL = true
+    process.env.CODECEPT_TEST = 'true'
+    promptStub = sinon.stub(inquirer, 'prompt')
   })
 
   afterEach(() => {
     try {
-      fs.unlinkSync(`${codecept_dir}/codecept.conf.ts`)
-      fs.unlinkSync(`${codecept_dir}/steps_file.ts`)
-      fs.unlinkSync(`${codecept_dir}/tsconfig.json`)
+      fs.rmSync(codecept_dir, { recursive: true, force: true })
     } catch (e) {
       // continue regardless of error
     }
-
-    try {
-      fs.unlinkSync(`${codecept_dir}/codecept.conf.js`)
-      fs.unlinkSync(`${codecept_dir}/steps_file.js`)
-      fs.unlinkSync(`${codecept_dir}/jsconfig.json`)
-    } catch (e) {
-      // continue regardless of error
-    }
-
+    sinon.restore()
     delete process.env._INIT_DRY_RUN_INSTALL
+    delete process.env.CODECEPT_TEST
   })
 
   it('should have init command available and noTranslation defined', async () => {
@@ -62,5 +60,32 @@ describe('Init Command', function () {
       }
       throw error
     }
+  })
+
+  it('should initialize a JS project', async () => {
+    // When yes: true, it skips prompts
+    await initModule.default(codecept_dir, { yes: true })
+
+    fs.existsSync(path.join(codecept_dir, 'codecept.conf.js')).should.be.true
+    fs.existsSync(path.join(codecept_dir, 'steps_file.js')).should.be.true
+  })
+
+  it('should initialize a TS project', async () => {
+    promptStub.onCall(0).resolves({
+        typescript: true,
+        tests: './tests/*_test.ts',
+        helper: 'Playwright',
+        output: './output',
+    })
+    promptStub.onCall(1).resolves({
+        Playwright_browser: 'chromium',
+        Playwright_url: 'http://localhost',
+        Playwright_show: false,
+    })
+
+    await initModule.default(codecept_dir, { yes: false })
+
+    fs.existsSync(path.join(codecept_dir, 'codecept.conf.ts')).should.be.true
+    fs.existsSync(path.join(codecept_dir, 'steps_file.ts')).should.be.true
   })
 })


### PR DESCRIPTION
## Motivation/Description of the PR
- Resolves #5614 

Applicable helpers:

- [ ] Playwright
- [ ] Puppeteer
- [ ] WebDriver
- [ ] REST
- [ ] FileHelper
- [ ] Appium

Applicable plugins:

- [ ] aiTrace
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pause
- [ ] coverage
- [ ] heal
- [ ] retryFailedStep
- [ ] screenshot
- [ ] selenoid
- [ ] stepTimeout
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] 🧹 Chore
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [x] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)
