### PR TITLE
ci(docker): build multi-arch images (amd64 + arm64)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,6 +29,9 @@ jobs:
           echo "VERSION=$VERSION" >> $GITHUB_ENV
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -51,6 +54,7 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: |
             ${{ env.DOCKER_REPO }}:latest
             ${{ env.DOCKER_REPO }}:${{ env.VERSION }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Download Playwright and its dependencies
-FROM mcr.microsoft.com/playwright:v1.55.0-noble
+FROM mcr.microsoft.com/playwright:v1.61.0-noble
 
 # Set non-interactive mode for apt operations
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
## Summary

Closes #5646 — the Docker Hub image (`codeceptjs/codeceptjs`) currently ships **amd64 only**. This PR makes the published image multi-arch so it works natively on ARM64 (Apple Silicon, AWS Graviton, Raspberry Pi, etc.).

## Changes

- **`.github/workflows/docker.yml`**
  - Add `docker/setup-qemu-action@v3` to enable arm64 emulation during the build.
  - Pass `platforms: linux/amd64,linux/arm64` to `build-push-action`, producing a single multi-arch manifest. `docker pull codeceptjs/codeceptjs` then resolves to the right architecture automatically.
- **`Dockerfile`**
  - Bump base image `mcr.microsoft.com/playwright:v1.55.0-noble` → `v1.61.0-noble` (latest). This release ships an arm64 manifest and matches the project's `playwright ^1.59.0` dependency, so the image's bundled browsers line up with the installed package.

## Why this is sufficient

- Base image `v1.61.0-noble` publishes both `amd64` and `arm64` manifests (verified via `docker manifest inspect`).
- The Dockerfile has no arch-specific downloads; the apt packages (`libgtk2.0-0`, `libxtst6`, `xvfb`, …) exist for both arches on Ubuntu Noble.
- `docker/entrypoint` and `docker/run.sh` are plain shell, architecture-agnostic.

## Notes / tradeoffs

- The arm64 image is built via **QEMU emulation**, which is slower (the `npm install` step in particular). If build time becomes a problem, a follow-up could split the build across native runners (`ubuntu-22.04` + `ubuntu-22.04-arm`) and merge manifests with `docker buildx imagetools`.
- The base image is pinned to an exact version, so it won't drift — it should be bumped alongside future Playwright upgrades.

🤖 Generated with [Claude Code](https://claude.com/claude-code)