### PR TITLE
Fixes run-rerun

### DIFF
--- a/lib/rerun.js
+++ b/lib/rerun.js
@@ -10,6 +10,8 @@ import { resolveImportModulePath } from './utils.js'
 const require = createRequire(import.meta.url)
 
 class CodeceptRerunner extends BaseCodecept {
+  rerunId = 0
+
   async runOnce(test) {
     await container.started()
 
@@ -40,23 +42,23 @@ class CodeceptRerunner extends BaseCodecept {
         mocha.suite.suites = []
         mocha.suite.tests = []
 
-        // Manually load each test file by importing it
+        // Load every test into the fresh Mocha instance. The lifecycle events
+        // provide Feature/Scenario to test files when noGlobals is enabled.
         for (const file of filesToRun) {
-          try {
-            // Clear CommonJS cache if available (for mixed environments)
-            try {
-              delete require.cache[file]
-            } catch (e) {
-              // ESM modules don't have require.cache, ignore
-            }
+          const absolutePath = fsPath.resolve(file)
+          mocha.suite.emit('pre-require', global, absolutePath, mocha)
 
-            // Force reload the module by using a cache-busting query parameter
-            const fileUrl = `${fsPath.resolve(file)}`
-            const resolvedPath = resolveImportModulePath(fileUrl)
-            await import(resolvedPath)
-          } catch (e) {
-            console.error(`Error loading test file ${file}:`, e)
-          }
+          try {
+            delete require.cache[require.resolve(absolutePath)]
+          } catch {}
+
+          const resolvedPath = resolveImportModulePath(absolutePath)
+          const fileUrl = new URL(resolvedPath)
+          fileUrl.searchParams.set('codeceptjsRerun', String(++this.rerunId))
+          const testModule = await import(fileUrl.href)
+
+          mocha.suite.emit('require', testModule, absolutePath, mocha)
+          mocha.suite.emit('post-require', global, absolutePath, mocha)
         }
 
         const done = () => {

--- a/test/data/sandbox/configs/run-rerun/codecept.conf.js
+++ b/test/data/sandbox/configs/run-rerun/codecept.conf.js
@@ -1,6 +1,7 @@
 export const config = {
   tests: './*_test.js',
   output: './output',
+  noGlobals: true,
   helpers: {
     CustomHelper: {
       require: './customHelper.js',

--- a/test/runner/run_rerun_test.js
+++ b/test/runner/run_rerun_test.js
@@ -50,7 +50,7 @@ describe('run-rerun command', function () {
     expect(stdout).toContain('Process run 1 of max 3, success runs 1/3');
     expect(stdout).toContain('Process run 2 of max 3, success runs 2/3');
     expect(stdout).toContain('Process run 3 of max 3, success runs 3/3');
-    expect(stdout).toContain('1 passed');
+    expect(stdout.match(/OK\s+\|\s+1 passed/g)).toHaveLength(3);
     expect(err).toBeNull();
   });
 
@@ -77,7 +77,9 @@ describe('run-rerun command', function () {
     const { err, stdout } = await safeExec(`${codecept_run_config('codecept.conf.fail_test.js', '@RunRerun - Fail all attempt')} --debug`);
 
     expect(stdout).toContain('Fail run 1 of max 3, success runs 0/2');
-    expect(stdout).toContain('Process run 3 of max 3, success runs 2/2');
+    expect(stdout).toContain('Fail run 2 of max 3, success runs 0/2');
+    expect(stdout).toContain('Fail run 3 of max 3, success runs 0/2');
+    expect(stdout).toContain('Flaky tests detected!');
     expect(err.code).toBe(1);
   });
 
@@ -88,7 +90,8 @@ describe('run-rerun command', function () {
     );
 
     expect(stdout).toContain('Process run 1 of max 3, success runs 1/2');
-    expect(stdout).toContain('Process run 2 of max 3, success runs 2/2');
+    expect(stdout).toContain('Fail run 2 of max 3, success runs 1/2');
+    expect(stdout).toContain('Process run 3 of max 3, success runs 2/2');
     expect(err).toBeNull();
   });
 
@@ -99,6 +102,9 @@ describe('run-rerun command', function () {
     );
 
     expect(stdout).toContain('Process run 1 of max 3, success runs 1/3');
-    expect(stdout).toContain('Process run 3 of max 3, success runs 3/3');
+    expect(stdout).toContain('Fail run 2 of max 3, success runs 1/3');
+    expect(stdout).toContain('Process run 3 of max 3, success runs 2/3');
+    expect(stdout).toContain('Flaky tests detected!');
+    expect(err.code).toBe(1);
   });
 });


### PR DESCRIPTION
  ## Summary

  Fixes `run-rerun`  https://github.com/codeceptjs/CodeceptJS/issues/5666

  - with `noGlobals: true`, test loading failed with `ReferenceError: Feature is not defined`;
  - with `noGlobals: false`, only the first run executed tests, while subsequent runs reported `0 passed` because test modules were cached.