### PR TITLE
fix(deps): don't auto-install detox & react-native (#5620)

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,11 +137,9 @@
     "xpath": "0.0.34",
     "zod": "^4.1.11"
   },
-  "optionalDependencies": {
-    "@codeceptjs/detox-helper": "1.1.14"
-  },
   "devDependencies": {
     "@apollo/server": "^5",
+    "@codeceptjs/detox-helper": "1.1.14",
     "@codeceptjs/expect-helper": "^4.0.0-beta.5",
     "@codeceptjs/mock-request": "0.3.1",
     "@eslint/eslintrc": "3.3.3",


### PR DESCRIPTION
Fixes #5620

## Problem

Installing `codeceptjs` (e.g. `pnpm i -D codeceptjs`) downloads **detox** and **react-native** — heavy packages most users never need. This also triggers the `dtrace-provider` build script that pnpm flags for `pnpm approve-builds`.

## Cause

`@codeceptjs/detox-helper` was declared under `optionalDependencies`:

```json
"optionalDependencies": {
  "@codeceptjs/detox-helper": "1.1.14"
}
```

`optionalDependencies` are **installed by default** by npm and pnpm — "optional" only means a download/build failure won't abort the install. And `@codeceptjs/detox-helper` hard-depends on `detox` and `react-native`, so they were pulled into every install.

The Detox helper is a user-configured **external** helper (`helpers: { Detox: { require: '@codeceptjs/detox-helper' } }`); CodeceptJS core never requires it.

## Fix

Move `@codeceptjs/detox-helper` to `devDependencies` — it is still needed in this repo for the external-helper docs generation (`Bunoshfile.js` → `docsExternalHelpers`). It is no longer shipped to consumers, so `detox` / `react-native` / `dtrace-provider` are no longer auto-installed.

Users who use the Detox helper install it themselves (`npm i @codeceptjs/detox-helper`), as already documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)