### PR TITLE
fix(helpers): restore substring matching in waitInUrl

### DIFF
--- a/docs/migration-4.md
+++ b/docs/migration-4.md
@@ -614,7 +614,7 @@ Test files written for 3.x keep working until you flip the flag.
 
 ### `wait*` Methods Resolve Relative URLs
 
-`waitInUrl`, `waitUrlEquals`, and `waitCurrentPathEquals` now resolve a relative path against the helper's configured `url` before comparing. In 3.x a literal substring match against `window.location.href` would fail for relative paths.
+`waitUrlEquals` and `waitCurrentPathEquals` now resolve a relative path against the helper's configured `url` before comparing. In 3.x a literal comparison against `window.location.href` would fail for relative paths.
 
 ```js
 // helpers: { Playwright: { url: 'https://app.example.com' } }
@@ -622,6 +622,8 @@ Test files written for 3.x keep working until you flip the flag.
 I.waitUrlEquals('/dashboard')   // matches https://app.example.com/dashboard
 I.waitInUrl('/users')           // matches any URL containing /users
 ```
+
+`waitInUrl` is unchanged from 3.x — it stays a plain substring match against the current URL and never resolves its argument.
 
 `waitUrlEquals` error messages now include the actual URL the page was on when the wait timed out — easier to diagnose `/dashboard` vs `/dashboard?session=expired`.
 

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -3423,7 +3423,6 @@ class Playwright extends Helper {
    */
   async waitInUrl(urlPart, sec = null) {
     const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout
-    const expectedUrl = resolveUrl(urlPart, this.options.url)
 
     return this.page
       .waitForFunction(
@@ -3431,13 +3430,13 @@ class Playwright extends Helper {
           const currUrl = decodeURIComponent(decodeURIComponent(decodeURIComponent(window.location.href)))
           return currUrl.indexOf(urlPart) > -1
         },
-        expectedUrl,
+        urlPart,
         { timeout: waitTimeout },
       )
       .catch(async e => {
         const currUrl = await this._getPageUrl()
         if (/Timeout/i.test(e.message)) {
-          throw new Error(`expected url to include ${expectedUrl}, but found ${currUrl}`)
+          throw new Error(`expected url to include ${urlPart}, but found ${currUrl}`)
         } else {
           throw e
         }

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -2501,7 +2501,6 @@ class Puppeteer extends Helper {
    */
   async waitInUrl(urlPart, sec = null) {
     const waitTimeout = sec ? sec * 1000 : this.options.waitForTimeout
-    const expectedUrl = resolveUrl(urlPart, this.options.url)
 
     return this.page
       .waitForFunction(
@@ -2510,12 +2509,12 @@ class Puppeteer extends Helper {
           return currUrl.indexOf(urlPart) > -1
         },
         { timeout: waitTimeout },
-        expectedUrl,
+        urlPart,
       )
       .catch(async e => {
         const currUrl = await this._getPageUrl()
         if (/Waiting failed:/i.test(e.message) || /failed: timeout/i.test(e.message)) {
-          throw new Error(`expected url to include ${expectedUrl}, but found ${currUrl}`)
+          throw new Error(`expected url to include ${urlPart}, but found ${currUrl}`)
         } else {
           throw e
         }

--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -2521,7 +2521,6 @@ class WebDriver extends Helper {
   async waitInUrl(urlPart, sec = null) {
     const client = this.browser
     const aSec = sec || this.options.waitForTimeoutInSeconds
-    const expectedUrl = resolveUrl(urlPart, this.options.url)
     let currUrl = ''
 
     return client
@@ -2529,7 +2528,7 @@ class WebDriver extends Helper {
         function () {
           return this.getUrl().then(res => {
             currUrl = decodeUrl(res)
-            return currUrl.indexOf(expectedUrl) > -1
+            return currUrl.indexOf(urlPart) > -1
           })
         },
         { timeout: aSec * 1000 },
@@ -2537,7 +2536,7 @@ class WebDriver extends Helper {
       .catch(e => {
         e = wrapError(e)
         if (e.message.indexOf('timeout')) {
-          throw new Error(`expected url to include ${expectedUrl}, but found ${currUrl}`)
+          throw new Error(`expected url to include ${urlPart}, but found ${currUrl}`)
         }
         throw e
       })

--- a/test/helper/webapi.js
+++ b/test/helper/webapi.js
@@ -151,13 +151,24 @@ export function tests() {
 
   describe('#waitInUrl, #waitUrlEquals', () => {
     it('should wait part of the URL to match the expected', async () => {
+      await I.amOnPage('/info')
+      await I.waitInUrl('/info')
+      await I.waitInUrl(`${siteUrl}/info`)
+
+      let err
       try {
-        await I.amOnPage('/info')
-        await I.waitInUrl('/info')
         await I.waitInUrl('/info2', 0.1)
       } catch (e) {
-        assert.include(e.message, `expected url to include ${siteUrl}/info2, but found ${siteUrl}/info`)
+        err = e
       }
+      assert.isDefined(err, 'expected waitInUrl to time out')
+      assert.include(err.message, `expected url to include /info2, but found ${siteUrl}/info`)
+    })
+
+    it('should match a URL part that is not anchored at the base url', async () => {
+      await I.amOnPage('/info?user=test')
+      await I.waitInUrl('user=test')
+      await I.waitInUrl('/info?user=test')
     })
 
     it('should wait for the entire URL to match the expected', async () => {


### PR DESCRIPTION
## Motivation/Description of the PR

#5451 introduced `resolveUrl()` and wired it into `waitInUrl` alongside `waitUrlEquals`. For `waitUrlEquals` that is correct — a strict comparison genuinely needs the relative path resolved against the configured base url. For `waitInUrl` it silently turned a **substring** match into an **origin-anchored** one:

```js
// before #5451
return currUrl.indexOf(urlPart) > -1                        // '/users' matches ANY url containing /users

// after #5451
const expectedUrl = resolveUrl(urlPart, this.options.url)   // '/users' -> 'https://app.example.com/users'
return currUrl.indexOf(expectedUrl) > -1                    // scheme + host + port must now match exactly
```

| call | before #5451 | after #5451 |
|---|---|---|
| `I.waitInUrl('/users')` after a redirect to another host/port/scheme | passes | times out |
| `I.waitInUrl('user=test')` on `/info?user=test` | passes | resolves to `<base>/user=test`, times out |
| `I.waitInUrl('/app')` with `url: 'http://localhost'` but live on `127.0.0.1` | passes | times out |

This also contradicts the method's own docs — `docs/webapi/waitInUrl.mustache` ("Waiting for the part of the URL to match the expected") and `docs/migration-4.md`, which literally states `I.waitInUrl('/users')` "matches any URL containing /users". The docs described the old behavior; only the code changed.

**Fix:** `waitInUrl` compares against the raw `urlPart` again in Playwright, Puppeteer and WebDriver, and reports it unresolved in the timeout message. `resolveUrl` imports stay — `waitUrlEquals` still uses them.

This is strictly more permissive than current `4.x` for every realistic input (`resolveUrl('/x', base)` always ends in `/x`, so anything matching the resolved form also matches the raw form), so no currently-passing usage regresses.

**`waitUrlEquals` is deliberately untouched.** #5451 also tightened it from substring to strict equality in Playwright/Puppeteer; that matches the method's name, its docs and WebDriver's long-standing behavior, so it is out of scope here.

No issue was filed for this — it was found while upgrading. Resolves the `waitInUrl` half of the behavior change in #5451.

Applicable helpers:

- [x] Playwright
- [x] Puppeteer
- [x] WebDriver
- [ ] REST
- [ ] FileHelper
- [ ] Appium

> `Appium` extends `WebDriver` and does not override `waitInUrl`, so it inherits the fix without a code change of its own.

Applicable plugins:

- [ ] aiTrace
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pause
- [ ] coverage
- [ ] heal
- [ ] retryFailedStep
- [ ] screenshot
- [ ] selenoid
- [ ] stepTimeout
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] 🧹 Chore
- [x] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [x] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [x] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)

Notes on the two unchecked boxes:

- **`npm run docs`** currently crashes on `4.x` before this PR as well — `TypeError: Cannot read properties of undefined (reading 'members')` at `runok.cjs:417` in `docsAppium`. Unrelated to this change and not fixed here. Regeneration is not needed anyway: `docs/webapi/waitInUrl.mustache` is unchanged (it already described the restored behavior), so the generated `docs/helpers/*.md` are byte-identical. `docs/migration-4.md` is hand-written and was updated in this PR.
- **`npm test`** was not run end to end; `test:unit` was (769 passing, 0 failing), but `test:rest` and `test:runner` were not. The helper suites that actually cover this change were run instead — see below.

### Testing

The existing test placed its `assert` **only inside `catch`**, so it passed vacuously whenever the wait unexpectedly succeeded — which is how this regression shipped. It now fails on a missing timeout, and a new case pins the bug.

Reverting only the helper change reproduces the regression in its own words:

```
Error: expected url to include http://127.0.0.1:8000/user=test, but found http://127.0.0.1:8000/info?user=test
```

Verified locally against the PHP test app:

| suite | result |
|---|---|
| Playwright — `waitInUrl` / `waitUrlEquals` / `waitCurrentPathEquals` | 6 passing |
| Puppeteer — same | 6 passing |
| WebDriver — same | 6 passing |
| Playwright / Puppeteer — url, path and tab-switching tests | 30 + 28 passing |
| `npm run test:unit` | 769 passing, 0 failing |
| `npm run lint` | clean |

The WebDriver leg was run through webdriverio's self-managed chromedriver rather than the Selenium container, which cannot complete its BiDi websocket handshake through Docker Desktop on macOS; CI covers the Selenium path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
