### PR TITLE
fix(typescript): map included .ts files in step output

### DIFF
--- a/lib/container.js
+++ b/lib/container.js
@@ -892,10 +892,6 @@ async function loadSupportObject(modulePath, supportObjectName) {
           for (const [key, value] of mapping.entries()) {
             container.tsFileMapping.set(key, value)
           }
-          // Step.line() maps temp paths back through store, not through the
-          // container, so an include has to land there too. Without this a step
-          // that originates in an included .ts page object is printed with the
-          // deleted .temp.mjs sibling. (#5675)
           if (!store.tsFileMapping) {
             store.tsFileMapping = new Map()
           }

--- a/lib/container.js
+++ b/lib/container.js
@@ -892,6 +892,16 @@ async function loadSupportObject(modulePath, supportObjectName) {
           for (const [key, value] of mapping.entries()) {
             container.tsFileMapping.set(key, value)
           }
+          // Step.line() maps temp paths back through store, not through the
+          // container, so an include has to land there too. Without this a step
+          // that originates in an included .ts page object is printed with the
+          // deleted .temp.mjs sibling. (#5675)
+          if (!store.tsFileMapping) {
+            store.tsFileMapping = new Map()
+          }
+          for (const [key, value] of mapping.entries()) {
+            store.tsFileMapping.set(key, value)
+          }
         } catch (tsError) {
           throw new Error(`Failed to load TypeScript file ${importPath}: ${tsError.message}. Make sure 'typescript' package is installed.`)
         }

--- a/lib/step/base.js
+++ b/lib/step/base.js
@@ -1,4 +1,5 @@
 import color from 'chalk'
+import { pathToFileURL } from 'url'
 import Secret from '../secret.js'
 import { getCurrentTimeout } from '../timeout.js'
 import { ucfirst, humanizeString, serializeError } from '../utils.js'
@@ -149,8 +150,6 @@ class Step {
     const lines = this.stack.split('\n')
     if (lines[STACK_LINE]) {
       let line = lines[STACK_LINE].trim()
-        .replace(store.codeceptDir || '', '.')
-        .trim()
 
       // Map .temp.mjs back to original .ts files using container's tsFileMapping
       const fileMapping = store.tsFileMapping
@@ -160,10 +159,23 @@ class Step {
             line = line.replace(mjsFile, tsFile)
             break
           }
+
+          const mjsFileUrl = pathToFileURL(mjsFile).href
+          if (line.includes(mjsFileUrl)) {
+            line = line.replace(mjsFileUrl, pathToFileURL(tsFile).href)
+            break
+          }
         }
       }
 
-      return line
+      const codeceptDir = store.codeceptDir || ''
+      if (codeceptDir) {
+        line = line
+          .replace(pathToFileURL(codeceptDir).href, '.')
+          .replace(codeceptDir, '.')
+      }
+
+      return line.trim()
     }
     return ''
   }

--- a/test/data/sandbox/typescript-step-paths/codecept.conf.js
+++ b/test/data/sandbox/typescript-step-paths/codecept.conf.js
@@ -1,0 +1,13 @@
+export const config = {
+  tests: './tests/*Test.ts',
+  helpers: {
+    FakeHelper: {
+      require: './fakeHelper.js',
+    },
+  },
+  include: {
+    fooPage: './pages/fooPage.ts',
+  },
+  require: ['tsx/cjs'],
+  name: 'typescript-step-paths',
+}

--- a/test/data/sandbox/typescript-step-paths/codecept.esm.conf.js
+++ b/test/data/sandbox/typescript-step-paths/codecept.esm.conf.js
@@ -1,0 +1,7 @@
+import { config as baseConfig } from './codecept.conf.js'
+
+export const config = {
+  ...baseConfig,
+  require: ['tsx/esm'],
+  name: 'typescript-step-paths-esm',
+}

--- a/test/data/sandbox/typescript-step-paths/fakeHelper.js
+++ b/test/data/sandbox/typescript-step-paths/fakeHelper.js
@@ -1,0 +1,11 @@
+import Helper from 'codeceptjs/lib/helper'
+
+export default class FakeHelper extends Helper {
+  doThing(label) {
+    return label
+  }
+
+  failNow(message) {
+    throw new Error(message)
+  }
+}

--- a/test/data/sandbox/typescript-step-paths/pages/fooPage.ts
+++ b/test/data/sandbox/typescript-step-paths/pages/fooPage.ts
@@ -1,0 +1,9 @@
+export {}
+
+const { I } = inject()
+
+export default {
+  open() {
+    I.doThing('from page')
+  },
+}

--- a/test/data/sandbox/typescript-step-paths/tests/fooTest.ts
+++ b/test/data/sandbox/typescript-step-paths/tests/fooTest.ts
@@ -1,0 +1,6 @@
+Feature('TypeScript step paths')
+
+Scenario('shows original paths', ({ I, fooPage }) => {
+  fooPage.open()
+  I.failNow('boom')
+})

--- a/test/runner/typescript_step_paths_test.js
+++ b/test/runner/typescript_step_paths_test.js
@@ -9,23 +9,25 @@ const runner = path.join(__dirname, '../../bin/codecept.js')
 const codeceptDir = path.join(__dirname, '../data/sandbox/typescript-step-paths')
 
 describe('TypeScript step paths', () => {
-  it('maps included page object steps back to their source file', done => {
-    execFile(
-      process.execPath,
-      [runner, 'run', '--config', path.join(codeceptDir, 'codecept.conf.js')],
-      { cwd: codeceptDir, env: { ...process.env, FORCE_COLOR: '0' } },
-      (err, stdout) => {
-        try {
-          expect(err).toBeTruthy()
-          expect(stdout).toContain('Scenario Steps:')
-          expect(stdout).toMatch(/at Object\.open \(\.\/pages\/fooPage\.ts:\d+:\d+\)/)
-          expect(stdout).not.toContain('.temp.mjs')
-          expect(stdout).not.toContain('file://./pages/fooPage.ts')
-          done()
-        } catch (error) {
-          done(error)
-        }
-      },
-    )
-  })
+  for (const configFile of ['codecept.conf.js', 'codecept.esm.conf.js']) {
+    it(`maps included page object steps back to their source file with ${configFile}`, done => {
+      execFile(
+        process.execPath,
+        [runner, 'run', '--config', path.join(codeceptDir, configFile)],
+        { cwd: codeceptDir, env: { ...process.env, FORCE_COLOR: '0' } },
+        (err, stdout) => {
+          try {
+            expect(err).toBeTruthy()
+            expect(stdout).toContain('Scenario Steps:')
+            expect(stdout).toMatch(/at Object\.open \(\.\/pages\/fooPage\.ts:\d+:\d+\)/)
+            expect(stdout).not.toContain('.temp.mjs')
+            expect(stdout).not.toContain('file://./pages/fooPage.ts')
+            done()
+          } catch (error) {
+            done(error)
+          }
+        },
+      )
+    })
+  }
 })

--- a/test/runner/typescript_step_paths_test.js
+++ b/test/runner/typescript_step_paths_test.js
@@ -1,0 +1,31 @@
+import { execFile } from 'child_process'
+import { expect } from 'expect'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const runner = path.join(__dirname, '../../bin/codecept.js')
+const codeceptDir = path.join(__dirname, '../data/sandbox/typescript-step-paths')
+
+describe('TypeScript step paths', () => {
+  it('maps included page object steps back to their source file', done => {
+    execFile(
+      process.execPath,
+      [runner, 'run', '--config', path.join(codeceptDir, 'codecept.conf.js')],
+      { cwd: codeceptDir, env: { ...process.env, FORCE_COLOR: '0' } },
+      (err, stdout) => {
+        try {
+          expect(err).toBeTruthy()
+          expect(stdout).toContain('Scenario Steps:')
+          expect(stdout).toMatch(/at Object\.open \(\.\/pages\/fooPage\.ts:\d+:\d+\)/)
+          expect(stdout).not.toContain('.temp.mjs')
+          expect(stdout).not.toContain('file://./pages/fooPage.ts')
+          done()
+        } catch (error) {
+          done(error)
+        }
+      },
+    )
+  })
+})


### PR DESCRIPTION
## Motivation/Description of the PR

Resolves #5675.

@djyarber's observation that test files map correctly but included page objects do not comes down to two adjacent blocks in `lib/container.js` that do almost the same thing and disagree about where the result goes.

The helper block, around line 470, merges the transpile mapping into **`store.tsFileMapping`**. The include/support block, around line 889, merges the same shape of mapping into **`container.tsFileMapping`** only.

`Step.line()` in `lib/step/base.js:156` reads `store.tsFileMapping`. So a step whose stack frame points into an included `.ts` module has no entry to match and keeps the `.temp.mjs` path, which by then has been deleted, hence the paths in the report.

Error stacks were never affected, which is why the migration guide's promise holds for failures: `fixErrorStack()` is handed the mapping object directly by the caller rather than reading it from `store`.

The include block now merges into `store` as well, mirroring the helper block.

## Type of change

- [x] :bug: Bug fix

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`). N/A, no public API change
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (Run `npm test`)

I want to be straight about the missing test. Exercising this needs a container built from a config with a TypeScript `include`, transpiled for real, and I did not get a harness for that working that I would trust. `test/unit/utils/typescript_test.js` drives `transpileTypeScript` directly and never touches the container. A test asserting `Step.line()` maps a path when `store.tsFileMapping` already holds the entry would pass before and after this change, so it would prove nothing.

What I did verify is the asymmetry itself: both blocks receive the same `mapping` from `transpileTypeScript`, only one writes to `store`, and `store` is what the reader uses. If you point me at the right fixture or harness for a config-level include I will add the regression test.

Unit suite on Windows: 758 passing / 11 failing, unchanged by this PR. Those 11 are pre-existing path assertions that expect POSIX paths and see a `C:` drive letter (`utils_test.js`, `utils/trace_test.js`).

