### PR TITLE
fix(appium): skip data connectivity on devices without telephony (#5677)

### DIFF
--- a/lib/helper/Appium.js
+++ b/lib/helper/Appium.js
@@ -978,11 +978,23 @@ class Appium extends Webdriver {
    */
   async setNetworkConnection(value) {
     onlyForApps.call(this, supportedPlatform.android)
-    return this.browser.execute('mobile: setConnectivity', {
+    const connectivity = {
       airplaneMode: !!(value & 1),
       wifi: !!(value & 2),
       data: !!(value & 4),
-    })
+    }
+    // `mobile: setConnectivity` runs `adb shell svc data <state>` for every field it receives,
+    // which fails with "Can't find service: phone" on images without telephony (e.g. tablets).
+    // Only a positive result is cached: a freshly booted device may not have registered a carrier
+    // yet, and caching that would strip `data` for the whole session.
+    if (!this._hasTelephony) {
+      const deviceInfo = await this.browser.execute('mobile: deviceInfo')
+      this._hasTelephony = !!deviceInfo?.carrierName
+    }
+    // Keep `data` on telephony-capable devices, otherwise the device stays online over cellular
+    // and going offline silently does nothing.
+    if (!this._hasTelephony) delete connectivity.data
+    return this.browser.execute('mobile: setConnectivity', connectivity)
   }
 
   /**

--- a/test/unit/helper/Appium_networkConnection_test.js
+++ b/test/unit/helper/Appium_networkConnection_test.js
@@ -2,7 +2,7 @@ import { expect } from 'chai'
 import sinon from 'sinon'
 import Appium from '../../../lib/helper/Appium.js'
 
-function createApp() {
+function createApp(deviceInfo = { carrierName: 'T-Mobile' }) {
   const app = new Appium({
     platform: 'Android',
     desiredCapabilities: {
@@ -10,6 +10,7 @@ function createApp() {
     },
   })
   app.browser = { execute: sinon.stub() }
+  app.browser.execute.withArgs('mobile: deviceInfo').resolves(deviceInfo)
   return app
 }
 
@@ -42,6 +43,29 @@ describe('Appium #setNetworkConnection, #grabNetworkConnection', () => {
     const app = createApp()
     await app.setNetworkConnection(0)
     expect(app.browser.execute.calledWith('mobile: setConnectivity', { airplaneMode: false, wifi: false, data: false })).to.be.true
+  })
+
+  it('should omit data on devices without telephony', async () => {
+    const app = createApp({ carrierName: '' })
+    await app.setNetworkConnection(1)
+    expect(app.browser.execute.calledWith('mobile: setConnectivity', { airplaneMode: true, wifi: false })).to.be.true
+  })
+
+  it('should probe telephony again while no carrier was seen yet', async () => {
+    const app = createApp({ carrierName: '' })
+    await app.setNetworkConnection(1)
+    app.browser.execute.withArgs('mobile: deviceInfo').resolves({ carrierName: 'T-Mobile' })
+    await app.setNetworkConnection(2)
+    expect(app.browser.execute.withArgs('mobile: deviceInfo').callCount).to.equal(2)
+    expect(app.browser.execute.calledWith('mobile: setConnectivity', { airplaneMode: false, wifi: true, data: false })).to.be.true
+  })
+
+  it('should probe telephony only once after a carrier was seen', async () => {
+    const app = createApp()
+    await app.setNetworkConnection(1)
+    await app.setNetworkConnection(6)
+    expect(app.browser.execute.withArgs('mobile: deviceInfo').callCount).to.equal(1)
+    expect(app.browser.execute.calledWith('mobile: setConnectivity', { airplaneMode: false, wifi: true, data: true })).to.be.true
   })
 
   it('should grab network connection using mobile: getConnectivity and map to legacy bitmask shape', async () => {


### PR DESCRIPTION
Fixes #5677

### Problem

`mobile: setConnectivity` runs `adb shell svc <type> <state>` for **every** field it is passed, so always sending `data` makes `setNetworkConnection()` fail on system images without telephony (e.g. tablet emulators, `ro.build.characteristics=tablet`):

```
WebDriverError: Error executing adbExec. Original error: 'Command
'... shell svc data disable' exited with code 20'; Command output: cmd: Can't find service: phone
```

This is a regression in 4.1.0 — #5662 replaced the legacy `setNetworkConnection` command, which tolerated the missing phone service. It takes down whole suites when the call sits in a `_beforeSuite` hook.

### Fix

Probe `mobile: deviceInfo` for a carrier and only send `data` when the device actually has telephony.

Dropping `data` unconditionally is *not* an option: on a telephony-capable device it leaves cellular up, so `setNetworkConnection(1)` keeps the device online and "go offline" silently does nothing.

```
# Android 13 emulator (has telephony), after mobile: setConnectivity
{airplaneMode:true, wifi:false}             -> Active default network: 106 (MOBILE still CONNECTED)
{airplaneMode:true, wifi:false, data:false} -> Active default network: none
```

Only a **positive** probe result is cached. The first `setNetworkConnection` of a run typically happens in a suite-setup hook, seconds after the emulator boots — a real phone whose modem has not registered a carrier yet would report an empty `carrierName` there, and caching that negative would strip `data` for the rest of the session. Guarding with `!this._hasTelephony` re-asks until a carrier appears, then stops probing.

| `_hasTelephony` | behaviour |
| --- | --- |
| `undefined` — never probed | probe |
| `false` — probed, no carrier seen | re-probe |
| `true` — probed, carrier seen | skip |

The cost is one extra `mobile: deviceInfo` per call on a genuinely telephony-less device. That is a plain info read, so unlike the send-and-catch alternative it provokes no exception and adds no red `ERROR webdriver:` line to tablet runs.

`carrierName` is still reported while airplane mode is on, so the probe is not perturbed by the connectivity state being changed. `grabNetworkConnection()` is unaffected — `mobile: getConnectivity` works on these images.

### Verified

Unit tests added for the telephony-less payload, the re-probe while no carrier has been seen, and probe-once-then-cache after a carrier appears. Full file passes (11 passing).

Verified as a patch against 4.1.0 on two live emulators — `sdk_gtablet_x86_64` (Android 15, no telephony) and `sdk_gphone64_x86_64` (Android 13, carrier `T-Mobile`):

| suite / test | image | result |
| --- | --- | --- |
| `NetworkConnectionIndicator` | Android 15 tablet | 6 passed |
| `NetworkConnectionIndicator` | Android 13 phone | 6 passed |
| `StudentAttendance` | Android 13 phone | 54 passed |
| `DndGameWithoutLessonPath` | Android 15 tablet | 8 passed |

No `ERROR webdriver:` line and no `Can't find service: phone` in any run. `StudentAttendance` is the test that originally caught the dropped-`data` failure, so its 54 passing scenarios confirm going offline still genuinely disconnects on a telephony-capable device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
