### PR TITLE
ci(reporter): post test results to GitHub PR comments via @testomatio/reporter

### DIFF
--- a/.github/workflows/appium_Android.yml
+++ b/.github/workflows/appium_Android.yml
@@ -13,12 +13,18 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pull-requests: write
+
 env:
   CI: true
   # Force terminal colors. @see https://www.npmjs.com/package/colors
   FORCE_COLOR: 1
   SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
   SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
+  GH_PAT: ${{ github.token }}
+  TESTOMATIO: ${{ secrets.TESTOMATIO }}
 
 jobs:
   appium:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -12,10 +12,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pull-requests: write
+
 env:
   CI: true
   # Force terminal colors. @see https://www.npmjs.com/package/colors
   FORCE_COLOR: 1
+  GH_PAT: ${{ github.token }}
+  TESTOMATIO: ${{ secrets.TESTOMATIO }}
 
 jobs:
   build:
@@ -69,6 +75,6 @@ jobs:
       - name: run webkit tests
         run: 'BROWSER=webkit node ./bin/codecept.js run -c test/acceptance/codecept.Playwright.js --grep @Playwright --debug'
       - name: run chromium unit tests
-        run: ./node_modules/.bin/mocha test/helper/Playwright_test.js --timeout 15000
+        run: ./node_modules/.bin/mocha test/helper/Playwright_test.js --timeout 15000 --reporter @testomatio/reporter/mocha
       - name: Stop mock server
         run: npm run mock-server:stop

--- a/.github/workflows/plugin.yml
+++ b/.github/workflows/plugin.yml
@@ -12,10 +12,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pull-requests: write
+
 env:
   CI: true
   # Force terminal colors. @see https://www.npmjs.com/package/colors
   FORCE_COLOR: 1
+  GH_PAT: ${{ github.token }}
+  TESTOMATIO: ${{ secrets.TESTOMATIO }}
 
 jobs:
   build:

--- a/.github/workflows/puppeteer.yml
+++ b/.github/workflows/puppeteer.yml
@@ -12,10 +12,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pull-requests: write
+
 env:
   CI: true
   # Force terminal colors. @see https://www.npmjs.com/package/colors
   FORCE_COLOR: 1
+  GH_PAT: ${{ github.token }}
+  TESTOMATIO: ${{ secrets.TESTOMATIO }}
 
 jobs:
   build:
@@ -55,6 +61,6 @@ jobs:
       - name: run tests
         run: './bin/codecept.js run-workers 2 -c test/acceptance/codecept.Puppeteer.js --grep @Puppeteer --debug'
       - name: run unit tests
-        run: ./node_modules/.bin/mocha test/helper/Puppeteer_test.js
+        run: ./node_modules/.bin/mocha test/helper/Puppeteer_test.js --reporter @testomatio/reporter/mocha
       - name: Stop mock server
         run: npm run mock-server:stop

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pull-requests: write
+
+env:
+  GH_PAT: ${{ github.token }}
+  TESTOMATIO: ${{ secrets.TESTOMATIO }}
+
 jobs:
   unit-tests:
     name: Unit tests

--- a/.github/workflows/webdriver.yml
+++ b/.github/workflows/webdriver.yml
@@ -12,10 +12,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pull-requests: write
+
 env:
   CI: true
   # Force terminal colors. @see https://www.npmjs.com/package/colors
   FORCE_COLOR: 1
+  GH_PAT: ${{ github.token }}
+  TESTOMATIO: ${{ secrets.TESTOMATIO }}
 
 jobs:
   build:
@@ -55,7 +61,6 @@ jobs:
         run: './bin/codecept.js check -c test/acceptance/codecept.WebDriver.js'
         timeout-minutes: 2
         env:
-          GH_PAT: ${{ github.token }}
           SELENIUM_HOST: localhost
           SELENIUM_PORT: 4444
       - name: run unit tests


### PR DESCRIPTION
## What

Enables the `@testomatio/reporter` **GitHub pipe** across the mocha-based test workflows so each job posts a pass/fail summary directly as a **PR comment**.

The reporter (v2.9.0) was already a devDependency and already wired into every mocha script (`--reporter @testomatio/reporter/mocha`). This PR only supplies the CI environment the pipe needs.

## Changes (6 workflows)

Added to `test.yml`, `plugin.yml`, `playwright.yml`, `puppeteer.yml`, `webdriver.yml`, `appium_Android.yml`:

```yaml
permissions:
  contents: read
  pull-requests: write

env:
  GH_PAT: ${{ github.token }}                 # activates the GitHub pipe (matches existing webdriver.yml convention)
  TESTOMATIO: ${{ secrets.TESTOMATIO }}       # activates TMS reporting once the secret is set; dormant no-op until then
```

- Added the missing `--reporter @testomatio/reporter/mocha` flag to the bare Playwright/Puppeteer helper unit runs.
- Dropped the now-redundant per-step `GH_PAT` in `webdriver.yml` (covered by workflow-level env).

## Verification

Simulated a PR environment locally — the mocha reporter activated the GitHub pipe and built the exact comment CI will post:

```
GitHub Pipe: Enabled
Pipes: GitHub Reporter, Debug Reporter
🟢 UNIT-TESTS PASSED
```

With no secrets (local/non-PR runs) it's a safe no-op: `Pipes: No pipes enabled`.

## Notes

- **PR comments work immediately** on same-repo PRs via `github.token`. To also stream results into Testomat.io TMS, add the repo secret `TESTOMATIO`.
- **Fork PRs won't receive comments** — GitHub makes `GITHUB_TOKEN` read-only and withholds secrets on `pull_request` runs from forks (platform limitation).
- One comment per workflow-job, updated in place across re-runs (keyed by a hidden marker).
- Scope is **mocha tests only**; CodeceptJS acceptance runs (`./bin/codecept.js run`) are intentionally untouched. `appium_iOS.yml` was skipped (disabled `if: false`, `3.x`-only push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)