### PR TITLE
ci(acceptance): add hang-proof Playwright smoke gate

### DIFF
--- a/.github/workflows/acceptance-smoke.yml
+++ b/.github/workflows/acceptance-smoke.yml
@@ -1,0 +1,52 @@
+name: Acceptance smoke
+
+on:
+  push:
+    branches:
+      - 4.x
+  pull_request:
+    branches:
+      - '**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  acceptance-smoke:
+    name: Acceptance smoke (Playwright)
+    runs-on: ubuntu-22.04
+    timeout-minutes: 20
+
+    strategy:
+      matrix:
+        node-version: [20.x]
+
+    steps:
+      - uses: actions/checkout@v6
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm i
+        env:
+          PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+      - name: Start test app server
+        run: nohup npm run test-app:start &
+      - name: Wait for test app server
+        run: |
+          for i in {1..20}; do
+            curl -sf http://127.0.0.1:8000/ && break
+            sleep 1
+          done
+      - name: Run acceptance smoke suite (hang-proof)
+        run: timeout 600 ./bin/codecept.js run --config test/acceptance/codecept.Playwright.smoke.js
+      - name: Upload acceptance output on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: acceptance-smoke-output
+          path: test/acceptance/output/
+          if-no-files-found: ignore

--- a/test/acceptance/codecept.Playwright.smoke.js
+++ b/test/acceptance/codecept.Playwright.smoke.js
@@ -1,0 +1,11 @@
+import { config as base } from './codecept.Playwright.js'
+
+// Allowlist of acceptance tests known to pass reliably on the 4.x promise core.
+// As promise-core fixes land and a file in plans/002-failing-acceptance.md
+// starts passing, move it into this glob. The long-term goal is to delete this
+// config and gate on the full codecept.Playwright.js.
+export const config = {
+  ...base,
+  tests: './{els,session,within}_test.js',
+  name: 'acceptance-smoke',
+}


### PR DESCRIPTION
## What

Re-establishes an **acceptance-level CI gate** for 4.x. Today CI runs only unit/rest/runner suites; the only acceptance workflow is `acceptance-tests.yml.disabled`, which still targets the `3.x` branch and a docker-compose WebDriverIO setup. The exact failure class blocking 4.0 (promise-composition hangs / broken error propagation) has **zero CI signal**.

This adds a hang-proof Playwright smoke job that runs the currently-passing subset on every PR, so the passing set can only grow.

## Files

- **`test/acceptance/codecept.Playwright.smoke.js`** — an explicit allowlist config (`tests: './{els,session,within}_test.js'`) of acceptance tests that pass reliably on the 4.x promise core.
- **`.github/workflows/acceptance-smoke.yml`** — `push` to `4.x` + `pull_request` to `**`; `timeout-minutes: 20` **and** an outer `timeout 600` (defense-in-depth; `exit 124` = hang); installs Chromium, boots the PHP test app, GET-polls health, runs the smoke suite, and uploads `test/acceptance/output/` on failure.

## Discovery (local, Node 22 / Playwright 1.59 / PHP 8.5)

Each acceptance file run individually under a hard timeout:

| File | Result |
|------|--------|
| `els_test.js` | PASS (30) |
| `session_test.js` | PASS (9 + 2 skipped) |
| `within_test.js` | PASS (12) |
| `config_test.js` | FAIL (7/1) — one scenario hits a JSON API that returns HTML locally; environment-flaky, not a promise-core failure → excluded |
| `coverage_test.js` | no `@Playwright` scenarios → excluded |
| `retryTo_test.js` | no `@Playwright` scenarios → excluded |

The smoke suite is **52 passed / 2 skipped / 0 failed** across **three consecutive** local runs (~58s each; includes the `@Playwright` gherkin `before_hook.feature` via the base config).

## Maintenance

The smoke glob is an allowlist: when a promise-core fix makes an excluded file pass, move it into the glob in the same PR. The long-term goal is to delete this config and gate on the full `codecept.Playwright.js`.

## Notes for reviewers

- No acceptance `*_test.js` file was edited, skipped, or tagged to make the gate green.
- The disabled 3.x acceptance workflow is left untouched.
- Defense in depth against runaway minutes: both `timeout-minutes: 20` and the inner `timeout 600`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)