### PR TITLE
fix(core): re-land asyncWrapper + promise-core error-path fixes onto 4.x (#5624, #5633)

### DIFF
--- a/lib/effects.js
+++ b/lib/effects.js
@@ -50,8 +50,10 @@ function within(context, fn) {
             return recorder.promise().then(() => res)
           })
           .catch(e => {
+            finishHelpers()
             finalize()
             recorder.throw(e)
+            return recorder.promise()
           })
       }
 
@@ -203,7 +205,7 @@ async function retryTo(callback, maxTries, pollInterval = 200) {
   const sessionName = 'retryTo'
 
   return new Promise((done, reject) => {
-    let tries = 1
+    let tries = 0
 
     function handleRetryException(err) {
       recorder.throw(err)
@@ -216,7 +218,7 @@ async function retryTo(callback, maxTries, pollInterval = 200) {
       try {
         await callback(tries)
       } catch (err) {
-        handleRetryException(err)
+        recorder.throw(err)
       }
 
       // Call done if no errors
@@ -228,7 +230,7 @@ async function retryTo(callback, maxTries, pollInterval = 200) {
       // Catch errors and retry
       recorder.session.catch(err => {
         recorder.session.restore(`${sessionName} ${tries}`)
-        if (tries <= maxTries) {
+        if (tries < maxTries) {
           output.debug(`Error ${err}... Retrying`)
           recorder.add(`${sessionName} ${tries}`, () => setTimeout(tryBlock, pollInterval))
         } else {

--- a/lib/mocha/asyncWrapper.js
+++ b/lib/mocha/asyncWrapper.js
@@ -197,11 +197,15 @@ export function setup(suite) {
   return function (done) {
     const doneFn = makeDoneCallableOnce(done)
     recorder.startUnlessRunning()
-    import('./test.js').then(testModule => {
-      const { enhanceMochaTest } = testModule.default || testModule
-      event.emit(event.test.before, enhanceMochaTest(suite?.ctx?.currentTest ?? suite?.currentTest))
-      recorder.add(() => doneFn())
-    })
+    import('./test.js')
+      .then(testModule => {
+        const { enhanceMochaTest } = testModule.default || testModule
+        event.emit(event.test.before, enhanceMochaTest(suite?.ctx?.currentTest ?? suite?.currentTest))
+        recorder.add(() => doneFn())
+      })
+      .catch(err => {
+        doneFn(err)
+      })
   }
 }
 
@@ -209,11 +213,15 @@ export function teardown(suite) {
   return function (done) {
     const doneFn = makeDoneCallableOnce(done)
     recorder.startUnlessRunning()
-    import('./test.js').then(testModule => {
-      const { enhanceMochaTest } = testModule.default || testModule
-      event.emit(event.test.after, enhanceMochaTest(suite?.ctx?.currentTest ?? suite?.currentTest))
-      recorder.add(() => doneFn())
-    })
+    import('./test.js')
+      .then(testModule => {
+        const { enhanceMochaTest } = testModule.default || testModule
+        event.emit(event.test.after, enhanceMochaTest(suite?.ctx?.currentTest ?? suite?.currentTest))
+        recorder.add(() => doneFn())
+      })
+      .catch(err => {
+        doneFn(err)
+      })
   }
 }
 

--- a/lib/session.js
+++ b/lib/session.js
@@ -109,6 +109,7 @@ function session(sessionName, config, fn) {
             output.stepShift = 0
             session.restoreVars(sessionName)
             event.dispatcher.removeListener(event.step.after, addContextToStep)
+            recorder.add('restore session on error', () => recorder.session.restore(`session:${sessionName}`))
             recorder.throw(e)
             return recorder.promise()
           })
@@ -124,6 +125,7 @@ function session(sessionName, config, fn) {
           session.restoreVars(sessionName)
           output.stepShift = 0
           event.dispatcher.removeListener(event.step.after, addContextToStep)
+          recorder.session.restore(`session:${sessionName}`)
           throw e
         })
       }

--- a/test/unit/mocha/asyncWrapper_test.js
+++ b/test/unit/mocha/asyncWrapper_test.js
@@ -230,4 +230,43 @@ describe('AsyncWrapper', () => {
       expect(suiteTests[0].err, 'the suite test got the hook error attached').to.be.instanceof(Error)
     })
   })
+
+  describe('setup/teardown import hardening (regression)', () => {
+    beforeEach(() => recorder.start())
+
+    it('setup(): a throwing then-body calls done with the error instead of hanging', async () => {
+      const suite = {
+        ctx: {
+          get currentTest() {
+            throw new Error('setup-boom')
+          },
+        },
+      }
+      const { count, arg } = await runHook(setup(suite), 1000)
+      expect(count).to.equal(1)
+      expect(arg).to.be.instanceof(Error)
+      expect(arg.message).to.equal('setup-boom')
+    })
+
+    it('teardown(): a throwing then-body calls done with the error instead of hanging', async () => {
+      const suite = {
+        ctx: {
+          get currentTest() {
+            throw new Error('teardown-boom')
+          },
+        },
+      }
+      const { count, arg } = await runHook(teardown(suite), 1000)
+      expect(count).to.equal(1)
+      expect(arg).to.be.instanceof(Error)
+      expect(arg.message).to.equal('teardown-boom')
+    })
+
+    it('setup(): happy path calls done with no error', async () => {
+      const suite = { ctx: { currentTest: { title: 'a sample test' } } }
+      const { count, arg } = await runHook(setup(suite), 1000)
+      expect(count).to.equal(1)
+      expect(arg, 'done called with no error').to.be.undefined
+    })
+  })
 })

--- a/test/unit/session_composition_test.js
+++ b/test/unit/session_composition_test.js
@@ -94,31 +94,28 @@ describe('promise-core composition (characterization)', () => {
       expect(recorder.getCurrentSessionId()).to.equal(null)
     })
 
-    it('FINDING: async callback error leaks the session id and never calls recorder.session.restore', async () => {
+    it('async callback error surfaces the error and restores the session id', async () => {
       session('asyncerr', async () => {
         throw new Error('boom')
       })
-      let rejected
-      await settles(recorder.promise()).catch(e => (rejected = e))
-      // characterized behavior, see plans/001-findings.md
-      expect(rejected, 'outer chain rejects').to.be.instanceof(Error)
-      expect(rejected.message).to.equal('boom')
-      expect(recorder.getCurrentSessionId(), 'session id leaks').to.equal('session:asyncerr')
+      const err = await drain()
+      expect(err, 'outer chain rejects').to.be.instanceof(Error)
+      expect(err.message).to.equal('boom')
+      expect(helper.calls.restoreVars, 'restoreVars called on error').to.be.greaterThan(0)
+      expect(recorder.getCurrentSessionId(), 'session id restored on error').to.equal(null)
     })
 
-    it('FINDING: sync callback whose queued task throws restores vars but leaks the session id', async () => {
+    it('sync callback whose queued task throws surfaces the error and restores the session id', async () => {
       session('syncerr', () => {
         recorder.add(() => {
           throw new Error('boomsync')
         })
       })
       const err = await drain()
-      // The finally recorder.catch re-throws before finalize() runs
-      // recorder.session.restore, so the session id leaks. See plans/001-findings.md
       expect(err, 'error surfaces after draining').to.be.instanceof(Error)
       expect(err.message).to.equal('boomsync')
-      expect(helper.calls.restoreVars, 'restoreVars called by the finally handler').to.equal(1)
-      expect(recorder.getCurrentSessionId(), 'session id leaks').to.equal('session:syncerr')
+      expect(helper.calls.restoreVars, 'restoreVars called by the finally handler').to.be.greaterThan(0)
+      expect(recorder.getCurrentSessionId(), 'session id restored on error').to.equal(null)
     })
   })
 
@@ -134,22 +131,40 @@ describe('promise-core composition (characterization)', () => {
       expect(inside).to.equal(true)
     })
 
-    it('FINDING: async callback error skips _withinEnd and detaches the error onto a trailing task', async () => {
+    it('async callback error runs _withinEnd and propagates the error', async () => {
       within('ctx', async () => {
         throw new Error('boomwithin')
       })
       const err = await drain()
-      // The error is only visible after draining trailing tasks because within()'s
-      // async catch omits `return recorder.promise()`. See plans/001-findings.md
-      expect(err, 'error surfaces after draining').to.be.instanceof(Error)
+      expect(err, 'error surfaces').to.be.instanceof(Error)
       expect(err.message).to.equal('boomwithin')
       expect(helper.calls.withinBegin, '_withinBegin ran').to.be.greaterThan(0)
-      expect(helper.calls.withinEnd, '_withinEnd skipped on error').to.equal(0)
+      expect(helper.calls.withinEnd, '_withinEnd runs on error').to.be.greaterThan(0)
     })
   })
 
   describe('retryTo()', () => {
-    it('FINDING: a synchronously-throwing callback rejects but keeps retrying past the rejection', async () => {
+    it('retries a throwing callback and resolves when a later attempt succeeds', async () => {
+      let firstTries
+      let calls = 0
+      let rejected = null
+      await settles(
+        retryTo(
+          tries => {
+            if (firstTries === undefined) firstTries = tries
+            calls++
+            if (tries < 3) throw new Error('not yet')
+          },
+          5,
+          20,
+        ),
+      ).catch(e => (rejected = e))
+      expect(rejected, 'resolves once an attempt succeeds (no premature reject)').to.equal(null)
+      expect(firstTries, 'first attempt receives tries === 1').to.equal(1)
+      expect(calls, 'ran until the succeeding attempt').to.equal(3)
+    })
+
+    it('a callback that always throws rejects only after exhausting maxTries', async () => {
       let firstTries
       let calls = 0
       let rejected
@@ -165,15 +180,11 @@ describe('promise-core composition (characterization)', () => {
         ),
         3000,
       ).catch(e => (rejected = e))
-      await new Promise(r => setTimeout(r, 300))
-      const finalCalls = calls
-      await new Promise(r => setTimeout(r, 300))
-      // characterized behavior, see plans/001-findings.md
-      expect(rejected, 'retryTo rejects with the real error').to.be.instanceof(Error)
+      await new Promise(r => setTimeout(r, 200))
+      expect(rejected, 'rejects with the real error').to.be.instanceof(Error)
       expect(rejected.message).to.equal('always')
-      expect(firstTries, 'first attempt receives tries === 2 (tries starts at 1, incremented before callback)').to.equal(2)
-      expect(calls, 'retrying continues past the first rejection').to.be.greaterThan(1)
-      expect(calls, 'retries stop once drained (no perpetual loop)').to.equal(finalCalls)
+      expect(firstTries, 'first attempt receives tries === 1').to.equal(1)
+      expect(calls, 'retried exactly maxTries times').to.equal(3)
     })
 
     it('retries via recorder failures then resolves', async () => {


### PR DESCRIPTION
## Why this PR exists

#5624 and #5633 show as **merged**, but their changes **never reached `4.x`**. Both were stacked on the `advisor/001-promise-core-characterization` branch (the base of #5622). #5622 was squash-merged to `4.x` first; #5624 and #5633 then merged into the `advisor/001` branch *afterward*. So their commits live on `advisor/001` and are not on `4.x`.

Verified on current `4.x` (`20607b70`): `asyncWrapper.js` has no `.catch` hardening, and `session.js`/`effects.js` have none of the error-path fixes.

This PR re-lands both deltas directly on `4.x` (cherry-picked; **no stacking this time**).

## What's included

**1. `fix(mocha)` — fail fast when test hook import chain rejects** (was #5624)
- `setup()`/`teardown()` in `lib/mocha/asyncWrapper.js` now `.catch(err => doneFn(err))` on the dynamic `import('./test.js')` chain (mirrors `suiteSetup`/`suiteTeardown`), so a rejected import reports an error instead of hanging the hook forever.
- 3 regression tests; reverting the fix makes the error-path tests hang.

**2. `fix(core)` — restore sessions & propagate errors on session/within/retryTo error paths** (was #5633)
- `within()` async error now runs `_withinEnd` (`finishHelpers()`) and `return recorder.promise()` (error propagates, not detached).
- `session()` async/sync error now restores the recorder session (fixes the session-id leak) — **surgical**: only adds `recorder.session.restore`, keeping the original `restoreVars` call so `BROWSER_RESTART=session` doesn't close the browser context (this was the regression that failed Playwright CI on #5633 and was fixed before merge).
- `retryTo()`: a thrown callback routes through `recorder.throw` (no premature `reject`) so throw-then-succeed resolves and reject happens only after `maxTries`; first attempt is `tries === 1` (was 2), retry count preserved.
- Characterization assertions in `session_composition_test.js` updated to the fixed behavior.

## Verification (cherry-picked onto current 4.x)

- `npx mocha` target unit files → **44 passing**
- `BROWSER_RESTART=session` acceptance (`session_test.js`) → **9 passed, 2 skipped, 0** `browser context has been closed`
- lint + prettier clean

Both changes were already CI-green on #5624/#5633 (incl. the full `playwright.yml` suite across browsers + restart modes); CI will re-run here against current `4.x`.

## After merge

The `advisor/001`, `advisor/003`, `advisor/006` branches can be deleted — their content is now fully represented on `4.x` (via #5622 + this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)