### PR TITLE
fix: resolve dynamic import() and bare require/module in TypeScript configs

### DIFF
--- a/lib/utils/typescript.js
+++ b/lib/utils/typescript.js
@@ -85,16 +85,27 @@ export async function transpileTypeScript(mainFilePath, typescript) {
       skipLibCheck: true,
     })
 
-    // Check if the code uses CommonJS globals
+    // Check if the code uses CommonJS globals.
+    //
+    // A bare `require` or `module` identifier counts, not just `require(...)` and
+    // `module.exports`: `if (require.main === module)` is the standard entrypoint idiom,
+    // and without a shim the transpiled file throws "require is not defined in ES module
+    // scope". Quoted occurrences (`from 'module'`) are specifiers, not references. A file
+    // that declares its own binding is left alone, so the shim can never redeclare it.
+    const references = name => new RegExp(`(?<!['"\`])\\b${name}\\b(?!['"\`])`).test(jsContent)
+    const declaresOwn = name => new RegExp(`\\b(?:const|let|var|function|class)\\s+${name}\\b|\\bimport\\s+${name}\\b`).test(jsContent)
+    const needsShim = name => references(name) && !declaresOwn(name)
+
     const usesCommonJSGlobals = /__dirname|__filename/.test(jsContent)
-    const usesRequire = /\brequire\s*\(/.test(jsContent)
+    const usesRequire = needsShim('require')
+    const usesModule = needsShim('module')
     const usesModuleExports = /\b(module\.exports|exports\.)/.test(jsContent)
 
-    if (usesCommonJSGlobals || usesRequire || usesModuleExports) {
+    if (usesCommonJSGlobals || usesRequire || usesModule || usesModuleExports) {
       // Inject ESM equivalents at the top of the file
       let esmGlobals = ''
 
-      if (usesRequire || usesModuleExports) {
+      if (usesRequire) {
         // IMPORTANT: Use the original .ts file path as the base for require()
         // This ensures dynamic require() calls work with relative paths from the original file location
         const originalFileUrl = `file://${filePath.replace(/\\/g, '/')}`
@@ -131,7 +142,11 @@ const require = (id) => {
   }
 };
 
-const module = { exports: {} };
+`
+      }
+
+      if (usesModule || usesModuleExports) {
+        esmGlobals += `const module = { exports: {} };
 const exports = module.exports;
 
 `
@@ -189,13 +204,18 @@ const __dirname = __dirname_fn(__filename);
     // Transpile this file
     let jsContent = transpileTS(filePath)
 
-    // Find all TypeScript imports in this file (both ESM imports and require() calls)
+    // Find all TypeScript imports in this file (static imports, dynamic import() and require() calls)
     const importRegex = /from\s+['"]([^'"]+?)['"]/g
+    const dynamicImportRegex = /\bimport\s*\(\s*['"]([^'"]+?)['"]\s*\)/g
     const requireRegex = /require\s*\(\s*['"]([^'"]+?)['"]\s*\)/g
     let match
     const imports = []
 
     while ((match = importRegex.exec(jsContent)) !== null) {
+      imports.push({ path: match[1], type: 'import' })
+    }
+
+    while ((match = dynamicImportRegex.exec(jsContent)) !== null) {
       imports.push({ path: match[1], type: 'import' })
     }
 
@@ -260,85 +280,76 @@ const __dirname = __dirname_fn(__filename);
       }
     }
 
-    // After all dependencies are transpiled, rewrite imports in this file
-    jsContent = jsContent.replace(
-      /from\s+['"]([^'"]+?)['"]/g,
-      (match, importPath) => {
-        let resolvedPath = importPath
-        const originalExt = path.extname(importPath)
+    // Resolve one ESM specifier to the temp file its source was transpiled into.
+    // Returns null when the specifier must be left untouched — bare package names,
+    // or paths that resolve to nothing we emitted.
+    const resolveEsmSpecifier = importPath => {
+      let resolvedPath = importPath
+      const originalExt = path.extname(importPath)
 
-        // Check if this is a path alias
-        const resolvedAlias = resolveTsPathAlias(importPath, tsConfig, configDir)
-        if (resolvedAlias) {
-          resolvedPath = resolvedAlias
-        } else if (importPath.startsWith('.')) {
-          resolvedPath = path.resolve(fileBaseDir, importPath)
-        } else {
-          return match
-        }
-
-        // If resolved path is a directory, try index.ts
-        if (fs.existsSync(resolvedPath) && fs.statSync(resolvedPath).isDirectory()) {
-          const indexPath = path.join(resolvedPath, 'index.ts')
-          if (fs.existsSync(indexPath) && transpiledFiles.has(indexPath)) {
-            const tempFile = transpiledFiles.get(indexPath)
-            const relPath = path.relative(fileBaseDir, tempFile).replace(/\\/g, '/')
-            if (!relPath.startsWith('.')) {
-              return `from './${relPath}'`
-            }
-            return `from '${relPath}'`
-          }
-        }
-
-        // Handle .js extension that might be .ts
-        if (resolvedPath.endsWith('.js')) {
-          const tsVersion = resolvedPath.replace(/\.js$/, '.ts')
-          if (transpiledFiles.has(tsVersion)) {
-            const tempFile = transpiledFiles.get(tsVersion)
-            const relPath = path.relative(fileBaseDir, tempFile).replace(/\\/g, '/')
-            if (!relPath.startsWith('.')) {
-              return `from './${relPath}'`
-            }
-            return `from '${relPath}'`
-          }
-          return match
-        }
-
-        // Try with .ts extension
-        const tsPath = resolvedPath.endsWith('.ts') ? resolvedPath : resolvedPath + '.ts'
-
-        // If we transpiled this file, use the temp file
-        if (transpiledFiles.has(tsPath)) {
-          const tempFile = transpiledFiles.get(tsPath)
-          const relPath = path.relative(fileBaseDir, tempFile).replace(/\\/g, '/')
-          if (!relPath.startsWith('.')) {
-            return `from './${relPath}'`
-          }
-          return `from '${relPath}'`
-        }
-
-        // Try index.ts for directory imports
-        const indexTsPath = path.join(resolvedPath, 'index.ts')
-        if (transpiledFiles.has(indexTsPath)) {
-          const tempFile = transpiledFiles.get(indexTsPath)
-          const relPath = path.relative(fileBaseDir, tempFile).replace(/\\/g, '/')
-          if (!relPath.startsWith('.')) {
-            return `from './${relPath}'`
-          }
-          return `from '${relPath}'`
-        }
-
-        // If the import doesn't have a standard module extension, add .js for ESM compatibility
-        const standardExtensions = ['.js', '.mjs', '.cjs', '.json', '.node']
-        const hasStandardExtension = standardExtensions.includes(originalExt.toLowerCase())
-
-        if (!hasStandardExtension) {
-          return match.replace(importPath, importPath + '.js')
-        }
-
-        return match
+      // Check if this is a path alias
+      const resolvedAlias = resolveTsPathAlias(importPath, tsConfig, configDir)
+      if (resolvedAlias) {
+        resolvedPath = resolvedAlias
+      } else if (importPath.startsWith('.')) {
+        resolvedPath = path.resolve(fileBaseDir, importPath)
+      } else {
+        return null
       }
-    )
+
+      const toRelative = tempFile => {
+        const relPath = path.relative(fileBaseDir, tempFile).replace(/\\/g, '/')
+        return relPath.startsWith('.') ? relPath : `./${relPath}`
+      }
+
+      // If resolved path is a directory, try index.ts
+      if (fs.existsSync(resolvedPath) && fs.statSync(resolvedPath).isDirectory()) {
+        const indexPath = path.join(resolvedPath, 'index.ts')
+        if (fs.existsSync(indexPath) && transpiledFiles.has(indexPath)) {
+          return toRelative(transpiledFiles.get(indexPath))
+        }
+      }
+
+      // Handle .js extension that might be .ts
+      if (resolvedPath.endsWith('.js')) {
+        const tsVersion = resolvedPath.replace(/\.js$/, '.ts')
+        return transpiledFiles.has(tsVersion) ? toRelative(transpiledFiles.get(tsVersion)) : null
+      }
+
+      // Try with .ts extension
+      const tsPath = resolvedPath.endsWith('.ts') ? resolvedPath : resolvedPath + '.ts'
+      if (transpiledFiles.has(tsPath)) {
+        return toRelative(transpiledFiles.get(tsPath))
+      }
+
+      // Try index.ts for directory imports
+      const indexTsPath = path.join(resolvedPath, 'index.ts')
+      if (transpiledFiles.has(indexTsPath)) {
+        return toRelative(transpiledFiles.get(indexTsPath))
+      }
+
+      // If the import doesn't have a standard module extension, add .js for ESM compatibility
+      const standardExtensions = ['.js', '.mjs', '.cjs', '.json', '.node']
+      if (!standardExtensions.includes(originalExt.toLowerCase())) {
+        return `${importPath}.js`
+      }
+
+      return null
+    }
+
+    // After all dependencies are transpiled, rewrite imports in this file
+    jsContent = jsContent.replace(/from\s+['"]([^'"]+?)['"]/g, (match, importPath) => {
+      const resolved = resolveEsmSpecifier(importPath)
+      return resolved === null ? match : `from '${resolved}'`
+    })
+
+    // Dynamic import() resolves exactly like a static import. Without this rewrite,
+    // `await import('./module')` survives transpilation still pointing at a `.ts` file
+    // that was never emitted, and fails with ERR_MODULE_NOT_FOUND at runtime.
+    jsContent = jsContent.replace(/(\bimport\s*\(\s*)['"]([^'"]+?)['"](\s*\))/g, (match, open, importPath, close) => {
+      const resolved = resolveEsmSpecifier(importPath)
+      return resolved === null ? match : `${open}'${resolved}'${close}`
+    })
 
     // Also rewrite require() calls to point to transpiled TypeScript files
     jsContent = jsContent.replace(

--- a/test/data/typescript-config-dynamic-import/codecept.conf.ts
+++ b/test/data/typescript-config-dynamic-import/codecept.conf.ts
@@ -1,0 +1,12 @@
+export const config = {
+  tests: './*_test.js',
+  output: './output',
+  name: 'typescript-config-dynamic-import',
+}
+
+// Lifecycle hooks commonly pull heavy modules lazily. The specifier is extensionless,
+// as TypeScript sources are normally written.
+export async function runTeardown(): Promise<string> {
+  const { teardown } = await import('./lifecycle/teardown')
+  return teardown()
+}

--- a/test/data/typescript-config-dynamic-import/common/labels.ts
+++ b/test/data/typescript-config-dynamic-import/common/labels.ts
@@ -1,0 +1,3 @@
+export function getSweepLabel(): string {
+  return 'swept'
+}

--- a/test/data/typescript-config-dynamic-import/lifecycle/teardown.ts
+++ b/test/data/typescript-config-dynamic-import/lifecycle/teardown.ts
@@ -1,0 +1,12 @@
+import { getSweepLabel } from '../common/labels'
+
+export function teardown(): string {
+  return `teardown:${getSweepLabel()}`
+}
+
+// Standard CommonJS entrypoint idiom: this module doubles as a CLI script. It must
+// survive transpilation (no "require is not defined in ES module scope") and must not
+// run when the module is merely imported.
+if (require.main === module) {
+  console.log(teardown())
+}

--- a/test/data/typescript-config-dynamic-import/package.json
+++ b/test/data/typescript-config-dynamic-import/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "typescript-config-dynamic-import",
+  "version": "1.0.0",
+  "type": "module"
+}

--- a/test/unit/utils/typescript_test.js
+++ b/test/unit/utils/typescript_test.js
@@ -9,6 +9,9 @@ const require = createRequire(import.meta.url)
 const typescript = require('typescript')
 
 const configPath = path.resolve(__dirname, '../../data/typescript-config-imports/tests/api/codecept.conf.ts')
+const dynamicImportDir = path.resolve(__dirname, '../../data/typescript-config-dynamic-import')
+const dynamicImportConfigPath = path.join(dynamicImportDir, 'codecept.conf.ts')
+const entrypointModulePath = path.join(dynamicImportDir, 'lifecycle/teardown.ts')
 
 describe('TypeScript transpilation', () => {
   it('uses unique temp file names per invocation so concurrent run-multiple workers do not delete each other (#5642)', async () => {
@@ -31,6 +34,38 @@ describe('TypeScript transpilation', () => {
     } finally {
       cleanupTempFiles(first.allTempFiles)
       cleanupTempFiles(second.allTempFiles)
+    }
+  })
+
+  it('transpiles and rewrites modules reached through a dynamic import()', async () => {
+    const result = await transpileTypeScript(dynamicImportConfigPath, typescript)
+
+    try {
+      // config + the dynamically imported module + that module's own static import
+      expect(result.allTempFiles.length).to.equal(3)
+
+      const configModule = await import(result.tempFile)
+      expect(await configModule.runTeardown()).to.equal('teardown:swept')
+    } finally {
+      cleanupTempFiles(result.allTempFiles)
+    }
+  })
+
+  it('shims a bare `require.main === module` entrypoint guard without running it', async () => {
+    const result = await transpileTypeScript(entrypointModulePath, typescript)
+    const logged = []
+    const originalLog = console.log
+    console.log = (...args) => logged.push(args.join(' '))
+
+    try {
+      // Importing must not throw "require is not defined in ES module scope" ...
+      const transpiled = await import(result.tempFile)
+      expect(transpiled.teardown()).to.equal('teardown:swept')
+      // ... and the guarded block must stay dormant, since the module was imported, not run.
+      expect(logged, `entrypoint block executed on import: ${logged}`).to.be.empty
+    } finally {
+      console.log = originalLog
+      cleanupTempFiles(result.allTempFiles)
     }
   })
 })


### PR DESCRIPTION
## Motivation/Description of the PR

A `.ts` config is not executed as TypeScript — `lib/config.js` transpiles it to a temp `.mjs` and `transpileTypeScript` walks and transpiles its import tree along with it. Two gaps in that walk make perfectly ordinary TypeScript fail, and both only surface at runtime, with errors that point away from the real cause.

**1. Dynamic `import()` is invisible to the transpiler.** The dependency scan and the rewrite pass matched `from '...'` and `require('...')` only. A module reached through `await import('./module')` was therefore never emitted, and the specifier survived transpilation still pointing at an extensionless `.ts` path:

```ts
// codecept.conf.ts
export const config = {
  // ...
  teardownAll: async () => {
    const { globalTeardown } = await import('./src/lifecycle/globalTeardown')
    await globalTeardown()
  },
}
```

```
ERR_MODULE_NOT_FOUND: Cannot find module '/…/src/lifecycle/globalTeardown'
imported from /…/codecept.conf.<pid>.<hash>.temp.mjs
```

The same import written statically at the top of the config works, which makes the failure look like an ESM-vs-`tsx` resolution problem in the runner rather than a gap in the transpiler. In our suite this cost a real workaround: both lifecycle hooks shelled out to `execSync('npx tsx <script>')` for a year, with a code comment blaming the worker ESM context.

Static and dynamic specifiers now share one resolver, so both follow identical ESM resolution — path aliases, `index.ts`, `.js`-that-is-really-`.ts`, and the extension-append fallback included.

**2. A bare `require` / `module` identifier gets no CommonJS shim.** Shim injection was gated on `/\brequire\s*\(/` and `/\b(module\.exports|exports\.)/`, so the standard entrypoint idiom matched neither:

```ts
// a module that doubles as a CLI script
if (require.main === module) {
  main()
}
```

```
ReferenceError: require is not defined in ES module scope, you can use import instead
```

Detection now counts bare `require` / `module` identifiers. Two refinements keep it from over-firing:

- quoted occurrences are ignored, so `import { createRequire } from 'module'` is not mistaken for a reference;
- a file that declares its own binding is skipped. This also fixes a pre-existing failure mode: a file doing `const require = createRequire(import.meta.url)` *and* calling `require('x')` used to get a second `const require` injected, i.e. a `SyntaxError` from the shim itself.

### Verification

New fixture `test/data/typescript-config-dynamic-import/` covers both paths in one realistic shape: a config that dynamically imports a lifecycle module, which in turn statically imports a third file and carries a `require.main === module` guard. Two unit tests assert the module tree is fully emitted and reachable, that the guarded file imports without throwing, and that the guard stays dormant on import.

Unit suite before this change: **769 passing, 11 pending, 0 failing**. After: **771 passing, 11 pending, 0 failing**. `eslint` clean on the touched files.

Also checked against the real-world case that prompted this, a 10-file config import tree in a private suite:

| | 4.x today | with this PR |
|---|---|---|
| `await import('./src/…/globalTeardown')` in a `.ts` config | `ERR_MODULE_NOT_FOUND` | resolves, module tree emitted |

Applicable helpers:

- [ ] Playwright
- [ ] Puppeteer
- [ ] WebDriver
- [ ] REST
- [ ] FileHelper
- [ ] Appium

Applicable plugins:

- [ ] aiTrace
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pause
- [ ] coverage
- [ ] heal
- [ ] retryFailedStep
- [ ] screenshot
- [ ] selenoid
- [ ] stepTimeout
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [x] :bug: Bug fix
- [ ] 🧹 Chore
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [x] :nail_care: Polish code

## Checklist:

- [x] Tests have been added (2 unit tests + fixture in `test/unit/utils/typescript_test.js`)
- [ ] Documentation has been added (not needed — no public API change)
- [x] Lint checking (`npx eslint lib/utils/typescript.js test/unit/utils/typescript_test.js`)
- [x] Local tests are passed (`mocha test/unit --recursive`: 771 passing, 0 failing)
