### PR TITLE
fix(junitReporter): stamp suites with their real start time

### DIFF
--- a/lib/listener/steps.js
+++ b/lib/listener/steps.js
@@ -16,6 +16,14 @@ const EXCLUDED_SESSIONS = ['tryTo', 'hopeThat']
  * Register steps inside tests
  */
 export default function () {
+  // Mocha's Suite has no start timestamp of its own, and junitReporter reads
+  // `suite.startedAt` for each `<testsuite timestamp>`. Without this the
+  // reporter falls back to `new Date()` at write time, stamping every suite
+  // with the moment the XML was serialized. (#5668)
+  event.dispatcher.on(event.suite.before, suite => {
+    suite.startedAt = +new Date()
+  })
+
   event.dispatcher.on(event.test.before, test => {
     test.startedAt = +new Date()
   })

--- a/test/unit/listener/steps_suite_started_at_test.js
+++ b/test/unit/listener/steps_suite_started_at_test.js
@@ -1,0 +1,45 @@
+import { expect } from 'chai'
+import event from '../../../lib/event.js'
+import recorder from '../../../lib/recorder.js'
+
+import stepsListener from '../../../lib/listener/steps.js'
+
+// junitReporter reads `suite.startedAt` for each `<testsuite timestamp>`.
+// Mocha never sets it, so before this listener existed the reporter fell back
+// to `new Date()` at write time. (#5668)
+describe('Steps Listener - suite.startedAt', () => {
+  beforeEach(() => {
+    recorder.reset()
+    recorder.start()
+    event.cleanDispatcher()
+    stepsListener()
+  })
+
+  afterEach(() => {
+    event.cleanDispatcher()
+    recorder.reset()
+  })
+
+  it('stamps the suite when it starts', () => {
+    const suite = { title: 'Login' }
+    const before = Date.now()
+
+    event.emit(event.suite.before, suite)
+
+    expect(suite.startedAt).to.be.a('number')
+    expect(suite.startedAt).to.be.at.least(before)
+    expect(suite.startedAt).to.be.at.most(Date.now())
+  })
+
+  it('stamps each suite independently', () => {
+    const first = { title: 'Login' }
+    const second = { title: 'Dashboard' }
+
+    event.emit(event.suite.before, first)
+    event.emit(event.suite.before, second)
+
+    expect(first.startedAt).to.be.a('number')
+    expect(second.startedAt).to.be.a('number')
+    expect(second.startedAt).to.be.at.least(first.startedAt)
+  })
+})


### PR DESCRIPTION
## Motivation/Description of the PR

Resolves #5668.

`junitReporter` writes each `<testsuite timestamp>` from `suite.startedAt` (`lib/plugin/junitReporter.js:135`), but nothing ever set that field. Confirming @mirao's read: `startedAt` is assigned in exactly one place, `lib/listener/steps.js:20`, and only to individual tests. Mocha's `Suite` does not carry it. So `toIso()` always fell through to its `new Date()` fallback and every suite got stamped with the moment the XML was serialized, which is after that suite and its `AfterSuite` had already finished.

The steps listener now stamps the suite on `event.suite.before`, mirroring what it already does for tests two lines below.

One thing worth flagging: the existing `junitReporter_test.js` builds its fixtures with `startedAt: Date.now()` on each suite object, so the tests were exercising a field that production never produced. That is why the reporter's own suite passed while the output was wrong. I left those fixtures alone since they now describe reality, and put the new coverage on the listener instead.

Scope note: this covers the in-process run. Under `run-workers`, `lib/mocha/test.js` serializes a test's parent down to `{ title }` and drops `startedAt` from the test payload as well, so a suite timestamp cannot cross that boundary without changing the worker payload. That looked like a separate change, so I left it out rather than widen this PR.

## Type of change

- [x] :bug: Bug fix

## Checklist:

- [x] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`). N/A, no public API change
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)

Two tests in `test/unit/listener/steps_suite_started_at_test.js`. They fail on the commit before this change with `expected undefined to be a number`, and pass with it.

Full unit suite on Windows: 758 passing / 13 failing before, 760 passing / 11 failing after. The 11 remaining failures are pre-existing path assertions that expect POSIX-style paths and see a `C:` drive letter (`utils_test.js`, `utils/trace_test.js`); they are identical with and without this change.

