### PR TITLE
fix(typings): add ARIA locators to ILocator

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -464,6 +464,7 @@ declare namespace CodeceptJS {
     | { shadow: string[] }
     | { custom: string }
     | { pw: string }
+    | { role: string; name?: string; text?: string; exact?: boolean }
   interface CustomLocators {}
   interface OtherLocators {
     props?: object


### PR DESCRIPTION
## Motivation/Description of the PR

ARIA locators (`{ role: 'button', text: 'Submit' }` / `{ role: 'button', name: 'Login' }`) work at runtime since #5260 and are documented in `docs/locators.md`, but `CodeceptJS.ILocator` never included them - TypeScript reports `TS2353: 'role' does not exist in type 'ILocator'`.

Adds:

```ts
| { role: string; name?: string; text?: string; exact?: boolean }
```

Optional `text` / `exact` match the acceptance tests and WebDriver; `name` matches the docs and Playwright/Puppeteer.

Applicable helpers:

- [ ] Playwright
- [ ] Puppeteer
- [ ] WebDriver
- [ ] REST
- [ ] FileHelper
- [ ] Appium

Applicable plugins:

- [ ] aiTrace
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pause
- [ ] coverage
- [ ] heal
- [ ] retryFailedStep
- [ ] screenshot
- [ ] selenoid
- [ ] stepTimeout
- [ ] subtitles

## Type of change

- [ ] 🔥  Breaking changes
- [ ] 🚀  New functionality
- [x] 🐛  Bug fix
- [ ] 🧹 Chore
- [ ] 📋  Documentation changes/updates
- [ ] ♨️  Hot fix
- [ ] 🔨  Markdown files fix - not related to source code
- [ ] 💅  Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)