### PR TITLE
fix(hooks): emit hook.failed when a helper suite hook throws

### DIFF
--- a/lib/mocha/asyncWrapper.js
+++ b/lib/mocha/asyncWrapper.js
@@ -4,7 +4,7 @@ import recorder from '../recorder.js'
 import assertThrown from '../assert/throws.js'
 import { ucfirst, isAsyncFunction } from '../utils.js'
 import { getInjectedArguments } from './inject.js'
-import { fireHook } from './hooks.js'
+import { fireHook, BeforeSuiteHook, AfterSuiteHook } from './hooks.js'
 
 const injectHook = function (inject, suite) {
   try {
@@ -232,6 +232,10 @@ export function suiteSetup(suite) {
 
     // Set up error handler for suite setup
     recorder.errHandler(err => {
+      // A helper's `_beforeSuite()` runs through this hook, not through the
+      // `injected()` wrapper, so nothing here used to emit `hook.failed` and
+      // reporters listening for it never saw the failure. (#5660)
+      event.emit(event.hook.failed, new BeforeSuiteHook(suite, err))
       doneFn(err)
     })
 
@@ -254,6 +258,8 @@ export function suiteTeardown(suite) {
 
     // Set up error handler for suite teardown
     recorder.errHandler(err => {
+      // Same for a helper's `_afterSuite()`. (#5660)
+      event.emit(event.hook.failed, new AfterSuiteHook(suite, err))
       doneFn(err)
     })
 

--- a/test/unit/mocha/asyncWrapper_test.js
+++ b/test/unit/mocha/asyncWrapper_test.js
@@ -269,4 +269,48 @@ describe('AsyncWrapper', () => {
       expect(arg, 'done called with no error').to.be.undefined
     })
   })
+  describe('helper lifecycle hook failures (#5660)', () => {
+    beforeEach(() => recorder.start())
+
+    // A helper's _beforeSuite()/_afterSuite() is queued on the recorder from an
+    // event.suite.before/after listener (lib/listener/helpers.js), not through
+    // the injected() wrapper, so it lands in suiteSetup/suiteTeardown's
+    // errHandler rather than in the path that fires hook.failed.
+    function queueFailingHelperHook(evt, message) {
+      event.dispatcher.on(evt, () => {
+        recorder.add(`hook MyHelper.${message}()`, () => {
+          throw new Error(message)
+        })
+        recorder.catch()
+      })
+    }
+
+    it('suiteSetup(): a failing helper _beforeSuite emits hook.failed', async () => {
+      const failed = sinon.spy()
+      event.dispatcher.on(event.hook.failed, failed)
+      queueFailingHelperHook(event.suite.before, '_beforeSuite')
+
+      const suite = { title: 'Login', ctx: { test: { title: 'codeceptjs.beforeSuite' } } }
+      const { arg } = await runHook(suiteSetup(suite), 2000)
+
+      expect(arg).to.be.instanceof(Error)
+      expect(arg.message).to.equal('_beforeSuite')
+      expect(failed.called, 'hook.failed was emitted').to.be.true
+      expect(failed.firstCall.args[0].hookName).to.equal('BeforeSuite')
+      expect(failed.firstCall.args[0].err).to.equal(arg)
+    })
+
+    it('suiteTeardown(): a failing helper _afterSuite emits hook.failed', async () => {
+      const failed = sinon.spy()
+      event.dispatcher.on(event.hook.failed, failed)
+      queueFailingHelperHook(event.suite.after, '_afterSuite')
+
+      const suite = { title: 'Login', ctx: { test: { title: 'codeceptjs.afterSuite' } } }
+      const { arg } = await runHook(suiteTeardown(suite), 2000)
+
+      expect(arg).to.be.instanceof(Error)
+      expect(failed.called, 'hook.failed was emitted').to.be.true
+      expect(failed.firstCall.args[0].hookName).to.equal('AfterSuite')
+    })
+  })
 })


### PR DESCRIPTION
## Motivation/Description of the PR

Resolves #5660.

@mirao's trace is correct and I followed it through the code. `event.hook.failed` is only emitted by `fireHook()`, which is only reached from the `injected()` wrapper used for test-file-defined `BeforeSuite()` / `AfterSuite()`. A custom helper's `_beforeSuite()` / `_afterSuite()` takes a different route:

`lib/mocha/ui.js:106` registers `suite.beforeAll('codeceptjs.beforeSuite', suiteSetup(suite))` → `suiteSetup` emits `event.suite.before` → `lib/listener/helpers.js:30` queues `runAsyncHelpersHook('_beforeSuite', ...)` on the recorder. When that throws, it surfaces in `suiteSetup`'s `recorder.errHandler`, which called `doneFn(err)` and nothing else. No `hook.failed`, so `junitReporter`'s listener never fired and the report stayed empty.

Both error handlers now emit the matching hook object before calling done. I passed the mocha suite straight through, which is what `fireHook()` already does, so `hook.ctx.test` and `hook.hookName` come out the same shape junitReporter already consumes (`['BeforeSuite', 'AfterSuite'].includes(hook.hookName)`).

I did not reuse `fireHook()` here: it derives the hook kind from `suite.ctx?.test?.title?.match(/"([^"]*)"/)[1]`, and these hooks are titled `codeceptjs.beforeSuite`, which has no quoted segment, so that match returns null and the indexing throws.

## Type of change

- [x] :bug: Bug fix

## Checklist:

- [x] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`). N/A, no public API change
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)

Two tests appended to `test/unit/mocha/asyncWrapper_test.js`, one per hook. They queue a throwing helper method the same way `runAsyncHelpersHook` does and assert both that `done` still receives the error and that `hook.failed` carries the right `hookName`. Both fail on the commit before this change with `hook.failed was emitted`.

Full unit suite on Windows: 758 passing / 13 failing before, 760 passing / 11 failing after. The 11 remaining are pre-existing path assertions that expect POSIX paths and see a `C:` drive letter (`utils_test.js`, `utils/trace_test.js`), identical with and without this change.

Related: #5683 fixes the other half of the junit reporting gap @mirao reported, the suite timestamp.

