### PR TITLE
fix: report Bun runtime in environment info

### DIFF
--- a/lib/command/info.js
+++ b/lib/command/info.js
@@ -44,6 +44,14 @@ async function getOsBrowsers() {
   ].join(', ')
 }
 
+// Which runtime executes CodeceptJS can only be told from `process.versions`; envinfo probes
+// PATH, where under `bunx --bun` the first `node` is a Bun shim with no --version, so
+// getNodeInfo() returns "Not Found" on a working install.
+async function getRuntimeInfo() {
+  if (process.versions.bun) return { bunInfo: await envinfo.helpers.getbunInfo() }
+  return { nodeInfo: await envinfo.helpers.getNodeInfo() }
+}
+
 export default async function (path) {
   const testsPath = getTestRoot(path)
   const config = await getConfig(testsPath)
@@ -53,7 +61,7 @@ export default async function (path) {
   output.print('\n Environment information: \n')
   const info = {}
   info.codeceptVersion = Codecept.version()
-  info.nodeInfo = await envinfo.helpers.getNodeInfo()
+  Object.assign(info, await getRuntimeInfo())
   info.osInfo = await envinfo.helpers.getOSInfo()
   info.cpuInfo = await envinfo.helpers.getCPUInfo()
   info.osBrowsers = await getOsBrowsers()
@@ -77,11 +85,11 @@ export default async function (path) {
   output.print('***************************************')
 }
 
-export { parsePlaywrightBrowsers }
+export { parsePlaywrightBrowsers, getRuntimeInfo }
 
 export const getMachineInfo = async () => {
   const info = {
-    nodeInfo: await envinfo.helpers.getNodeInfo(),
+    ...(await getRuntimeInfo()),
     osInfo: await envinfo.helpers.getOSInfo(),
     cpuInfo: await envinfo.helpers.getCPUInfo(),
     chromeInfo: await envinfo.helpers.getChromeInfo(),

--- a/test/unit/command/info_test.js
+++ b/test/unit/command/info_test.js
@@ -1,7 +1,47 @@
 import { expect } from 'chai'
-import { parsePlaywrightBrowsers } from '../../../lib/command/info.js'
+import { parsePlaywrightBrowsers, getRuntimeInfo } from '../../../lib/command/info.js'
 
 describe('info command', () => {
+  describe('getRuntimeInfo', () => {
+    let originalBunVersion
+
+    beforeEach(() => {
+      originalBunVersion = process.versions.bun
+    })
+
+    afterEach(() => {
+      if (originalBunVersion === undefined) {
+        delete process.versions.bun
+      } else {
+        process.versions.bun = originalBunVersion
+      }
+    })
+
+    it('should report bunInfo when running under Bun', async () => {
+      process.versions.bun = '1.4.2'
+      const info = await getRuntimeInfo()
+      expect(info).to.have.property('bunInfo')
+      expect(info).to.not.have.property('nodeInfo')
+      expect(info.bunInfo[0]).to.equal('bun')
+    })
+
+    it('should report nodeInfo when not running under Bun', async () => {
+      delete process.versions.bun
+      const info = await getRuntimeInfo()
+      expect(info).to.have.property('nodeInfo')
+      expect(info).to.not.have.property('bunInfo')
+      expect(info.nodeInfo[0]).to.equal('Node')
+    })
+
+    it('should return an array so the printer shows the version at index 1', async () => {
+      delete process.versions.bun
+      const { nodeInfo } = await getRuntimeInfo()
+      expect(nodeInfo).to.be.an('array')
+      expect(nodeInfo.length).to.be.at.least(2)
+      expect(nodeInfo[1]).to.be.a('string')
+    })
+  })
+
   describe('parsePlaywrightBrowsers', () => {
     describe('old format (Playwright < 1.58)', () => {
       const oldFormatOutput = `browser: chromium version 140.0.7339.186


### PR DESCRIPTION
Closes #5698

## Problem

`codecept info` — and the machine-info block printed by `run --verbose`, `run-workers --verbose` and `check` — hardcoded `envinfo.helpers.getNodeInfo()`. That helper probes `PATH`, not the running process, so under Bun the report was wrong in one of two ways:

- **`nodeInfo: Not Found` on a perfectly working install**, either because the image is Bun-only and has no `node` at all, or because `bunx --bun` prepends a temp dir whose `node` re-execs Bun and rejects `--version`.
- **A real but irrelevant Node version**, when some Node happens to be on `PATH`. This is the worse case, because it looks correct: an issue reported from a Bun project read as "Node 24.18.0" while Bun — the thing that actually matters — appeared nowhere.

Bun is a supported runtime for CodeceptJS 4, and `codeceptjs info` explicitly asks users to paste this block into GitHub issues, so getting the runtime wrong defeats the purpose of the block.

## Fix

Choose the helper by the runtime that is actually executing, and resolve both runtimes the same way through `envinfo`:

```js
async function getRuntimeInfo() {
  if (process.versions.bun) return { bunInfo: await envinfo.helpers.getbunInfo() }
  return { nodeInfo: await envinfo.helpers.getNodeInfo() }
}
```

`envinfo` already ships `getbunInfo` (lowercase `b`); it was simply never called. The branch has to read `process.versions.bun` because `envinfo` probes `PATH` and therefore cannot say which runtime is executing — that is runtime detection, distinct from version reporting.

This covers all four surfaces at once, since `info`, `run --verbose`, `run-workers --verbose` and `check` all print through `getMachineInfo()`.

**Node output is unchanged**, and the returned array keeps the shape of `getNodeInfo()`, so the existing `Array.isArray` printer shows the version at index 1 with no printer change. Nothing anywhere reads the `nodeInfo` key — it is only ever printed — so introducing `bunInfo` breaks no consumer. `envinfo` is pinned to an exact `7.21.0`, so `getbunInfo` is guaranteed present.

## Verification

Tested on the minimal reproduction from #5698, on Bun 1.4.2 / Node 24.18.0:

| scenario | before | after |
|---|---|---|
| `bunx --bun codeceptjs info` | `nodeInfo: Not Found` | `bunInfo: 1.4.2` |
| `bun --bun … info` / `run --verbose` | `nodeInfo: Not Found` | `bunInfo: 1.4.2` |
| Bun-only env, no `node` on PATH at all | `nodeInfo: Not Found` | `bunInfo: 1.4.2` |
| both runtimes on PATH, executed by Bun | `nodeInfo: 24.18.0` (wrong runtime) | `bunInfo: 1.4.2` |
| `node … info` / `run --verbose` | `nodeInfo: 24.18.0` | `nodeInfo: 24.18.0` (unchanged) |

Exactly one runtime line is printed, and `PATH` does not choose it — the executing runtime does.

Note that the version *number* still comes from `PATH`, so it is accurate whenever the executing binary is the one on `PATH`. That is the pre-existing behaviour of `getNodeInfo()` and it now applies identically to both runtimes: `getNodeInfo()` already misreports on plain Node when `PATH` disagrees with the executing binary (running v24.18.0 with v18.20.6 first on `PATH` reports `18.20.6`). Keeping Bun symmetric with Node was the deliberate choice here rather than special-casing one runtime.

## Tests

Three cases added to `test/unit/command/info_test.js`, covering the branch taken for each runtime and the array shape the printer depends on. They stub `process.versions.bun` so they run hermetically under either runtime, and assert no literal version, so they pass on machines where the probe returns `Not Found`.

Full unit suite: 773 passing. eslint and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
