### PR TITLE
fix(core): restore sessions and propagate errors on session/within/retryTo error paths

### DIFF
--- a/lib/effects.js
+++ b/lib/effects.js
@@ -50,8 +50,10 @@ function within(context, fn) {
             return recorder.promise().then(() => res)
           })
           .catch(e => {
+            finishHelpers()
             finalize()
             recorder.throw(e)
+            return recorder.promise()
           })
       }
 
@@ -203,7 +205,7 @@ async function retryTo(callback, maxTries, pollInterval = 200) {
   const sessionName = 'retryTo'
 
   return new Promise((done, reject) => {
-    let tries = 1
+    let tries = 0
 
     function handleRetryException(err) {
       recorder.throw(err)
@@ -216,7 +218,7 @@ async function retryTo(callback, maxTries, pollInterval = 200) {
       try {
         await callback(tries)
       } catch (err) {
-        handleRetryException(err)
+        recorder.throw(err)
       }
 
       // Call done if no errors
@@ -228,7 +230,7 @@ async function retryTo(callback, maxTries, pollInterval = 200) {
       // Catch errors and retry
       recorder.session.catch(err => {
         recorder.session.restore(`${sessionName} ${tries}`)
-        if (tries <= maxTries) {
+        if (tries < maxTries) {
           output.debug(`Error ${err}... Retrying`)
           recorder.add(`${sessionName} ${tries}`, () => setTimeout(tryBlock, pollInterval))
         } else {

--- a/lib/session.js
+++ b/lib/session.js
@@ -109,6 +109,7 @@ function session(sessionName, config, fn) {
             output.stepShift = 0
             session.restoreVars(sessionName)
             event.dispatcher.removeListener(event.step.after, addContextToStep)
+            recorder.add('restore session on error', () => recorder.session.restore(`session:${sessionName}`))
             recorder.throw(e)
             return recorder.promise()
           })
@@ -124,6 +125,7 @@ function session(sessionName, config, fn) {
           session.restoreVars(sessionName)
           output.stepShift = 0
           event.dispatcher.removeListener(event.step.after, addContextToStep)
+          recorder.session.restore(`session:${sessionName}`)
           throw e
         })
       }

--- a/test/unit/session_composition_test.js
+++ b/test/unit/session_composition_test.js
@@ -94,31 +94,28 @@ describe('promise-core composition (characterization)', () => {
       expect(recorder.getCurrentSessionId()).to.equal(null)
     })
 
-    it('FINDING: async callback error leaks the session id and never calls recorder.session.restore', async () => {
+    it('async callback error surfaces the error and restores the session id', async () => {
       session('asyncerr', async () => {
         throw new Error('boom')
       })
-      let rejected
-      await settles(recorder.promise()).catch(e => (rejected = e))
-      // characterized behavior, see plans/001-findings.md
-      expect(rejected, 'outer chain rejects').to.be.instanceof(Error)
-      expect(rejected.message).to.equal('boom')
-      expect(recorder.getCurrentSessionId(), 'session id leaks').to.equal('session:asyncerr')
+      const err = await drain()
+      expect(err, 'outer chain rejects').to.be.instanceof(Error)
+      expect(err.message).to.equal('boom')
+      expect(helper.calls.restoreVars, 'restoreVars called on error').to.be.greaterThan(0)
+      expect(recorder.getCurrentSessionId(), 'session id restored on error').to.equal(null)
     })
 
-    it('FINDING: sync callback whose queued task throws restores vars but leaks the session id', async () => {
+    it('sync callback whose queued task throws surfaces the error and restores the session id', async () => {
       session('syncerr', () => {
         recorder.add(() => {
           throw new Error('boomsync')
         })
       })
       const err = await drain()
-      // The finally recorder.catch re-throws before finalize() runs
-      // recorder.session.restore, so the session id leaks. See plans/001-findings.md
       expect(err, 'error surfaces after draining').to.be.instanceof(Error)
       expect(err.message).to.equal('boomsync')
-      expect(helper.calls.restoreVars, 'restoreVars called by the finally handler').to.equal(1)
-      expect(recorder.getCurrentSessionId(), 'session id leaks').to.equal('session:syncerr')
+      expect(helper.calls.restoreVars, 'restoreVars called by the finally handler').to.be.greaterThan(0)
+      expect(recorder.getCurrentSessionId(), 'session id restored on error').to.equal(null)
     })
   })
 
@@ -134,22 +131,40 @@ describe('promise-core composition (characterization)', () => {
       expect(inside).to.equal(true)
     })
 
-    it('FINDING: async callback error skips _withinEnd and detaches the error onto a trailing task', async () => {
+    it('async callback error runs _withinEnd and propagates the error', async () => {
       within('ctx', async () => {
         throw new Error('boomwithin')
       })
       const err = await drain()
-      // The error is only visible after draining trailing tasks because within()'s
-      // async catch omits `return recorder.promise()`. See plans/001-findings.md
-      expect(err, 'error surfaces after draining').to.be.instanceof(Error)
+      expect(err, 'error surfaces').to.be.instanceof(Error)
       expect(err.message).to.equal('boomwithin')
       expect(helper.calls.withinBegin, '_withinBegin ran').to.be.greaterThan(0)
-      expect(helper.calls.withinEnd, '_withinEnd skipped on error').to.equal(0)
+      expect(helper.calls.withinEnd, '_withinEnd runs on error').to.be.greaterThan(0)
     })
   })
 
   describe('retryTo()', () => {
-    it('FINDING: a synchronously-throwing callback rejects but keeps retrying past the rejection', async () => {
+    it('retries a throwing callback and resolves when a later attempt succeeds', async () => {
+      let firstTries
+      let calls = 0
+      let rejected = null
+      await settles(
+        retryTo(
+          tries => {
+            if (firstTries === undefined) firstTries = tries
+            calls++
+            if (tries < 3) throw new Error('not yet')
+          },
+          5,
+          20,
+        ),
+      ).catch(e => (rejected = e))
+      expect(rejected, 'resolves once an attempt succeeds (no premature reject)').to.equal(null)
+      expect(firstTries, 'first attempt receives tries === 1').to.equal(1)
+      expect(calls, 'ran until the succeeding attempt').to.equal(3)
+    })
+
+    it('a callback that always throws rejects only after exhausting maxTries', async () => {
       let firstTries
       let calls = 0
       let rejected
@@ -165,15 +180,11 @@ describe('promise-core composition (characterization)', () => {
         ),
         3000,
       ).catch(e => (rejected = e))
-      await new Promise(r => setTimeout(r, 300))
-      const finalCalls = calls
-      await new Promise(r => setTimeout(r, 300))
-      // characterized behavior, see plans/001-findings.md
-      expect(rejected, 'retryTo rejects with the real error').to.be.instanceof(Error)
+      await new Promise(r => setTimeout(r, 200))
+      expect(rejected, 'rejects with the real error').to.be.instanceof(Error)
       expect(rejected.message).to.equal('always')
-      expect(firstTries, 'first attempt receives tries === 2 (tries starts at 1, incremented before callback)').to.equal(2)
-      expect(calls, 'retrying continues past the first rejection').to.be.greaterThan(1)
-      expect(calls, 'retries stop once drained (no perpetual loop)').to.equal(finalCalls)
+      expect(firstTries, 'first attempt receives tries === 1').to.equal(1)
+      expect(calls, 'retried exactly maxTries times').to.equal(3)
     })
 
     it('retries via recorder failures then resolves', async () => {


### PR DESCRIPTION
## What

Implements the actual fixes for the latent promise-core divergences that #5622 characterized. Each fix makes an **error path symmetric with its already-working success path**, and the corresponding characterization assertion is updated to the corrected behavior in the same commit.

⚠️ **Stacked on #5622** (base = `advisor/001-promise-core-characterization`); review only the `fix(core): …` commit. Merge #5622 first.

## Fixes (4 of the 7 findings)

| # | Finding | Fix |
|---|---------|-----|
| 5 | `within()` async error skipped `_withinEnd` and detached the error | catch now runs `finishHelpers()` (so `_withinEnd` runs on error) and `return recorder.promise()` (so the error propagates through `within()`) |
| 3 | `session()` async error leaked the session id | catch now **schedules** `recorder.session.restore` via `recorder.add` so the recorder session is restored on error |
| 4 | `session()` sync queued-throw leaked the session id | the `finally` `recorder.catch` now calls `recorder.session.restore` before re-throwing (the only place that runs on a rejected chain) |
| 6 | `retryTo()` rejected prematurely / `tries === 2` on first | a thrown callback routes through `recorder.throw` instead of an immediate `reject(err)`, so the retry logic owns the outcome — **throw-then-succeed now resolves**; reject only after `maxTries`. `tries` starts at **1**; retry count preserved (`tries < maxTries`) |

### Important: the session fix is deliberately surgical

The session error paths are entangled with the Playwright browser lifecycle. An earlier version of this PR routed the async-error cleanup through `finalize()` — which also swaps the original (no-op) `restoreVars(sessionName)` call for the real `restoreVars()`. That **closed the browser context under `BROWSER_RESTART=session`** and failed the Playwright CI job (4 `Cannot create page: browser context has been closed` failures in `session_test.js`).

The fix is now minimal: **only** add the missing `recorder.session.restore` (the session-id leak the finding is about); the existing `restoreVars`/listener cleanup is left exactly as-is. Net `lib/session.js` change is two added lines.

## Verification

- `npm run test:unit` → **748 passed, 0 failed, 11 skipped**
- `npm run test:runner` → **273 passed, 0 failed** — incl. `should rerun flaky tests`, `should rerun retried steps`, `should use retryFailedStep plugin for failed steps`, etc.
- Acceptance (real Chromium), **both** restart modes — `BROWSER_RESTART=browser` and `BROWSER_RESTART=session` — `within`/`session`/`els` green, **0** `browser context has been closed` failures. (The one remaining local acceptance failure is `config_test.js`'s API call to the local mock at `:3001/api/users`, which 404s only in this sandbox and passes in CI — unrelated to these changes.)

## Deliberately **not** changed here

1. **`recorder.retries` never cleared by `reset()`** — `lib/plugin/retryFailedStep.js` (on by default) reads/mutates `recorder.retries`; the in-code comment warns clearing it breaks the plugin. Needs per-test scoping coordinated with that plugin.
2. **Stopped recorder → silent hang** — `add()`'s no-op-when-stopped is a contract the `should not add steps when stopped` test depends on; these error-path fixes reduce the wedging, but a blanket change is unsafe.
3. **Nested cross-level restore order** — low severity; real `within`/`session` keep start+restore at one level. The characterization test pins the correct synchronous id semantics.

Happy to tackle any of these three as a focused follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)