### PR TITLE
fix(graphql): drop ESM-broken _checkRequirements() so `check` works (#5654)

### DIFF
--- a/lib/helper/GraphQL.js
+++ b/lib/helper/GraphQL.js
@@ -53,14 +53,6 @@ class GraphQL extends Helper {
     this.axios.defaults.headers = this.options.defaultHeaders
   }
 
-  static _checkRequirements() {
-    try {
-      require('axios')
-    } catch (e) {
-      return ['axios']
-    }
-  }
-
   static _config() {
     return [
       {

--- a/lib/helper/GraphQLDataFactory.js
+++ b/lib/helper/GraphQLDataFactory.js
@@ -174,15 +174,6 @@ class GraphQLDataFactory extends Helper {
     Object.keys(this.factories).forEach(f => (this.created[f] = []))
   }
 
-  static _checkRequirements() {
-    try {
-      require('axios')
-      require('rosie')
-    } catch (e) {
-      return ['axios', 'rosie']
-    }
-  }
-
   _after() {
     if (!this.config.cleanup) {
       return Promise.resolve()


### PR DESCRIPTION
Fixes #5654

## Problem

Running `npx codeceptjs check` with the GraphQL helper configured throws a false error:

```
Error: Required modules are not installed.

RUN: [sudo] npm install -g axios
```

even when axios is installed.

## Root cause

`GraphQL._checkRequirements()` (and `GraphQLDataFactory._checkRequirements()`) called `require('axios')`. In the ESM build `require` is undefined, so the line throws `ReferenceError: require is not defined`. The surrounding `catch` swallows it and returns the dependency list as "missing" — a false positive. `container.js`'s `checkHelperRequirements()` then throws and blocks the command.

## Fix

Delete `_checkRequirements()` from both helpers entirely. Dependencies are imported at the top of each ESM module, so a genuinely missing dependency fails at import time — the runtime check is redundant. Both call sites (`container.js:checkHelperRequirements`, `command/init.js`) already guard with `if (Helper._checkRequirements)`, so removing the method is safe.

## Verification

Both helpers load, and `_checkRequirements` is now `undefined` (skipped by the guards):

```
GraphQL._checkRequirements is undefined
GraphQLDataFactory._checkRequirements is undefined
```

`npx codeceptjs check` no longer reports axios/rosie as missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)