### PR TITLE
fix(run-multiple): avoid temp.mjs filename collision across forked processes

### DIFF
--- a/lib/utils/typescript.js
+++ b/lib/utils/typescript.js
@@ -385,7 +385,9 @@ const __dirname = __dirname_fn(__filename);
     )
 
     // Write the transpiled file with updated imports
-    const tempFile = filePath.replace(/\.ts$/, '.temp.mjs')
+    // Use process.pid in the filename to avoid collisions when run-multiple forks
+    // several processes that all transpile the same .ts files concurrently.
+    const tempFile = filePath.replace(/\.ts$/, `.${process.pid}.temp.mjs`)
     fs.writeFileSync(tempFile, jsContent)
     transpiledFiles.set(filePath, tempFile)
   }


### PR DESCRIPTION
## Problem

Fixes #5642

When `run-multiple` launches N concurrent worker processes, each process independently transpiles the same TypeScript files (config, helpers, page objects, includes) to temporary `.temp.mjs` files. Since the temp filename is derived purely from the source path:

```js
// before
const tempFile = filePath.replace(/\.ts$/, '.temp.mjs')
```

all workers write to the **same path** (e.g. `CustomHelper.temp.mjs`). When one worker finishes and deletes its temp file via `cleanupTempFiles()`, any other worker that hasn't yet `import()`ed the file fails with:

```
Error: Cannot find module '.../CustomHelper.temp.mjs'
```

This is a classic TOCTOU race; the repro in #5642 shows it failing ~85% of the time with 12 workers.

## Fix

Embed `process.pid` in the temp filename so each worker writes its own isolated copy:

```js
// after
const tempFile = filePath.replace(/\.ts$/, `.${process.pid}.temp.mjs`)
```

No other changes needed:
- `cleanupTempFiles()` iterates `allTempFiles` which is built from `transpiledFiles.values()` — already contains the pid-suffixed paths, so cleanup is correct.
- `lib/step/base.js` uses `.includes('.temp.mjs')` (substring), which matches `*.{pid}.temp.mjs` unchanged.

## Test plan

- [ ] `run-multiple` no longer races on the repro from #5642 (run 40 iterations, all pass)
- [ ] Single-process `run` still works (temp files created, imported, cleaned up normally)
- [ ] TypeScript configs, helpers, and page objects all load correctly