### PR TITLE
fix(appium): replace deprecated setNetworkConnection/getNetworkConnection with mobile: setConnectivity/getConnectivity

### DIFF
--- a/lib/helper/Appium.js
+++ b/lib/helper/Appium.js
@@ -832,12 +832,12 @@ class Appium extends Webdriver {
    */
   async grabNetworkConnection() {
     onlyForApps.call(this, supportedPlatform.android)
-    const res = await this.browser.getNetworkConnection()
+    const res = await this.browser.execute('mobile: getConnectivity')
     return {
-      value: res,
-      inAirplaneMode: res.inAirplaneMode,
-      hasWifi: res.hasWifi,
-      hasData: res.hasData,
+      value: (res.airplaneMode ? 1 : 0) | (res.wifi ? 2 : 0) | (res.data ? 4 : 0),
+      inAirplaneMode: res.airplaneMode,
+      hasWifi: res.wifi,
+      hasData: res.data,
     }
   }
 
@@ -978,7 +978,11 @@ class Appium extends Webdriver {
    */
   async setNetworkConnection(value) {
     onlyForApps.call(this, supportedPlatform.android)
-    return this.browser.setNetworkConnection(value)
+    return this.browser.execute('mobile: setConnectivity', {
+      airplaneMode: !!(value & 1),
+      wifi: !!(value & 2),
+      data: !!(value & 4),
+    })
   }
 
   /**

--- a/test/unit/helper/Appium_networkConnection_test.js
+++ b/test/unit/helper/Appium_networkConnection_test.js
@@ -1,0 +1,84 @@
+import { expect } from 'chai'
+import sinon from 'sinon'
+import Appium from '../../../lib/helper/Appium.js'
+
+function createApp() {
+  const app = new Appium({
+    platform: 'Android',
+    desiredCapabilities: {
+      platformName: 'Android',
+    },
+  })
+  app.browser = { execute: sinon.stub() }
+  return app
+}
+
+describe('Appium #setNetworkConnection, #grabNetworkConnection', () => {
+  it('should call mobile: setConnectivity with airplane mode only for value 1', async () => {
+    const app = createApp()
+    await app.setNetworkConnection(1)
+    expect(app.browser.execute.calledWith('mobile: setConnectivity', { airplaneMode: true, wifi: false, data: false })).to.be.true
+  })
+
+  it('should call mobile: setConnectivity with wifi only for value 2', async () => {
+    const app = createApp()
+    await app.setNetworkConnection(2)
+    expect(app.browser.execute.calledWith('mobile: setConnectivity', { airplaneMode: false, wifi: true, data: false })).to.be.true
+  })
+
+  it('should call mobile: setConnectivity with data only for value 4', async () => {
+    const app = createApp()
+    await app.setNetworkConnection(4)
+    expect(app.browser.execute.calledWith('mobile: setConnectivity', { airplaneMode: false, wifi: false, data: true })).to.be.true
+  })
+
+  it('should call mobile: setConnectivity with wifi and data for value 6', async () => {
+    const app = createApp()
+    await app.setNetworkConnection(6)
+    expect(app.browser.execute.calledWith('mobile: setConnectivity', { airplaneMode: false, wifi: true, data: true })).to.be.true
+  })
+
+  it('should call mobile: setConnectivity with everything off for value 0', async () => {
+    const app = createApp()
+    await app.setNetworkConnection(0)
+    expect(app.browser.execute.calledWith('mobile: setConnectivity', { airplaneMode: false, wifi: false, data: false })).to.be.true
+  })
+
+  it('should grab network connection using mobile: getConnectivity and map to legacy bitmask shape', async () => {
+    const app = createApp()
+    app.browser.execute.resolves({ airplaneMode: false, wifi: false, data: true })
+    const val = await app.grabNetworkConnection()
+    expect(app.browser.execute.calledWith('mobile: getConnectivity')).to.be.true
+    expect(val.value).to.equal(4)
+    expect(val.inAirplaneMode).to.equal(false)
+    expect(val.hasWifi).to.equal(false)
+    expect(val.hasData).to.equal(true)
+  })
+
+  it('should grab network connection with wifi and airplane mode combined', async () => {
+    const app = createApp()
+    app.browser.execute.resolves({ airplaneMode: true, wifi: true, data: false })
+    const val = await app.grabNetworkConnection()
+    expect(val.value).to.equal(3)
+    expect(val.inAirplaneMode).to.equal(true)
+    expect(val.hasWifi).to.equal(true)
+    expect(val.hasData).to.equal(false)
+  })
+
+  it('should throw when used outside android platform', async () => {
+    const app = new Appium({
+      platform: 'iOS',
+      desiredCapabilities: {
+        platformName: 'iOS',
+      },
+    })
+    app.browser = { execute: sinon.stub() }
+    let error
+    try {
+      await app.setNetworkConnection(1)
+    } catch (err) {
+      error = err
+    }
+    expect(error).to.be.instanceOf(Error)
+  })
+})


### PR DESCRIPTION
## Summary
- Replaces the deprecated WebdriverIO `getNetworkConnection`/`setNetworkConnection` protocol calls in `Appium.grabNetworkConnection()`/`Appium.setNetworkConnection()` with the recommended Appium `mobile: getConnectivity`/`mobile: setConnectivity` execute commands, removing the `[WEBDRIVERIO DEPRECATION NOTICE]` console warnings introduced by `@wdio/protocols` 9.27.2+.
- `grabNetworkConnection()` keeps its original return shape (`value`/`inAirplaneMode`/`hasWifi`/`hasData`) by re-encoding the new `{wifi, data, airplaneMode}` response back into the legacy bitmask, so existing test code that inspects `.value` isn't broken.
- Command names and parameter shapes were verified against the actual `appium-android-driver` source (`execute-method-map.ts`, `commands/network.ts`).

## Known limitation
`mobile: setConnectivity`/`mobile: getConnectivity` were added to `appium-android-driver` in April 2023. Users still running with `appiumV2: false` (Appium 1.x, unmaintained since 2022) will not have these commands available on the server side.

Fixes #5619

## Test plan
- [x] Added `test/unit/helper/Appium_networkConnection_test.js` covering the bitmask encode/decode logic for both methods and the Android platform guard
- [x] `npx mocha test/unit/helper/Appium_networkConnection_test.js` passes (8/8)
- [x] `npx prettier --check lib/helper/Appium.js test/unit/helper/Appium_networkConnection_test.js` passes
- [ ] Real-device verification against Sauce Labs Android (existing tests in `test/helper/Appium_test.js` cover this method but are not currently tagged `@quick`/`@second`, so they don't run in CI — pre-existing gap, unrelated to this change)