### PR TITLE
fix(junit): preserve suite identity for hook failures reported from workers

### DIFF
--- a/lib/mocha/hooks.js
+++ b/lib/mocha/hooks.js
@@ -33,12 +33,22 @@ class Hook {
   }
 
   simplify() {
+    // this.runnable (context.ctx.test) is the hook's own runnable; its
+    // .parent is the real Mocha Suite that owns this hook. Included here so
+    // run-workers can forward suite identity to the main process, where
+    // listeners (e.g. junitReporter) have no other way to recover it — the
+    // worker's live Suite/ctx objects aren't serializable across the thread
+    // boundary, only these plain fields are.
+    const suite = this.runnable?.parent
     return {
       hookName: this.hookName,
       title: this.title,
       // test: this.test ? serializeTest(this.test) : null,
       // suite: this.suite ? serializeSuite(this.suite) : null,
       error: this.err ? serializeError(this.err) : null,
+      suiteTitle: suite?.title || null,
+      suiteFile: suite?.file || null,
+      suiteTags: suite?.tags || [],
     }
   }
 

--- a/lib/plugin/junitReporter.js
+++ b/lib/plugin/junitReporter.js
@@ -67,13 +67,29 @@ export default function (config = {}) {
 
   let written = false
   const hookFailures = []
+  // groupBySuite() (below) groups by object identity, not by value — reused
+  // across BeforeSuite/AfterSuite failures from the same worker-forwarded
+  // suite so they land in one <testsuite>, not one per failure.
+  const workerSuiteByKey = new Map()
 
   event.dispatcher.on(event.hook.failed, hook => {
     if (!hook || !['BeforeSuite', 'AfterSuite'].includes(hook.hookName)) return
     const err = hook.err || hook.error
     if (!err) return
     const runnable = hook.ctx && hook.ctx.test
-    const suite = runnable && runnable.parent
+    // Under run-workers, hook.ctx is absent — the failure arrives as the
+    // plain object from Hook.simplify() in the main process instead of a
+    // live Hook instance. Fall back to the suiteTitle/suiteFile/suiteTags
+    // simplify() carries across the worker boundary so the failure still
+    // groups under its real suite instead of the "Tests" fallback.
+    let suite = runnable && runnable.parent
+    if (!suite && hook.suiteTitle) {
+      const key = `${hook.suiteTitle} ${hook.suiteFile || ''}`
+      if (!workerSuiteByKey.has(key)) {
+        workerSuiteByKey.set(key, { title: hook.suiteTitle, file: hook.suiteFile, tags: hook.suiteTags })
+      }
+      suite = workerSuiteByKey.get(key)
+    }
     hookFailures.push({
       title: hook.title || `${hook.hookName} hook failed`,
       state: 'failed',

--- a/test/data/sandbox/codecept.workers-junit.conf.js
+++ b/test/data/sandbox/codecept.workers-junit.conf.js
@@ -1,0 +1,20 @@
+export const config = {
+  tests: './workers-junit-suite-hooks/*.js',
+  timeout: 10000,
+  output: './output',
+  helpers: {
+    FileSystem: {},
+    Workers: {
+      require: './workers_helper',
+    },
+  },
+  include: {},
+  async bootstrap() {},
+  mocha: {},
+  plugins: {
+    junitReporter: {
+      enabled: true,
+    },
+  },
+  name: 'sandbox',
+}

--- a/test/data/sandbox/workers-junit-suite-hooks/junit_suite_hooks.worker.js
+++ b/test/data/sandbox/workers-junit-suite-hooks/junit_suite_hooks.worker.js
@@ -1,0 +1,13 @@
+Feature('JunitWorkerSuiteHooks')
+
+BeforeSuite(async () => {
+  throw new Error('BeforeSuite worker failure')
+})
+
+Scenario('should not be executed either', ({ I }) => {
+  I.say('unreachable')
+})
+
+AfterSuite(async () => {
+  throw new Error('AfterSuite worker failure')
+})

--- a/test/runner/run_workers_test.js
+++ b/test/runner/run_workers_test.js
@@ -6,6 +6,7 @@ import fs from 'fs'
 import semver from 'semver'
 import { exec } from 'child_process'
 import { fileURLToPath } from 'url'
+import xml2js from 'xml2js'
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 
@@ -509,6 +510,34 @@ describe('CodeceptJS Workers Runner', function () {
         expect(err?.code || 0).toEqual(err2?.code || 0)
         done()
       })
+    })
+  })
+
+  it('should preserve suite identity for BeforeSuite/AfterSuite hook failures in the JUnit report', function (done) {
+    if (!semver.satisfies(process.version, '>=11.7.0')) this.skip('not for node version')
+    const reportFile = path.join(codecept_dir, 'output', 'report.xml')
+    if (fs.existsSync(reportFile)) fs.rmSync(reportFile)
+
+    exec(`${codecept_run_glob('codecept.workers-junit.conf.js')} 1`, (err, stdout) => {
+      ;(async () => {
+        expect(stdout).toContain('BeforeSuite worker failure')
+        expect(stdout).toContain('AfterSuite worker failure')
+        expect(err.code).toEqual(1)
+
+        expect(fs.existsSync(reportFile)).toEqual(true)
+        const parsed = await new xml2js.Parser().parseStringPromise(fs.readFileSync(reportFile, 'utf8'))
+
+        // Both hook failures must land under the real suite name, grouped into a
+        // single <testsuite>, not split across two <testsuite name="Tests"> elements.
+        expect(parsed.testsuites.testsuite).toHaveLength(1)
+        const suiteEl = parsed.testsuites.testsuite[0]
+        expect(suiteEl.$.name).toEqual('JunitWorkerSuiteHooks')
+        expect(suiteEl.testcase).toHaveLength(2)
+
+        const names = suiteEl.testcase.map(tc => tc.$.name)
+        expect(names.some(n => n.includes('BeforeSuite'))).toEqual(true)
+        expect(names.some(n => n.includes('AfterSuite'))).toEqual(true)
+      })().then(done, done)
     })
   })
 


### PR DESCRIPTION
## What's the bug

Under `run-workers`, when a `BeforeSuite`/`AfterSuite` hook fails, the JUnit report puts the failure under a generic `<testsuite name="Tests">` instead of the suite that actually failed, and each failure gets split into its own `<testsuite>` element instead of being grouped with other failures from the same suite.

This is a follow-up to #5657, which fixed the main bug from #5645 (hook failures not appearing in the report at all). That PR's description explicitly notes this as a known limitation:

> Under `run-workers` the forwarded payload (`hook.simplify()`) doesn't carry the suite, so hook-failure testcases group under a fallback `Tests` suite instead of the feature title. Fixable later by including the suite title in the worker message.

This PR does that.

## Root cause

`lib/plugin/junitReporter.js`'s `event.hook.failed` listener reads the suite from `hook.ctx.test.parent`:

```js
const runnable = hook.ctx && hook.ctx.test
const suite = runnable && runnable.parent
```

On the main thread `hook.ctx` is a live Mocha context and this works (verified separately with a real Mocha run — `ctx.test` for a suite-level hook is the hook's own runnable, and `runnable.parent` is the real Suite). But under `run-workers`, the failure is forwarded from the worker process via `Hook.simplify()` (`lib/mocha/hooks.js`):

```js
simplify() {
  return {
    hookName: this.hookName,
    title: this.title,
    error: this.err ? serializeError(this.err) : null,
  }
}
```

No `ctx`, so `runnable` and `suite` are both `undefined` for every worker-forwarded hook failure. `buildXml`'s `groupBySuite` then keys each failure by itself (`test.parent || test`), and the suite name falls back to the literal `'Tests'`:

```js
const suiteName = (suite && suite.title) || 'Tests'
```

## Fix

`Hook.simplify()` now also serializes the suite identity from `this.runnable.parent` (the same object the main-thread path already reads successfully):

```js
simplify() {
  const suite = this.runnable?.parent
  return {
    hookName: this.hookName,
    title: this.title,
    error: this.err ? serializeError(this.err) : null,
    suiteTitle: suite?.title || null,
    suiteFile: suite?.file || null,
    suiteTags: suite?.tags || [],
  }
}
```

`junitReporter.js`'s listener falls back to these fields when `hook.ctx` is absent, reusing one synthetic suite object per `title+file` pair so multiple failures from the same worker-reported suite still group into a single `<testsuite>` instead of one per failure:

```js
let suite = runnable && runnable.parent
if (!suite && hook.suiteTitle) {
  const key = `${hook.suiteTitle} ${hook.suiteFile || ''}`
  if (!workerSuiteByKey.has(key)) {
    workerSuiteByKey.set(key, { title: hook.suiteTitle, file: hook.suiteFile, tags: hook.suiteTags })
  }
  suite = workerSuiteByKey.get(key)
}
```

## Reproduction steps

1. `tests/My_test.js`:
   ```js
   Feature('My');
   BeforeSuite(async () => { throw new Error('Before Suite Error'); });
   Scenario('test something', () => {});
   AfterSuite(async () => { throw new Error('After Suite Error'); });
   ```
2. `codecept.conf.js` with `junitReporter: { enabled: true }`
3. Run: `node bin/codecept.js run-workers 2 --config codecept.conf.js`
4. Inspect `output/report.xml`

Before this change:
```
testsuite name="Tests"
testsuite name="Tests"
```

After:
```
testsuite name="My"
```
(single element, both failures grouped inside)

## Edge cases verified

All run against the actual `run-workers` command, not simulated.

| Scenario | Before | After |
|---|---|---|
| BeforeSuite + AfterSuite fail, same suite, run-workers | 2x `<testsuite name="Tests">`, one testcase each | 1x `<testsuite name="My">`, both testcases inside |
| Two different suites each with a failing BeforeSuite/AfterSuite, run-workers | not tested pre-fix (same "Tests" collapse issue) | each suite gets its own correctly-named `<testsuite>`; no cross-suite mixing |
| Per-test `Before` hook failure (not BeforeSuite/AfterSuite), run-workers | unaffected (different hookName, filtered out before this code path) | unaffected, same as before |
| Plain `Scenario` failure (no hook failure at all), run-workers | unaffected (goes through `result.tests`, not `hookFailures`) | unaffected, same as before |
| Main-thread (no `run-workers`) BeforeSuite/AfterSuite failure | correct suite name (existing `hook.ctx` path) | unchanged — this path doesn't touch the new fallback at all |

Existing test suite: `mocha test/unit/junitReporter_test.js` — 10/10 passing, including the two hook-failure tests already in that file.
Full suite: `mocha test/unit` — 761 passing, 11 pending, 0 failing.
`mocha test/runner` — 275 passing, 2 pending, 0 failing.

## Out of scope

`lib/listener/result.js` also listens on `event.hook.failed` but only for stats counting (`failedHooks`), unaffected by this change. The other known limitation mentioned in #5657 (`_beforeSuite`/`_afterSuite` helper-level failures via `suiteSetup`/`suiteTeardown` not emitting `event.hook.failed` at all) is a separate, pre-existing gap not touched here.