### PR TITLE
fix(pause): remove leaked dispatcher listeners and guard session restore

### DIFF
--- a/lib/pause.js
+++ b/lib/pause.js
@@ -19,6 +19,35 @@ let finish
 let next
 let registeredVariables = {}
 let externalHandler = null
+let pauseSessionOpen = false
+
+function onStepAfter() {
+  recorder.add('Start next pause session', () => {
+    // test already finished, nothing to pause
+    if (!store.currentTest) return
+    if (!next) return
+    return pauseSession()
+  })
+}
+
+function onTestFinished() {
+  if (typeof finish === 'function') finish()
+  if (pauseSessionOpen) {
+    recorder.session.restore('pause')
+    pauseSessionOpen = false
+  }
+  if (rl) rl.close()
+  if (!externalHandler) history.save()
+  event.dispatcher.removeListener(event.step.after, onStepAfter)
+  event.dispatcher.removeListener(event.test.finished, onTestFinished)
+}
+
+function registerPauseListeners() {
+  event.dispatcher.removeListener(event.step.after, onStepAfter)
+  event.dispatcher.removeListener(event.test.finished, onTestFinished)
+  event.dispatcher.on(event.step.after, onStepAfter)
+  event.dispatcher.on(event.test.finished, onTestFinished)
+}
 
 /**
  * Pauses test execution and starts interactive shell
@@ -28,22 +57,7 @@ const pause = function (passedObject = {}) {
   if (store.dryRun) return
 
   next = false
-  // add listener to all next steps to provide next() functionality
-  event.dispatcher.on(event.step.after, () => {
-    recorder.add('Start next pause session', () => {
-      // test already finished, nothing to pause
-      if (!store.currentTest) return
-      if (!next) return
-      return pauseSession()
-    })
-  })
-
-  event.dispatcher.on(event.test.finished, () => {
-    if (typeof finish === 'function') finish()
-    recorder.session.restore('pause')
-    if (rl) rl.close()
-    if (!externalHandler) history.save()
-  })
+  registerPauseListeners()
 
   recorder.add('Start new session', () => pauseSession(passedObject))
 }
@@ -51,12 +65,14 @@ const pause = function (passedObject = {}) {
 function pauseSession(passedObject = {}) {
   registeredVariables = passedObject
   recorder.session.start('pause')
+  pauseSessionOpen = true
 
   if (externalHandler) {
     store.onPause = true
     return externalHandler({ registeredVariables }).then(() => {
       store.onPause = false
       recorder.session.restore('pause')
+      pauseSessionOpen = false
     })
   }
 
@@ -107,6 +123,7 @@ async function parseInput(cmd) {
   if (!cmd || cmd === 'resume' || cmd === 'exit') {
     if (typeof finish === 'function') finish()
     recorder.session.restore('pause')
+    pauseSessionOpen = false
     rl.close()
     history.save()
     return nextStep()
@@ -265,6 +282,7 @@ function setPauseHandler(handler) {
  */
 function pauseNow(passedObject = {}) {
   if (store.dryRun) return
+  registerPauseListeners()
   recorder.add('Triggered pause', () => pauseSession(passedObject))
 }
 

--- a/test/unit/pause_test.js
+++ b/test/unit/pause_test.js
@@ -1,5 +1,18 @@
 import { expect } from 'chai'
-import { setPauseHandler } from '../../lib/pause.js'
+import sinon from 'sinon'
+import pause, { setPauseHandler, pauseNow } from '../../lib/pause.js'
+import recorder from '../../lib/recorder.js'
+import event from '../../lib/event.js'
+import store from '../../lib/store.js'
+
+const settles = (promise, ms = 2000) =>
+  Promise.race([
+    promise,
+    new Promise((_, reject) => {
+      const t = setTimeout(() => reject(new Error(`did not settle within ${ms}ms`)), ms)
+      t.unref?.()
+    }),
+  ])
 
 describe('pause external handler hook', () => {
   afterEach(() => {
@@ -24,5 +37,66 @@ describe('pause external handler hook', () => {
     expect(p).to.be.a('promise')
     await p
     expect(received).to.deep.equal({ registeredVariables: { foo: 1 } })
+  })
+})
+
+describe('pause listener lifecycle', () => {
+  beforeEach(() => {
+    store.dryRun = false
+    setPauseHandler(null)
+    recorder.reset()
+    recorder.stop()
+  })
+
+  afterEach(() => {
+    setPauseHandler(null)
+    event.dispatcher.emit(event.test.finished)
+    recorder.reset()
+  })
+
+  it('keeps exactly one listener no matter how many pause() calls', () => {
+    const baseStep = event.dispatcher.listenerCount(event.step.after)
+    const baseFin = event.dispatcher.listenerCount(event.test.finished)
+    pause()
+    pause()
+    pause()
+    expect(event.dispatcher.listenerCount(event.step.after)).to.equal(baseStep + 1)
+    expect(event.dispatcher.listenerCount(event.test.finished)).to.equal(baseFin + 1)
+  })
+
+  it('removes both pause listeners when the test finishes', () => {
+    const baseStep = event.dispatcher.listenerCount(event.step.after)
+    const baseFin = event.dispatcher.listenerCount(event.test.finished)
+    pause()
+    expect(event.dispatcher.listenerCount(event.step.after)).to.equal(baseStep + 1)
+    event.dispatcher.emit(event.test.finished)
+    expect(event.dispatcher.listenerCount(event.step.after)).to.equal(baseStep)
+    expect(event.dispatcher.listenerCount(event.test.finished)).to.equal(baseFin)
+  })
+
+  it('does not restore the pause session when none is open on test.finished', async () => {
+    pause()
+    recorder.start()
+    const restoreSpy = sinon.spy(recorder.session, 'restore')
+    event.dispatcher.emit(event.test.finished)
+    event.dispatcher.emit(event.test.finished)
+    const pauseRestores = restoreSpy.getCalls().filter(c => c.args[0] === 'pause').length
+    restoreSpy.restore()
+    expect(pauseRestores, 'no pause restore when nothing is open').to.equal(0)
+    expect(recorder.getCurrentSessionId()).to.equal(null)
+    await settles(recorder.promise())
+  })
+
+  it('pauseNow drives the external handler and restores the session', async () => {
+    let received = null
+    setPauseHandler(arg => {
+      received = arg
+      return Promise.resolve()
+    })
+    recorder.start()
+    pauseNow({ foo: 1 })
+    await settles(recorder.promise())
+    expect(received).to.deep.equal({ registeredVariables: { foo: 1 } })
+    expect(recorder.getCurrentSessionId()).to.equal(null)
   })
 })


### PR DESCRIPTION
## What

Every `pause()` call registered **two permanent listeners** on the global event dispatcher (`event.step.after`, `event.test.finished`) and never removed them. Each extra `pause()`:

- scheduled extra recorder tasks on every subsequent step,
- fired `finish()` multiple times per test finish, and
- ran an **unconditional** `recorder.session.restore('pause')` on every test finish — **even when no pause session was open** — popping `oldPromises`/`sessionStack` blindly and unbalancing the recorder's session stack (the corrupted-session-stack hang class blocking 4.0).

Tolerable in 3.x when `pause()` was a rare manual debugging call; in 4.x the **MCP server drives pause programmatically** (`setPauseHandler`/`pauseNow`), so repeated pauses per process are now normal, and ≥10 calls also trip `MaxListenersExceededWarning`.

## Change

- Convert the two anonymous listeners into named handlers (`onStepAfter`, `onTestFinished`) and register them through an **idempotent** helper that removes any prior registration first — repeated `pause()`/`pauseNow()` keep exactly one of each. `onTestFinished` removes both listeners when the test finishes.
- Track an open-pause flag; only `recorder.session.restore('pause')` when one is actually open (set on `session.start` in `pauseSession`, cleared at all three restore sites: test-finished, external-handler resolve, REPL resume/exit).
- `pauseNow` performs the same idempotent registration as `pause()` (previously it registered none, leaking an open session at test end on the MCP path).

`setPauseHandler`/`pauseNow` signatures and resolve semantics are unchanged — `bin/mcp-server.js` is untouched. The interactive REPL `eval`/history paths are intentionally untouched.

## Tests (`test/unit/pause_test.js`, +4)

- Three `pause()` calls leave exactly **one** listener of each (baseline + 1).
- After `event.test.finished`, both pause listeners are gone (back to baseline).
- A `test.finished` with no open pause session does **not** call `recorder.session.restore('pause')` (sinon spy), and the session id stays `null` / chain settles.
- The MCP path: `pauseNow()` + `setPauseHandler` drives the handler and restores the session.

**Reverting the fix fails the three listener/guard tests** (verified). The existing `setPauseHandler` tests pass unchanged.

## Verification

- `npx mocha test/unit/pause_test.js --exit` → 6 passing
- `npm run test:unit` → **731 passed, 0 failed, 11 skipped**
- `npm run test:runner` → **273 passed, 0 failed, 2 skipped**
- `npm run lint` → clean

## Notes for reviewers

- `grep "dispatcher.on(" lib/pause.js` shows registrations only through the idempotent named-handler path — no anonymous listeners.
- The open-pause flag is a boolean; per the plan, when a proper `recorder.session.isOpen(name)` API exists it should replace the flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)