### PR TITLE
fix: preserve test artifacts on retry

### DIFF
--- a/lib/listener/retryEnhancer.js
+++ b/lib/listener/retryEnhancer.js
@@ -44,7 +44,8 @@ function copyCodeceptJSProperties(originalTest, retriedTest) {
   }
 
   if (originalTest.artifacts !== undefined) {
-    retriedTest.artifacts = originalTest.artifacts ? [...originalTest.artifacts] : []
+    const artifacts = originalTest.artifacts
+    retriedTest.artifacts = artifacts ? (Array.isArray(artifacts) ? Object.assign([], artifacts) : { ...artifacts }) : []
   }
 
   if (originalTest.steps !== undefined) {

--- a/lib/plugin/screencast.js
+++ b/lib/plugin/screencast.js
@@ -276,7 +276,8 @@ function buildSrt(steps) {
 }
 
 function ensureArtifactsObject(test) {
-  if (!test.artifacts || Array.isArray(test.artifacts)) test.artifacts = {}
+  if (!test.artifacts) test.artifacts = {}
+  else if (Array.isArray(test.artifacts)) test.artifacts = Object.assign({}, test.artifacts)
 }
 
 function attachJUnitArtifact(test, filePath) {

--- a/test/unit/mocha/test_clone_test.js
+++ b/test/unit/mocha/test_clone_test.js
@@ -137,4 +137,34 @@ describe('Test cloning for retries', function () {
     expect(retriedTest.applyOptions).to.be.a('function')
     expect(retriedTest.simplify).to.be.a('function')
   })
+
+  it('should copy object-shaped artifacts on retry without throwing', function () {
+    retryEnhancer()
+
+    const originalTest = createTest('Test with object artifacts', () => {})
+
+    originalTest.artifacts = { screenshot: 'failed.png', screencast: 'failed.webm' }
+
+    const retriedTest = Test.prototype.clone.call(originalTest)
+    event.emit(event.test.before, retriedTest)
+
+    expect(retriedTest.artifacts).to.deep.equal({ screenshot: 'failed.png', screencast: 'failed.webm' })
+    expect(retriedTest.simplify).to.be.a('function')
+  })
+
+  it('should keep named keys written onto array-shaped artifacts', function () {
+    retryEnhancer()
+
+    const originalTest = createTest('Test with mixed artifacts', () => {})
+
+    const artifacts = ['trace.zip']
+    artifacts.screenshot = 'failed.png'
+    originalTest.artifacts = artifacts
+
+    const retriedTest = Test.prototype.clone.call(originalTest)
+    event.emit(event.test.before, retriedTest)
+
+    expect([...retriedTest.artifacts]).to.deep.equal(['trace.zip'])
+    expect(retriedTest.artifacts.screenshot).to.equal('failed.png')
+  })
 })

--- a/test/unit/plugin/screencast_test.js
+++ b/test/unit/plugin/screencast_test.js
@@ -128,6 +128,27 @@ describe('screencast', () => {
     expect(test.artifacts.screencast).to.match(/keep-on-fail.*\.webm$/)
   })
 
+  it('on=fail keeps a screenshot already written onto array-shaped artifacts', async () => {
+    const sc = makeFakeScreencast()
+    container.clear({ Playwright: { options: {}, page: { screencast: sc } } })
+
+    screencast({ on: 'fail' })
+    const test = createTest('keep-screenshot')
+    test.artifacts.screenshot = 'failed.png'
+
+    event.dispatcher.emit(event.test.before, test)
+    event.dispatcher.emit(event.test.started, test)
+    event.dispatcher.emit(event.step.started, aStep())
+    await recorder.promise()
+
+    event.dispatcher.emit(event.test.failed, test, new Error('boom'))
+    event.dispatcher.emit(event.test.after, test)
+    await recorder.promise()
+
+    expect(test.artifacts.screenshot).to.equal('failed.png')
+    expect(test.artifacts.screencast).to.match(/keep-screenshot.*\.webm$/)
+  })
+
   it('captions=true triggers showActions; captions=false does not', async () => {
     const sc = makeFakeScreencast()
     container.clear({ Playwright: { options: {}, page: { screencast: sc } } })


### PR DESCRIPTION
## Motivation/Description of the PR
With `retry` enabled every failed test lost its artifacts (screenshot/video): `retryEnhancer` copied `test.artifacts` with array spread, but artifacts is an object map — the spread threw `TypeError: not iterable` and aborted test enhancement. The `screencast` plugin additionally wiped array-shaped artifacts, dropping the `screenshot` key.

- `retryEnhancer`: copy artifacts preserving shape (object map → `{...a}`, array → `Object.assign([], a)`)
- `screencast.ensureArtifactsObject`: merge array-shaped artifacts instead of replacing with `{}`

Resolves #5689

Applicable helpers:

- [x] Playwright

Applicable plugins:

- [x] screenshot (+ screencast, not in this list)

## Type of change

- [x] :bug: Bug fix

## Checklist:

- [x] Tests have been added (3 cases, all fail without the fix)
- [ ] Documentation has been added (not needed)
- [x] Lint checking (Run `npm run lint`)
- [x] Local tests are passed (unit suite: 772 passing)
