### PR TITLE
 mask secret data rows in data-driven titles

### DIFF
--- a/lib/data/context.js
+++ b/lib/data/context.js
@@ -68,6 +68,10 @@ function replaceTitle(title, dataRow) {
     return `${title} | {${JSON.stringify(dataRow.data)}}`
   }
 
+  if (typeof dataRow.data.getMasked === 'function') {
+    return `${title} | ${dataRow.data.getMasked()}`
+  }
+
   // if `dataRow` is object and has own `toString()` method,
   // it should be printed
   if (Object.prototype.toString.call(dataRow.data) === Object().toString() && dataRow.data.toString() !== Object().toString()) {

--- a/test/unit/data/ui_test.js
+++ b/test/unit/data/ui_test.js
@@ -122,4 +122,11 @@ describe('ui', () => {
       expect(dataScenarioConfig.scenarios[0].test.title).to.equal('scenario | {"username":"jon","password":"snow"}')
     })
   })
+
+  describe('secret data rows', () => {
+    it("should not leak a secret data row's value into the title", () => {
+      const dataScenarioConfig = context.Data([new Secret('theSecretPassword')]).Scenario('scenario', () => {})
+      expect(dataScenarioConfig.scenarios[0].test.title).to.equal('scenario | *****')
+    })
+  })
 })


### PR DESCRIPTION
## Summary

 Secret used as a whole data row leaks its value into the test title via toString(): Data([new Secret('pw')]).Scenario('Login', ...) → title Login | pw. 
 
 maskSecretInTitle only catches the {"_secret":"..."} JSON form (nested secrets in object rows), not bare secret rows.