### PR TITLE
fix(typescript): unique temp file names to fix run-multiple race (#5642)

### DIFF
--- a/lib/utils/typescript.js
+++ b/lib/utils/typescript.js
@@ -385,7 +385,9 @@ const __dirname = __dirname_fn(__filename);
     )
 
     // Write the transpiled file with updated imports
-    const tempFile = filePath.replace(/\.ts$/, '.temp.mjs')
+    // Include process.pid + a random suffix so concurrent run-multiple workers
+    // don't write to and delete each other's temp files (see issue #5642).
+    const tempFile = filePath.replace(/\.ts$/, `.${process.pid}.${Math.random().toString(36).slice(2, 10)}.temp.mjs`)
     fs.writeFileSync(tempFile, jsContent)
     transpiledFiles.set(filePath, tempFile)
   }

--- a/test/unit/utils/typescript_test.js
+++ b/test/unit/utils/typescript_test.js
@@ -1,0 +1,36 @@
+import { expect } from 'chai'
+import { fileURLToPath } from 'url'
+import path from 'path'
+import { createRequire } from 'module'
+import { transpileTypeScript, cleanupTempFiles } from '../../../lib/utils/typescript.js'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const require = createRequire(import.meta.url)
+const typescript = require('typescript')
+
+const configPath = path.resolve(__dirname, '../../data/typescript-config-imports/tests/api/codecept.conf.ts')
+
+describe('TypeScript transpilation', () => {
+  it('uses unique temp file names per invocation so concurrent run-multiple workers do not delete each other (#5642)', async () => {
+    const first = await transpileTypeScript(configPath, typescript)
+    const second = await transpileTypeScript(configPath, typescript)
+
+    try {
+      expect(first.allTempFiles.length).to.be.greaterThan(0)
+      expect(second.allTempFiles.length).to.equal(first.allTempFiles.length)
+
+      // Every temp file path is still recognisable as a transpiled file
+      for (const file of [...first.allTempFiles, ...second.allTempFiles]) {
+        expect(file).to.match(/\.temp\.mjs$/)
+      }
+
+      // The two invocations must not share any temp file path, otherwise one
+      // worker's cleanup would remove files the other still needs to import.
+      const shared = first.allTempFiles.filter(f => second.allTempFiles.includes(f))
+      expect(shared, `temp files were shared between invocations: ${shared}`).to.be.empty
+    } finally {
+      cleanupTempFiles(first.allTempFiles)
+      cleanupTempFiles(second.allTempFiles)
+    }
+  })
+})


### PR DESCRIPTION
## Problem

Fixes #5642.

Under `run-multiple`, tests intermittently fail with `Cannot find module *.temp.mjs` / `ENOENT`.

The built-in TypeScript transpiler writes each transpiled file to a **fixed** `<source>.temp.mjs` path next to the source. `run-multiple` forks one OS process per `browsers` entry, all at once, and each worker transpiles the same config/helper/include files to the **same** temp paths and then deletes them on cleanup. Workers race over the shared paths, so one worker's cleanup removes files another worker still needs to import.

## Fix

Include `process.pid` plus a short random suffix in the temp file name (`<source>.<pid>.<rand>.temp.mjs`), so each worker writes and removes only its own files.

- All import/`require` rewrites resolve through the existing `transpiledFiles` map, so rewritten references automatically point at the unique names — no other changes needed.
- The names still end in `.temp.mjs`, so the stack-trace remapping in `lib/step/base.js` and `fixErrorStack` keep working unchanged.

## Test

Added `test/unit/utils/typescript_test.js`: two transpilation runs of the same fixture must produce disjoint temp-file sets. It fails on the old code (`temp files were shared between invocations`) and passes with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)