### PR TITLE
fix: keep element text in simplifyHtmlElement

### DIFF
--- a/lib/html.js
+++ b/lib/html.js
@@ -78,11 +78,12 @@ const defaultHtmlOpts = {
   textElements: ['label', 'h1', 'h2'],
   allowedAttrs: ['id', 'for', 'class', 'name', 'type', 'value', 'tabindex', 'aria-labelledby', 'aria-label', 'label', 'placeholder', 'title', 'alt', 'src', 'role'],
   allowedRoles: ['button', 'checkbox', 'search', 'textbox', 'tab'],
+  keepText: false,
 }
 
 function removeNonInteractiveElements(html, opts = {}) {
   opts = { ...defaultHtmlOpts, ...opts }
-  const { interactiveElements, textElements, allowedAttrs, allowedRoles } = opts
+  const { interactiveElements, textElements, allowedAttrs, allowedRoles, keepText } = opts
 
   // Parse the HTML into a document tree
   const document = parse(html)
@@ -111,8 +112,14 @@ function removeNonInteractiveElements(html, opts = {}) {
     return false
   }
 
+  function hasVisibleText(node) {
+    if (node.nodeName === '#text') return !!node.value.trim()
+    return (node.childNodes || []).some(hasVisibleText)
+  }
+
   function hasMeaningfulText(node) {
     if (textElements.includes(node.nodeName)) return true
+    if (keepText && hasVisibleText(node)) return true
     return false
   }
 
@@ -294,7 +301,7 @@ function splitByChunks(text, chunkSize) {
 
 function simplifyHtmlElement(html, maxLength = 300) {
   try {
-    html = removeNonInteractiveElements(html)
+    html = removeNonInteractiveElements(html, { keepText: true })
     html = html.replace(/<html>(?:<head>.*?<\/head>)?<body>(.*)<\/body><\/html>/s, '$1').trim()
   } catch (e) {
     // keep raw html if minification fails

--- a/test/unit/html_test.js
+++ b/test/unit/html_test.js
@@ -3,7 +3,7 @@ import path from 'path'
 import { expect } from 'chai'
 import { fileURLToPath } from 'url'
 import * as cheerio from 'cheerio'
-import { scanForErrorMessages, removeNonInteractiveElements, minifyHtml, splitByChunks, cleanHtml, formatHtml, isTrashClass } from '../../lib/html.js'
+import { scanForErrorMessages, removeNonInteractiveElements, minifyHtml, splitByChunks, cleanHtml, formatHtml, isTrashClass, simplifyHtmlElement } from '../../lib/html.js'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
@@ -222,6 +222,37 @@ describe('HTML module', () => {
       expect(out).not.to.include('<style')
       // structure preserved
       expect(out).to.include('<span>hi</span>')
+    })
+  })
+
+  describe('#simplifyHtmlElement', () => {
+    const button = label =>
+      '<button type="button"><span class="content inline-flex items-center gap-3 w-full">' +
+      '<span class="badge badge-type manual"><svg class="md-icon md-icon-file-document-outline"></svg></span>' +
+      `<span>${label}</span></span></button>`
+
+    it('keeps the visible label when it is nested in non-interactive elements', () => {
+      const out = simplifyHtmlElement(button('New test'))
+      expect(out).to.include('New test')
+      expect(out).to.include('<button type="button">')
+    })
+
+    it('keeps elements with different labels distinguishable', () => {
+      expect(simplifyHtmlElement(button('New test'))).not.to.equal(simplifyHtmlElement(button('New tests from requirement')))
+    })
+
+    it('drops nested elements without text', () => {
+      expect(simplifyHtmlElement(button('New test'))).not.to.include('<svg')
+    })
+
+    it('truncates to maxLength', () => {
+      const out = simplifyHtmlElement(button('New test'), 50)
+      expect(out).to.have.length(53)
+      expect(out.endsWith('...')).to.be.true
+    })
+
+    it('does not change removeNonInteractiveElements by default', () => {
+      expect(removeNonInteractiveElements(button('New test'))).not.to.include('New test')
     })
   })
 })


### PR DESCRIPTION
## What was wrong

`simplifyHtmlElement()` calls `removeNonInteractiveElements()`, which strips non-interactive descendants. When an interactive element's visible label lives in nested `<span>`s (icon + badge + text button markup), everything inside is removed and the element serializes as an empty shell.

```js
import { simplifyHtmlElement } from './lib/html.js'
const html = `<button type="button"><span class="content inline-flex items-center gap-3 w-full"><span class="badge badge-type manual"><svg class="md-icon md-icon-file-document-outline"></svg></span><span>New test</span></span></button>`
console.log(simplifyHtmlElement(html))
```

Before:

```html
<button type="button"><span class="content inline-flex items-center w-full"></span></button>
```

After:

```html
<button type="button"><span class="content inline-flex items-center w-full"><span>New test</span></span></button>
```

## Why it matters

`WebElement.toSimplifiedHTML()` is the only caller, and it feeds `MultipleElementsFound`, whose job is to describe candidate elements so a human or an agent can tell them apart. With the labels stripped, two different menu items — `New test` and `New tests from requirement` — rendered byte-identically, making the error message useless and any automated choice between them a guess.

## The change

`removeNonInteractiveElements()` gets an opt-in `keepText` option, `false` by default. When enabled, a non-interactive subtree is dropped only if it contains no visible text. `simplifyHtmlElement()` passes `keepText: true`, since it describes a single element and that element's own text is exactly what the caller needs.

`removeNonInteractiveElements()`'s existing behavior is unchanged: with `keepText` false the new condition short-circuits, and output on the full-page fixtures (`test/data/github.html`, `test/data/testomat.html`) is byte-identical to before. `maxLength` truncation still applies after simplification, as before.

## Tests

New `#simplifyHtmlElement` block in `test/unit/html_test.js` covers the nested label, distinguishability of two similar labels, dropping of text-free nested markup, `maxLength` truncation, and that `removeNonInteractiveElements()` still strips the nested label by default.

`npx mocha test/unit --recursive --timeout 10000` — 786 passing, 11 pending, 0 failing.