### PR TITLE
fix: guard sort() with shuffle check so --shuffle is not silently ignored

### DIFF
--- a/lib/codecept.js
+++ b/lib/codecept.js
@@ -289,8 +289,11 @@ class Codecept {
       // Ignore if gherkin module not available
     }
 
-    // Sort test files alphabetically for consistent execution order
-    this.testFiles.sort()
+    // Sort test files alphabetically for consistent execution order,
+    // but skip sorting when --shuffle is active so the randomised order is preserved.
+    if (!this.opts.shuffle) {
+      this.testFiles.sort()
+    }
 
     return new Promise((resolve, reject) => {
       const mocha = container.mocha()


### PR DESCRIPTION
Fixes #5605

## What

`run()` calls `this.testFiles.sort()` unconditionally after `loadTests()` has already applied `shuffle()` when `--shuffle` is set. The sort overwrites the randomised order every time, making `--shuffle` silently have no effect.

```js
// loadTests() — line 217
if (this.opts.shuffle) {
  this.testFiles = shuffle(this.testFiles)  // ✅ shuffled
}

// run() — line 293 (added by #5438)
this.testFiles.sort()  // ❌ always runs — shuffle is lost
```

## Fix

Guard the sort with `!this.opts.shuffle`:

```js
// Sort alphabetically for consistent order, but preserve shuffle when active.
if (!this.opts.shuffle) {
  this.testFiles.sort()
}
```

Normal runs continue to get alphabetical order. `--shuffle` runs now keep their randomised order.

## Why this happened

The `sort()` was introduced in #5438 to fix worker suite distribution — a correct fix for that issue, but it introduced this regression for `--shuffle` users.

## Change

Single guard condition in `lib/codecept.js` — no other behaviour changed.