### PR TITLE
fix(parser): inject params into one-line non-async arrow scenarios

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -4,7 +4,8 @@ function _interopDefault(ex) {
 import * as acorn from 'acorn'
 import parseFunctionModule from 'parse-function'
 const parseFunction = _interopDefault(parseFunctionModule)
-const parser = parseFunction({ parse: acorn.parse, ecmaVersion: 11, plugins: ['objectRestSpread'] })
+const ecmaVersion = 11
+const parser = parseFunction({ parse: acorn.parse, ecmaVersion, plugins: ['objectRestSpread'] })
 import output from './output.js'
 
 parser.use(destructuredArgs)
@@ -17,7 +18,7 @@ export const getParamsToString = function (fn) {
 function getParams(fn, { warnOnLegacyFormat = false } = {}) {
   if (fn.isSinonProxy) return []
   try {
-    const reflected = parser.parse(fn)
+    const reflected = parser.parse(normalizeArrowFn(fn))
     if (warnOnLegacyFormat && (reflected.args.length > 1 || reflected.args[0] === 'I')) {
       output.error('Error: old CodeceptJS v2 format detected. Upgrade your project to the new format -> https://bit.ly/codecept3Up')
     }
@@ -37,6 +38,17 @@ function getParams(fn, { warnOnLegacyFormat = false } = {}) {
 }
 
 export { getParams }
+
+function normalizeArrowFn(fn) {
+  const code = (typeof fn === 'function' ? fn.toString() : String(fn)).trim()
+  if (!code.includes('=>') || code.startsWith('async')) return fn
+  try {
+    if (acorn.parseExpressionAt(code, 0, { ecmaVersion }).type !== 'ArrowFunctionExpression') return fn
+  } catch {
+    return fn
+  }
+  return `async ${code}`
+}
 
 function destructuredArgs() {
   return (node, result) => {

--- a/test/unit/parser_test.js
+++ b/test/unit/parser_test.js
@@ -40,5 +40,19 @@ describe('parser', () => {
     it('should get params for class method with destructured args', () => {
       expect(getParams(obj.method5)).to.eql(['locator', 'sec'])
     })
+
+    // prettier-ignore
+    const fixturesOneLineArrows = [
+      ['destructured args and a condition', ({ locator, sec }) => { if (true) { return locator } }, ['locator', 'sec']],
+      ['a single arg and a condition', locator => { if (true) { return locator } }, ['locator']],
+      ['multiple args and a loop', (locator, sec) => { for (;;) { return locator || sec } }, ['locator', 'sec']],
+      ['a nested arrow function', ({ locator, sec }) => { [locator].forEach((l) => { if (l) { return sec } }) }, ['locator', 'sec']],
+    ]
+
+    fixturesOneLineArrows.forEach(([title, fn, params]) => {
+      it(`should get params for one-line arrow function with ${title}`, () => {
+        expect(getParams(fn)).to.eql(params)
+      })
+    })
   })
 })


### PR DESCRIPTION
Fixes #5679

## Problem

`Scenario('...', ({ I }) => { if (true) { I.say('hello') } })` injects nothing — `I`, page objects and `current` are all `undefined`, and the test dies with `TypeError: Cannot read properties of undefined`.

`parse-function@5.6.10` decides whether its input is an ES6 object method with:

```js
const isMethod = /^\*?.+\([\S\W]*\)\s*{/i.test(result.value)
if (!(isFunction || isAsyncFn || isAsyncArrow) && isMethod) result.value = `{ ${result.value} }`
```

The greedy `.+` combined with `[\S\W]*` matches any source containing a `) {` sequence, so a non-async arrow whose body holds an `if`, `for`, `while` or `switch` is wrapped in braces as a fake object method and acorn throws. `getParams()` logs the `SyntaxError` and returns `undefined`.

Async arrows escape via the library's own `isAsyncArrow` check. In plain JavaScript a multi-line arrow escapes too, because `.` does not cross a newline. **That second escape does not exist under TypeScript** — `tsx`/`esbuild` emit every function on one line, so `fn.toString()` returns the one-line form however the source was written. In a TypeScript suite every non-async scenario with destructured params and a conditional fails, which is why this surfaced as a 4.0 regression.

## Fix

`normalizeArrowFn()` asks acorn whether the source really is an `ArrowFunctionExpression` and, if so, hands `parse-function` `async <source>` so it takes the `isAsyncArrow` branch instead of the method-wrapping one.

Anything acorn does not confirm as an arrow — class methods, generators, function expressions, strings, unparseable input — is returned untouched, so only input that already fails is affected. The prefix cannot change a parameter list, and default values stay correct because their offsets are sliced from the same prefixed string.

`ecmaVersion` becomes a shared const so the parse and the arrow check cannot drift apart. **Its value is unchanged**, so no syntax gains or loses parseability.

## Verification

| Check | Result |
|---|---|
| New tests with `lib/parser.js` reverted | 4 failing |
| New tests with the fix | 12 passing (8 pre-existing + 4 new) |
| Differential vs. the old parser, 47 function shapes, both `getParams` and `getParamsToString` | **0 regressions**, 15 fixes |
| `npm run test:unit` | 773 passed, 0 failed |
| `npm run test:runner` | 276 passed, 0 failed |
| Repro from the issue, incl. `Data().Scenario(({ current }) => ...)` | 4 passed, params injected |

The differential corpus covered class methods, async/static methods, getters, generators and async generators, function expressions, expression-body arrows, rest params, default values (numeric, string, call expressions), nested arrows, strings containing `=>`, sinon proxies, string inputs and garbage input.

## Not included

A one-line arrow whose body uses **ES2021+ syntax** (`??=`, `||=`, numeric separators, class fields) still gets no params, because `ecmaVersion: 11` pins the parser to ES2020. That is a separate, pre-existing defect with the same symptom — unrelated to the `isMethod` misdetection and unchanged by this PR. Raising it to `'latest'` fixes it and was green on both suites, but it is deliberately left out to keep this PR to the reported bug. Happy to add it here or in a follow-up if maintainers prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)