### PR TITLE
fix(data): detect DataTable structurally so Data() works under tsx/cjs (#5641)

### DIFF
--- a/lib/data/context.js
+++ b/lib/data/context.js
@@ -82,8 +82,13 @@ function isTableDataRow(row) {
   return has.call(row, 'data') && has.call(row, 'skip')
 }
 
+function isDataTable(dataTable) {
+  if (dataTable instanceof DataTable) return true
+  return Boolean(dataTable) && Array.isArray(dataTable.array) && Array.isArray(dataTable.rows) && typeof dataTable.add === 'function'
+}
+
 function detectDataType(dataTable) {
-  if (dataTable instanceof DataTable) {
+  if (isDataTable(dataTable)) {
     return dataTable.rows
   }
 

--- a/test/unit/data/ui_test.js
+++ b/test/unit/data/ui_test.js
@@ -97,5 +97,29 @@ describe('ui', () => {
       const dataScenarioConfig = context.Data(dataTable).Scenario('scenario', () => {})
       expect('scenario | {"username":"Username","password":"*****"}').to.equal(dataScenarioConfig.scenarios[2].test.title)
     })
+
+    it('accepts a DataTable coming from a duplicate module instance', () => {
+      class ForeignDataTable {
+        constructor(array) {
+          this.array = array
+          this.rows = []
+        }
+
+        add(array) {
+          const data = {}
+          this.array.forEach((key, i) => (data[key] = array[i]))
+          this.rows.push({ skip: false, data })
+        }
+      }
+
+      const foreign = new ForeignDataTable(['username', 'password'])
+      foreign.add(['jon', 'snow'])
+      foreign.add(['tyrion', 'lannister'])
+
+      expect(foreign).to.not.be.instanceOf(DataTable)
+      const dataScenarioConfig = context.Data(foreign).Scenario('scenario', () => {})
+      expect(dataScenarioConfig.scenarios).to.have.lengthOf(2)
+      expect(dataScenarioConfig.scenarios[0].test.title).to.equal('scenario | {"username":"jon","password":"snow"}')
+    })
   })
 })


### PR DESCRIPTION
Fixes #5641

## Problem

`Data(table).Scenario(...)` throws `Invalid data type. Data accepts either: DataTable || generator || Array || function` for a perfectly valid `DataTable` after migrating to 4.x. It works in 3.x.

```ts
import { dataTable as DataTable } from 'codeceptjs';

const cases = new DataTable(['input', 'expected']);
cases.add(['input1', 'expected1']);

Data(cases).Scenario('test something', ({ current }) => { /* ... */ });
```

## Root cause

The check in `lib/data/context.js` is identity-based:

```js
if (dataTable instanceof DataTable) { return dataTable.rows }
```

In a 4.x project configured with `require: ['tsx/cjs']`, the test file is transpiled to **CommonJS**, so `import { dataTable } from 'codeceptjs'` resolves through tsx's loader and the test gets its **own copy** of the `DataTable` class. The framework runs as **ESM** with a **different** `DataTable` class. So `cases instanceof DataTable` is `false` even though `cases` is a genuine DataTable, and the `throw` fires.

This worked in 3.x because everything was CommonJS — a single module registry and a single class. It's the same dual-module loading hazard behind #5632 / #5635.

## Fix

Detect a DataTable **structurally** in addition to `instanceof`, which survives duplicate module instances:

```js
function isDataTable(dataTable) {
  if (dataTable instanceof DataTable) return true
  return Boolean(dataTable) && Array.isArray(dataTable.array) && Array.isArray(dataTable.rows) && typeof dataTable.add === 'function'
}
```

The duck-type can't collide with the other accepted inputs — plain arrays, generators and functions all fail it and fall through to their existing branches, so behavior is otherwise unchanged.

## Verification

- Reproduced the exact failure (identical stack trace) against the `tsx/cjs` fixture, then confirmed all data rows run after the fix.
- Added a regression unit test in `test/unit/data/ui_test.js` that feeds `Data()` a DataTable from a different class identity (simulating the tsx/cjs hazard without needing tsx).
- All data unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)