### PR TITLE
fix(pause): stop pause() at the right step in 4.x (#5652)

### DIFF
--- a/lib/globals.js
+++ b/lib/globals.js
@@ -30,10 +30,8 @@ export async function initCodeceptGlobals(dir, config, container) {
   // pause/inject/share stay global even under noGlobals — they're the everyday
   // debugging/wiring entry points and have no useful import alternative for
   // page-object code that runs before the container is available.
-  global.pause = async (...args) => {
-    const pauseModule = await import('./pause.js')
-    return (pauseModule.default || pauseModule)(...args)
-  }
+  const pauseModule = await import('./pause.js')
+  global.pause = pauseModule.default || pauseModule
   global.inject = () => container.support()
   global.share = container.share
 

--- a/test/unit/pause_test.js
+++ b/test/unit/pause_test.js
@@ -4,6 +4,7 @@ import pause, { setPauseHandler, pauseNow } from '../../lib/pause.js'
 import recorder from '../../lib/recorder.js'
 import event from '../../lib/event.js'
 import store from '../../lib/store.js'
+import { initCodeceptGlobals } from '../../lib/globals.js'
 
 const settles = (promise, ms = 2000) =>
   Promise.race([
@@ -98,5 +99,52 @@ describe('pause listener lifecycle', () => {
     await settles(recorder.promise())
     expect(received).to.deep.equal({ registeredVariables: { foo: 1 } })
     expect(recorder.getCurrentSessionId()).to.equal(null)
+  })
+})
+
+describe('global pause() queue ordering (issue #5652)', () => {
+  let savedPause
+  let savedNoGlobals
+
+  beforeEach(async () => {
+    savedPause = global.pause
+    savedNoGlobals = store.noGlobals
+    store.dryRun = false
+    setPauseHandler(() => Promise.resolve())
+    recorder.reset()
+    recorder.stop()
+    await initCodeceptGlobals(process.cwd(), { output: 'output', noGlobals: true }, { support() {}, share() {} })
+  })
+
+  afterEach(() => {
+    setPauseHandler(null)
+    event.dispatcher.emit(event.test.finished)
+    recorder.reset()
+    global.pause = savedPause
+    store.noGlobals = savedNoGlobals
+  })
+
+  it('global.pause is a synchronous function, not an async wrapper', () => {
+    expect(global.pause).to.equal(pause)
+    expect(global.pause.constructor.name).to.equal('Function')
+  })
+
+  it('queues the pause step between the steps surrounding it in the test body', () => {
+    // Mirrors a scenario body that runs synchronously to build the recorder queue:
+    //   I.amOnPage(...); pause(); I.see(...);
+    // The pause step must land *before* `see`, not after the rest of the body.
+    recorder.start()
+    recorder.add('amOnPage', () => {})
+    global.pause()
+    recorder.add('see', () => {})
+
+    const order = recorder.scheduled().split('\n')
+    const amOnPageIdx = order.indexOf('amOnPage')
+    const pauseIdx = order.indexOf('Start new session')
+    const seeIdx = order.indexOf('see')
+
+    expect(pauseIdx, 'pause step must be queued synchronously').to.be.greaterThan(-1)
+    expect(pauseIdx, 'pause must be queued after the preceding step').to.be.greaterThan(amOnPageIdx)
+    expect(pauseIdx, 'pause must be queued before the following step').to.be.lessThan(seeIdx)
   })
 })


### PR DESCRIPTION
Fixes #5652

## Problem

In 4.x, `pause()` stops **after** the following step instead of **before** it:

```ts
Scenario('test something', ({ I }) => {
  I.amOnPage('https://example.com');
  pause();                  // expected: stops here
  I.see('Example Domain');  // actual: pause stops after this
});
```

Works correctly in 3.7.9; broken in 4.0.x and 4.1 beta.

## Root cause

`global.pause` was wired as an **async wrapper** doing a lazy dynamic import in `lib/globals.js`:

```js
global.pause = async (...args) => {
  const pauseModule = await import('./pause.js')
  return (pauseModule.default || pauseModule)(...args)
}
```

A scenario body runs **synchronously** to build the recorder queue — every `I.*` call does `recorder.add(...)` synchronously. Because `pause` was async, calling it returned at the `await import(...)`, deferring its `recorder.add('Start new session', ...)` to a later microtask — **after** the rest of the synchronous body had already been queued.

`DEBUG=codeceptjs:recorder` for the repro:

```
Queued | amOnPage
Queued | see: "Example Domain"     <-- whole body queued synchronously
Running | amOnPage
Queued | Start new session         <-- pause inserted AFTER `see`
```

This also explains why `await pause()` worked as a workaround: awaiting suspends the synchronous body until pause's `recorder.add` has run.

## Fix

`initCodeceptGlobals` is already `async`, so resolve the module up front and assign the real function directly, making `pause` synchronous at call time:

```js
const pauseModule = await import('./pause.js')
global.pause = pauseModule.default || pauseModule
```

Ordering is restored:

```
Queued | amOnPage
Queued | Start new session         <-- between the two steps
Queued | see: "Example Domain"
```

## Test

Added a regression test in `test/unit/pause_test.js` that wires `global.pause` via `initCodeceptGlobals` and asserts:
- `global.pause` is the real (synchronous) `pause` function, not an async wrapper;
- mirroring the repro (`amOnPage → pause → see`), the `Start new session` step is queued **between** the surrounding steps (checked synchronously via `recorder.scheduled()`).

The test fails against the old async-wrapper implementation and passes with the fix. Full `test/unit` suite is green (759 passing).

> Note: `global.within` and `global.session` use the same async-lazy-import pattern and share the same latent hazard (currently masked because they're always awaited). Left out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)