### PR TITLE
fix(typescript): no loader required under Bun

### DIFF
--- a/lib/utils/loaderCheck.js
+++ b/lib/utils/loaderCheck.js
@@ -6,10 +6,16 @@
  * Check if a TypeScript loader is available for test files
  * Note: This checks if loaders are in the require array, not if packages are installed
  * Package installation is checked when actually requiring modules
+ * Always true under Bun, which transpiles TypeScript itself
  * @param {string[]} requiredModules - Array of required modules from config
  * @returns {boolean}
  */
 export function checkTypeScriptLoader(requiredModules = []) {
+  // Bun transpiles TypeScript natively, so no loader is needed.
+  // Node is not treated the same way: its native type stripping rejects enums
+  // and does not resolve extensionless relative imports.
+  if (process.versions.bun) return true
+
   // Check if a loader is configured in the require array
   return (
     requiredModules.includes('tsx/esm') ||

--- a/test/unit/utils/loaderCheck_test.js
+++ b/test/unit/utils/loaderCheck_test.js
@@ -1,0 +1,56 @@
+import { expect } from 'chai'
+import { checkTypeScriptLoader, validateTypeScriptSetup } from '../../../lib/utils/loaderCheck.js'
+
+describe('TypeScript loader check', () => {
+  const hadBun = 'bun' in process.versions
+  const originalBun = process.versions.bun
+
+  afterEach(() => {
+    if (hadBun) {
+      process.versions.bun = originalBun
+    } else {
+      delete process.versions.bun
+    }
+  })
+
+  describe('on Node', () => {
+    beforeEach(() => {
+      delete process.versions.bun
+    })
+
+    it('detects a configured loader', () => {
+      for (const loader of ['tsx/esm', 'tsx/cjs', 'tsx', 'ts-node/esm', 'ts-node/register', 'ts-node']) {
+        expect(checkTypeScriptLoader([loader]), loader).to.be.true
+      }
+    })
+
+    it('reports an error for TypeScript tests without a loader', () => {
+      expect(checkTypeScriptLoader([])).to.be.false
+
+      const validation = validateTypeScriptSetup(['basic_test.ts'], [])
+      expect(validation.hasError).to.be.true
+      expect(validation.message).to.include('TypeScript Test Files Detected')
+    })
+
+    it('passes when there are no TypeScript test files', () => {
+      expect(validateTypeScriptSetup(['basic_test.js'], []).hasError).to.be.false
+    })
+  })
+
+  describe('on Bun', () => {
+    beforeEach(() => {
+      process.versions.bun = '1.4.2'
+    })
+
+    // Bun transpiles TypeScript itself, so requiring tsx/ts-node is pointless (#5697)
+    it('needs no loader in the require array', () => {
+      expect(checkTypeScriptLoader([])).to.be.true
+      expect(validateTypeScriptSetup(['basic_test.ts'], []).hasError).to.be.false
+    })
+
+    it('still accepts a configured loader', () => {
+      expect(checkTypeScriptLoader(['tsx/esm'])).to.be.true
+      expect(validateTypeScriptSetup(['basic_test.ts'], ['tsx/esm']).hasError).to.be.false
+    })
+  })
+})


### PR DESCRIPTION
Fixes #5697

## Problem

`require: ['tsx/esm']` is mandatory even when running under Bun, which transpiles TypeScript natively. Without it the run aborts with `process.exit(1)` and the "TypeScript Test Files Detected but No Loader Configured" banner — although the tests run perfectly fine once the check is bypassed.

`checkTypeScriptLoader()` only string-matches the `require` array against a hardcoded list of Node loaders; there is no check of whether the runtime already handles TypeScript. So under Bun the `require` entry exists purely to satisfy that string match, and `tsx` sits in `devDependencies` and is imported on every run only to do nothing.

Bun's `module.register()` is a no-op stub, so tsx's `resolve`/`load` hooks are never invoked. Verified with a hooks module that logs on every call: `bun --bun` produces no hook line at all (and the enum evaluates fine, Bun having transpiled it itself), while `node --experimental-strip-types` does fire the hooks.

## Fix

Return `true` early from `checkTypeScriptLoader()` when `process.versions.bun` is set.

This is deliberately Bun-specific and **not** "skip the check whenever the runtime can do TypeScript". Node cannot replace `tsx` here: its native type stripping rejects enums (`ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX`) and does not resolve extensionless relative imports.

## Verification

Ran the minimal reproduction from the issue against this branch — Bun 1.4.2, no `require` entry, `tsx` not installed:

| Run | Result |
| --- | --- |
| Bun, with fix | `✔ plain TS scenario with an enum` — `OK \| 1 passed` |
| Bun, fix reverted | loader banner, exit 1 |
| Node, with fix | loader banner (unchanged, as intended) |

The Node row is the negative control: the fix is Bun-gated, so Node still demands a real loader — which it must, since native type stripping rejects the `enum` in that very repro file.

Also confirmed on a real 14-suite Playwright project (~1900 tests): removing the `require` line and deleting `tsx` from `node_modules` entirely, a full browser run passed unchanged — page objects, enums and extensionless relative imports included.

## Tests

`lib/utils/loaderCheck.js` had no unit coverage. Added `test/unit/utils/loaderCheck_test.js`, which stubs `process.versions.bun` (mutable under both runtimes) and restores it in `afterEach`, pinning both the new Bun branch and the pre-existing Node behaviour so the loader list cannot regress silently.

- New file: 5 passing
- Full unit suite (`mocha test/unit --recursive`): 775 passing, 11 pending, 0 failing
- eslint and prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)