### PR TITLE
feat: fillField works with role=combobox widgets

### DIFF
--- a/docs/basics.md
+++ b/docs/basics.md
@@ -241,6 +241,13 @@ I.uncheckOption('Subscribe')
 
 > [selectOption](/web-api#iselectoption) works with native `<select>` elements as well as custom components using `role="combobox"` or `role="listbox"`.
 
+> [fillField](/web-api#ifillfield) works with searchable comboboxes built on `role="combobox"` — including triggers rendered as a `<button>`. The combobox is expanded, its search input is located, and the value is typed into it, leaving the list filtered so an option can be picked:
+>
+> ```js
+> I.fillField('Country', 'Ukr')
+> I.click('Ukraine')
+> ```
+
 ### Assertions
 
 CodeceptJS provides **built-in browser assertions** instead of generic `expect()` calls. This keeps tests readable and produces clear failure messages without extra assertion libraries.

--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -40,7 +40,8 @@ import { findByPlaywrightLocator } from './extras/PlaywrightLocator.js'
 import { dropFile } from './scripts/dropFile.js'
 import WebElement from '../element/WebElement.js'
 import { selectElement } from './extras/elementSelection.js'
-import { fillRichEditor } from './extras/richTextEditor.js'
+import { detectFillTarget, fillRichEditor, FILL_TARGET } from './extras/richTextEditor.js'
+import { fillComboBox } from './extras/comboBox.js'
 
 let playwright
 let perfTiming
@@ -2282,7 +2283,14 @@ class Playwright extends Helper {
 
     await highlightActiveElement.call(this, el)
 
-    if (await fillRichEditor(this, el, value)) {
+    const fillTarget = await detectFillTarget(this, el)
+
+    if (fillTarget === FILL_TARGET.COMBOBOX) {
+      await fillComboBox(this, el, value)
+      return this._waitForAction()
+    }
+
+    if (await fillRichEditor(this, fillTarget, value)) {
       return this._waitForAction()
     }
 

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -45,7 +45,8 @@ import { dontSeeElementError, seeElementError, dontSeeElementInDOMError, seeElem
 import { dontSeeTraffic, seeTraffic, grabRecordedNetworkTraffics, stopRecordingTraffic, flushNetworkTraffics } from './network/actions.js'
 import WebElement from '../element/WebElement.js'
 import { selectElement } from './extras/elementSelection.js'
-import { fillRichEditor } from './extras/richTextEditor.js'
+import { detectFillTarget, fillRichEditor, FILL_TARGET } from './extras/richTextEditor.js'
+import { fillComboBox } from './extras/comboBox.js'
 
 let puppeteer
 
@@ -1592,7 +1593,14 @@ class Puppeteer extends Helper {
     assertElementExists(els, field, 'Field')
     const el = selectElement(els, field, this)
 
-    if (await fillRichEditor(this, el, value)) {
+    const fillTarget = await detectFillTarget(this, el)
+
+    if (fillTarget === FILL_TARGET.COMBOBOX) {
+      await fillComboBox(this, el, value)
+      return this._waitForAction()
+    }
+
+    if (await fillRichEditor(this, fillTarget, value)) {
       highlightActiveElement.call(this, el, await this._getContext())
       return this._waitForAction()
     }

--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -42,7 +42,8 @@ import { dropFile } from './scripts/dropFile.js'
 import { dontSeeTraffic, seeTraffic, grabRecordedNetworkTraffics, stopRecordingTraffic, flushNetworkTraffics } from './network/actions.js'
 import WebElement from '../element/WebElement.js'
 import { selectElement } from './extras/elementSelection.js'
-import { fillRichEditor } from './extras/richTextEditor.js'
+import { detectFillTarget, fillRichEditor, FILL_TARGET } from './extras/richTextEditor.js'
+import { fillComboBox } from './extras/comboBox.js'
 
 const SHADOW = 'shadow'
 const webRoot = 'body'
@@ -1264,8 +1265,16 @@ class WebDriver extends Helper {
     const elem = selectElement(res, field, this)
     highlightActiveElement.call(this, elem)
 
-    if (this.isWeb !== false && await fillRichEditor(this, elem, value)) {
-      return
+    if (this.isWeb !== false) {
+      const fillTarget = await detectFillTarget(this, elem)
+
+      if (fillTarget === FILL_TARGET.COMBOBOX) {
+        return fillComboBox(this, elem, value)
+      }
+
+      if (await fillRichEditor(this, fillTarget, value)) {
+        return
+      }
     }
 
     try {

--- a/lib/helper/extras/comboBox.js
+++ b/lib/helper/extras/comboBox.js
@@ -1,0 +1,136 @@
+import WebElement from '../../element/WebElement.js'
+
+const MARKER = 'data-codeceptjs-combobox-target'
+const PREVIOUS = 'data-codeceptjs-combobox-previous'
+const OPEN_TIMEOUT = 1000
+const POLL_INTERVAL = 50
+
+function locateInput(el, opts) {
+  const marker = opts.marker
+  const previous = opts.previous
+  const doc = el.ownerDocument
+  const NON_TEXT = ['checkbox', 'radio', 'button', 'submit', 'reset', 'image', 'file', 'range', 'color', 'hidden']
+  const SELECTOR = 'input, textarea, [contenteditable="true"], [contenteditable=""]'
+
+  function isEditable(node) {
+    if (!node || node.nodeType !== 1) return false
+    if (node.isContentEditable) return true
+    const t = node.tagName
+    if (t !== 'INPUT' && t !== 'TEXTAREA') return false
+    if (node.disabled || node.readOnly) return false
+    return t !== 'INPUT' || NON_TEXT.indexOf((node.type || 'text').toLowerCase()) === -1
+  }
+
+  function isVisible(node) {
+    return node.getClientRects().length > 0
+  }
+
+  function mark(node) {
+    doc.querySelectorAll('[' + marker + ']').forEach(n => n.removeAttribute(marker))
+    node.setAttribute(marker, '1')
+    let name = node.tagName.toLowerCase()
+    if (node.id) name += '#' + node.id
+    if (node.placeholder) name += '[placeholder="' + node.placeholder + '"]'
+    return name
+  }
+
+  function pick(root) {
+    const active = doc.activeElement
+    if (active && active !== el && !active.hasAttribute(previous) && root.contains(active) && isEditable(active)) return active
+    const nodes = root.querySelectorAll(SELECTOR)
+    for (let i = 0; i < nodes.length; i++) {
+      if (isEditable(nodes[i]) && isVisible(nodes[i])) return nodes[i]
+    }
+    return null
+  }
+
+  if (opts.tagActive) {
+    doc.querySelectorAll('[' + previous + ']').forEach(n => n.removeAttribute(previous))
+    if (doc.activeElement && doc.activeElement.nodeType === 1) doc.activeElement.setAttribute(previous, '1')
+  }
+
+  if (isEditable(el)) return mark(el)
+
+  const inner = pick(el)
+  if (inner) return mark(inner)
+
+  const roots = []
+  const controlled = el.getAttribute('aria-controls') || el.getAttribute('aria-owns')
+  if (controlled && doc.getElementById(controlled)) roots.push(doc.getElementById(controlled))
+  doc.querySelectorAll('[role="dialog"], [role="listbox"]').forEach(n => {
+    if (isVisible(n)) roots.push(n)
+  })
+
+  for (let i = 0; i < roots.length; i++) {
+    const found = pick(roots[i])
+    if (found) return mark(found)
+  }
+
+  if (!opts.allowActive) return null
+
+  let active = doc.activeElement
+  while (active && active.shadowRoot && active.shadowRoot.activeElement) active = active.shadowRoot.activeElement
+  if (active && active !== el && !active.hasAttribute(previous) && isEditable(active) && isVisible(active)) return mark(active)
+
+  return null
+}
+
+function readValue(el) {
+  return el.value === undefined ? el.textContent : el.value
+}
+
+function isActive(el) {
+  return el.ownerDocument.activeElement === el
+}
+
+function unmarkAll(markers) {
+  markers.forEach(marker => document.querySelectorAll('[' + marker + ']').forEach(n => n.removeAttribute(marker)))
+}
+
+async function findMarked(helper) {
+  const root = helper.page || helper.browser
+  const raw = await root.$('[' + MARKER + ']')
+  return new WebElement(raw, helper)
+}
+
+async function clearMarker(helper) {
+  if (helper.page) return helper.page.evaluate(unmarkAll, [MARKER, PREVIOUS])
+  return helper.executeScript(unmarkAll, [MARKER, PREVIOUS])
+}
+
+export async function fillComboBox(helper, el, value) {
+  const trigger = el instanceof WebElement ? el : new WebElement(el, helper)
+  const options = { marker: MARKER, previous: PREVIOUS }
+  let found = await trigger.evaluate(locateInput, { ...options, tagActive: true })
+
+  if (!found) {
+    if ((await trigger.getAttribute('aria-expanded')) !== 'true') {
+      helper.debugSection('ComboBox', 'Expanding combobox')
+      await trigger.click()
+    }
+    const deadline = Date.now() + OPEN_TIMEOUT
+    while (!found && Date.now() < deadline) {
+      await new Promise(resolve => setTimeout(resolve, POLL_INTERVAL))
+      found = await trigger.evaluate(locateInput, { ...options, allowActive: true })
+    }
+  }
+
+  if (!found) {
+    await clearMarker(helper)
+    throw new Error('fillField: combobox exposes no text input to type into. Use I.selectOption() to pick one of its options.')
+  }
+
+  const target = await findMarked(helper)
+  helper.debugSection('ComboBox', `Typing into ${found}`)
+
+  await target.focus()
+  if (!(await target.evaluate(isActive))) await target.click()
+  if (!(await target.evaluate(isActive))) {
+    throw new Error(`fillField: combobox input ${found} did not accept focus.`)
+  }
+
+  if (await target.evaluate(readValue)) await target.selectAllAndDelete()
+  await target.typeText(value, { delay: helper.options.pressKeyDelay })
+
+  await clearMarker(helper)
+}

--- a/lib/helper/extras/richTextEditor.js
+++ b/lib/helper/extras/richTextEditor.js
@@ -7,18 +7,31 @@ const EDITOR = {
   IFRAME: 'iframe',
   CONTENTEDITABLE: 'contenteditable',
   HIDDEN_TEXTAREA: 'hidden-textarea',
+  COMBOBOX: 'combobox',
   UNREACHABLE: 'unreachable',
 }
+
+export const FILL_TARGET = EDITOR
 
 function detectAndMark(el, opts) {
   const marker = opts.marker
   const kinds = opts.kinds
   const CE = '[contenteditable="true"], [contenteditable=""]'
+  const NON_TEXT = ['checkbox', 'radio', 'button', 'submit', 'reset', 'image', 'file', 'range', 'color', 'hidden']
 
   function mark(kind, target) {
     document.querySelectorAll('[' + marker + ']').forEach(n => n.removeAttribute(marker))
     if (target && target.nodeType === 1) target.setAttribute(marker, '1')
     return kind
+  }
+
+  function isEditable(node) {
+    if (!node || node.nodeType !== 1) return false
+    if (node.isContentEditable) return true
+    const t = node.tagName
+    if (t !== 'INPUT' && t !== 'TEXTAREA') return false
+    if (node.disabled || node.readOnly) return false
+    return t !== 'INPUT' || NON_TEXT.indexOf((node.type || 'text').toLowerCase()) === -1
   }
 
   if (!el || el.nodeType !== 1) return mark(kinds.STANDARD, el)
@@ -31,6 +44,10 @@ function detectAndMark(el, opts) {
   if ((tag === 'INPUT' || tag === 'TEXTAREA') && !isFormHidden) {
     const style = window.getComputedStyle(el)
     if (style.display === 'none') return mark(kinds.UNREACHABLE, el)
+  }
+
+  if (el.getAttribute('role') === 'combobox' || (!isEditable(el) && el.hasAttribute('aria-haspopup'))) {
+    return mark(kinds.COMBOBOX, null)
   }
 
   const canSearchDescendants = tag !== 'INPUT' && tag !== 'TEXTAREA'
@@ -136,9 +153,12 @@ async function clearMarker(helper) {
   return helper.executeScript(unmarkAll, MARKER)
 }
 
-export async function fillRichEditor(helper, el, value) {
+export async function detectFillTarget(helper, el) {
   const source = el instanceof WebElement ? el : new WebElement(el, helper)
-  const kind = await source.evaluate(detectAndMark, { marker: MARKER, kinds: EDITOR })
+  return source.evaluate(detectAndMark, { marker: MARKER, kinds: EDITOR })
+}
+
+export async function fillRichEditor(helper, kind, value) {
   if (kind === EDITOR.STANDARD) return false
   if (kind === EDITOR.UNREACHABLE) {
     throw new Error('fillField: cannot fill a display:none form control. Locator must point at the visible editor surface (a wrapper, iframe, or contenteditable).')

--- a/lib/locator.js
+++ b/lib/locator.js
@@ -615,8 +615,8 @@ Locator.field = {
    */
   labelEquals: literal =>
     xpathLocator.combine([
-      `.//*[self::input | self::textarea | self::select][not(./@type = 'submit' or ./@type = 'image' or ./@type = 'hidden')][((./@name = ${literal}) or ./@id = //label[@for][normalize-space(string(.)) = ${literal}]/@for or ./@placeholder = ${literal})]`,
-      `.//label[normalize-space(string(.)) = ${literal}]//.//*[self::input | self::textarea | self::select][not(./@type = 'submit' or ./@type = 'image' or ./@type = 'hidden')]`,
+      `.//*[self::input | self::textarea | self::select][not(./@aria-hidden = 'true')][not(./@type = 'submit' or ./@type = 'image' or ./@type = 'hidden')][((./@name = ${literal}) or ./@id = //label[@for][normalize-space(string(.)) = ${literal}]/@for or ./@placeholder = ${literal})]`,
+      `.//label[normalize-space(string(.)) = ${literal}]//.//*[self::input | self::textarea | self::select][not(./@aria-hidden = 'true')][not(./@type = 'submit' or ./@type = 'image' or ./@type = 'hidden')]`,
     ]),
 
   /**
@@ -625,8 +625,8 @@ Locator.field = {
    */
   labelContains: literal =>
     xpathLocator.combine([
-      `.//*[self::input | self::textarea | self::select][not(./@type = 'submit' or ./@type = 'image' or ./@type = 'hidden')][(((./@name = ${literal}) or ./@id = //label[@for][contains(normalize-space(string(.)), ${literal})]/@for) or ./@placeholder = ${literal})]`,
-      `.//label[contains(normalize-space(string(.)), ${literal})]//.//*[self::input | self::textarea | self::select][not(./@type = 'submit' or ./@type = 'image' or ./@type = 'hidden')]`,
+      `.//*[self::input | self::textarea | self::select][not(./@aria-hidden = 'true')][not(./@type = 'submit' or ./@type = 'image' or ./@type = 'hidden')][(((./@name = ${literal}) or ./@id = //label[@for][contains(normalize-space(string(.)), ${literal})]/@for) or ./@placeholder = ${literal})]`,
+      `.//label[contains(normalize-space(string(.)), ${literal})]//.//*[self::input | self::textarea | self::select][not(./@aria-hidden = 'true')][not(./@type = 'submit' or ./@type = 'image' or ./@type = 'hidden')]`,
       `.//*[@aria-label = ${literal}]`,
       `.//*[@title = ${literal}]`,
       `.//*[@aria-labelledby][@aria-labelledby = //*[@id][normalize-space(string(.)) = ${literal}]/@id]`,
@@ -636,7 +636,7 @@ Locator.field = {
    * @param {string} literal
    * @returns {string}
    */
-  byName: literal => `.//*[self::input | self::textarea | self::select][@name = ${literal}]`,
+  byName: literal => `.//*[self::input | self::textarea | self::select][not(./@aria-hidden = 'true')][@name = ${literal}]`,
 
   /**
    * @param {string} literal
@@ -644,8 +644,8 @@ Locator.field = {
    */
   byText: literal =>
     xpathLocator.combine([
-      `.//*[self::input | self::textarea | self::select][not(./@type = 'submit' or ./@type = 'image' or ./@type = 'hidden')][(((./@name = ${literal}) or ./@id = //label[@for][contains(normalize-space(string(.)), ${literal})]/@for) or ./@placeholder = ${literal})]`,
-      `.//label[contains(normalize-space(string(.)), ${literal})]//.//*[self::input | self::textarea | self::select][not(./@type = 'submit' or ./@type = 'image' or ./@type = 'hidden')]`,
+      `.//*[self::input | self::textarea | self::select][not(./@aria-hidden = 'true')][not(./@type = 'submit' or ./@type = 'image' or ./@type = 'hidden')][(((./@name = ${literal}) or ./@id = //label[@for][contains(normalize-space(string(.)), ${literal})]/@for) or ./@placeholder = ${literal})]`,
+      `.//label[contains(normalize-space(string(.)), ${literal})]//.//*[self::input | self::textarea | self::select][not(./@aria-hidden = 'true')][not(./@type = 'submit' or ./@type = 'image' or ./@type = 'hidden')]`,
     ]),
 }
 

--- a/test/data/app/view/form/combobox.php
+++ b/test/data/app/view/form/combobox.php
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Comboboxes</title>
+</head>
+<body>
+    <h1>Comboboxes</h1>
+    <p>Test pages for fillField against combobox widgets.</p>
+    <ul>
+        <li><a href="/form/combobox/baseui">Base UI</a> — button[role=combobox], input inside popup</li>
+        <li><a href="/form/combobox/baseui-inline">Base UI (inline)</a> — input[role=combobox], typed directly</li>
+        <li><a href="/form/custom_select">Custom select</a> — div[role=combobox], no text input</li>
+    </ul>
+</body>
+</html>

--- a/test/data/app/view/form/combobox/baseui-inline.php
+++ b/test/data/app/view/form/combobox/baseui-inline.php
@@ -1,0 +1,58 @@
+<?php $initial = isset($_GET['initial']) ? $_GET['initial'] : ''; ?>
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Base UI Combobox (inline input)</title>
+    <style>
+        body { font-family: Arial, sans-serif; padding: 20px; }
+        label { display: block; font-weight: bold; margin-bottom: 5px; }
+        input[role="combobox"] { width: 250px; padding: 10px; border: 1px solid #ccc; border-radius: 4px; }
+        .Popup { background: #fff; border: 1px solid #ccc; border-radius: 4px; padding: 6px; min-width: 250px; box-shadow: 0 4px 12px rgba(0,0,0,.15); }
+        [role="option"] { padding: 8px; cursor: pointer; }
+        [role="option"][data-highlighted] { background: #e8e8e8; }
+    </style>
+    <script type="importmap">
+    {"imports": {
+      "react": "https://esm.sh/react@19.2.0",
+      "react/jsx-runtime": "https://esm.sh/react@19.2.0/jsx-runtime",
+      "react-dom": "https://esm.sh/react-dom@19.2.0",
+      "react-dom/client": "https://esm.sh/react-dom@19.2.0/client"
+    }}
+    </script>
+</head>
+<body>
+    <h1>Base UI Combobox (inline input)</h1>
+    <form id="combobox-form" method="post" action="/richtext_submit">
+        <input type="text" id="outer-title" placeholder="Outer title">
+        <div id="root"></div>
+        <button type="submit" id="submit">Submit</button>
+    </form>
+    <script type="module">
+        import * as React from 'react'
+        import { createRoot } from 'react-dom/client'
+        import { Combobox } from 'https://esm.sh/@base-ui-components/react@1.0.0-rc.0/combobox?external=react,react-dom'
+        import { Field } from 'https://esm.sh/@base-ui-components/react@1.0.0-rc.0/field?external=react,react-dom'
+
+        const h = React.createElement
+        const countries = ['United Kingdom', 'United States', 'Ukraine', 'Portugal', 'France', 'Germany']
+        const initial = <?php echo json_encode($initial, JSON_UNESCAPED_UNICODE); ?>
+
+        function App() {
+            return h(Field.Root, null,
+                h(Field.Label, null, 'Country'),
+                h(Combobox.Root, { items: countries, name: 'content', defaultValue: initial || null },
+                    h(Combobox.Input, { placeholder: 'e.g. United Kingdom' }),
+                    h(Combobox.Portal, null,
+                        h(Combobox.Positioner, { sideOffset: 4 },
+                            h(Combobox.Popup, { className: 'Popup' },
+                                h(Combobox.List, null, item => h(Combobox.Item, { key: item, value: item }, item)))))))
+        }
+
+        createRoot(document.getElementById('root')).render(h(App))
+
+        window.__comboValue = () => document.querySelector('input[name="content"]').value
+        window.__ready = true
+    </script>
+</body>
+</html>

--- a/test/data/app/view/form/combobox/baseui.php
+++ b/test/data/app/view/form/combobox/baseui.php
@@ -1,0 +1,60 @@
+<?php $initial = isset($_GET['initial']) ? $_GET['initial'] : ''; ?>
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Base UI Combobox</title>
+    <style>
+        body { font-family: Arial, sans-serif; padding: 20px; }
+        label { display: block; font-weight: bold; margin-bottom: 5px; }
+        button[role="combobox"] { width: 250px; padding: 10px; text-align: left; border: 1px solid #ccc; border-radius: 4px; background: #fff; }
+        .Popup { background: #fff; border: 1px solid #ccc; border-radius: 4px; padding: 6px; min-width: 250px; box-shadow: 0 4px 12px rgba(0,0,0,.15); }
+        .Popup input { width: 100%; padding: 8px; box-sizing: border-box; }
+        [role="option"] { padding: 8px; cursor: pointer; }
+        [role="option"][data-highlighted] { background: #e8e8e8; }
+    </style>
+    <script type="importmap">
+    {"imports": {
+      "react": "https://esm.sh/react@19.2.0",
+      "react/jsx-runtime": "https://esm.sh/react@19.2.0/jsx-runtime",
+      "react-dom": "https://esm.sh/react-dom@19.2.0",
+      "react-dom/client": "https://esm.sh/react-dom@19.2.0/client"
+    }}
+    </script>
+</head>
+<body>
+    <h1>Base UI Combobox</h1>
+    <form id="combobox-form" method="post" action="/richtext_submit">
+        <input type="text" id="outer-title" placeholder="Outer title">
+        <div id="root"></div>
+        <button type="submit" id="submit">Submit</button>
+    </form>
+    <script type="module">
+        import * as React from 'react'
+        import { createRoot } from 'react-dom/client'
+        import { Combobox } from 'https://esm.sh/@base-ui-components/react@1.0.0-rc.0/combobox?external=react,react-dom'
+        import { Field } from 'https://esm.sh/@base-ui-components/react@1.0.0-rc.0/field?external=react,react-dom'
+
+        const h = React.createElement
+        const countries = ['United Kingdom', 'United States', 'Ukraine', 'Portugal', 'France', 'Germany']
+        const initial = <?php echo json_encode($initial, JSON_UNESCAPED_UNICODE); ?>
+
+        function App() {
+            return h(Field.Root, null,
+                h(Field.Label, null, 'Country'),
+                h(Combobox.Root, { items: countries, name: 'content', defaultValue: initial || null },
+                    h(Combobox.Trigger, null, h(Combobox.Value, { placeholder: 'Select country' })),
+                    h(Combobox.Portal, null,
+                        h(Combobox.Positioner, { sideOffset: 4 },
+                            h(Combobox.Popup, { className: 'Popup' },
+                                h(Combobox.Input, { placeholder: 'e.g. United Kingdom' }),
+                                h(Combobox.List, null, item => h(Combobox.Item, { key: item, value: item }, item)))))))
+        }
+
+        createRoot(document.getElementById('root')).render(h(App))
+
+        window.__comboValue = () => document.querySelector('input[name="content"]').value
+        window.__ready = true
+    </script>
+</body>
+</html>

--- a/test/helper/webapi.js
+++ b/test/helper/webapi.js
@@ -949,6 +949,80 @@ export function tests() {
     })
   })
 
+  describe('#fillField - comboboxes', function () {
+    this.timeout(60000)
+
+    async function open(page, initial) {
+      const q = initial != null ? `?initial=${encodeURIComponent(initial)}` : ''
+      await I.amOnPage(`/form/combobox/${page}${q}`)
+      await I.waitForFunction(() => window.__ready === true, [], 30)
+    }
+
+    async function outerTitleValue() {
+      return I.executeScript(() => document.getElementById('outer-title').value)
+    }
+
+    async function comboInputValue() {
+      return I.executeScript(() => {
+        const inputs = [...document.querySelectorAll('input[role="combobox"]')]
+        return inputs.length ? inputs[inputs.length - 1].value : null
+      })
+    }
+
+    async function visibleOptions() {
+      return I.executeScript(() =>
+        [...document.querySelectorAll('[role="option"]')]
+          .filter(o => o.getClientRects().length)
+          .map(o => o.textContent.trim()),
+      )
+    }
+
+    for (const page of ['baseui', 'baseui-inline']) {
+      describe(page, () => {
+        it('types into the combobox and filters its options', async () => {
+          await open(page)
+          await I.fillField('Country', 'United')
+          expect(await comboInputValue()).to.equal('United')
+          expect(await visibleOptions()).to.deep.equal(['United Kingdom', 'United States'])
+        })
+
+        it('submits the option picked after filtering', async () => {
+          await open(page)
+          await I.fillField('Country', 'Ukr')
+          await I.click('Ukraine')
+          await I.click('#submit')
+          await I.waitForElement('#result', 15)
+          expect(await I.grabTextFrom('#result')).to.include('Ukraine')
+        })
+
+        it('rewrites a pre-populated value', async () => {
+          await open(page, 'Portugal')
+          await I.fillField('Country', 'France')
+          expect(await comboInputValue()).to.equal('France')
+        })
+
+        it('does not leak keystrokes to the outer focused input', async () => {
+          await open(page)
+          await I.click('#outer-title')
+          await I.fillField('Country', 'United')
+          expect(await outerTitleValue()).to.equal('')
+        })
+      })
+    }
+
+    it('fails with a helpful message when the combobox has no text input', async () => {
+      await I.amOnPage('/form/custom_select')
+      let message = ''
+      try {
+        await I.fillField('Country', 'London')
+      } catch (e) {
+        message = e.message
+      }
+      expect(message).to.include('no text input')
+      expect(message).to.include('selectOption')
+    })
+  })
+
   describe('#clearField', () => {
     it('should clear a given element', async () => {
       await I.amOnPage('/form/field')

--- a/test/unit/locator_test.js
+++ b/test/unit/locator_test.js
@@ -808,4 +808,41 @@ describe('Locator', () => {
       expect(items[0].getAttribute('id')).to.eql('rename')
     })
   })
+  describe('Locator.field', () => {
+    const comboboxXml = `<root>
+      <label for="value-input" id="country-label">Country</label>
+      <button type="button" role="combobox" id="trigger" aria-expanded="false" aria-labelledby="country-label"></button>
+      <input id="value-input" name="country" tabindex="-1" aria-hidden="true" value=""/>
+    </root>`
+
+    it('skips the aria-hidden proxy input a label points at', () => {
+      const comboboxDoc = new DOMParser().parseFromString(comboboxXml, 'text/xml')
+      const root = xpath.select1('//root', comboboxDoc)
+
+      expect(xpath.select(Locator.field.labelEquals("'Country'"), root)).to.have.length(0)
+      expect(xpath.select(Locator.field.byName("'country'"), root)).to.have.length(0)
+    })
+
+    it('resolves the labelled combobox once the proxy is skipped', () => {
+      const comboboxDoc = new DOMParser().parseFromString(comboboxXml, 'text/xml')
+      const root = xpath.select1('//root', comboboxDoc)
+
+      const nodes = xpath.select(Locator.field.labelContains("'Country'"), root)
+      expect(nodes).to.have.length(1)
+      expect(nodes[0].getAttribute('id')).to.eql('trigger')
+    })
+
+    it('still matches a regular labelled input', () => {
+      const formXml = `<root>
+        <label for="name">Name</label>
+        <input id="name" name="name" value=""/>
+      </root>`
+      const formDoc = new DOMParser().parseFromString(formXml, 'text/xml')
+      const root = xpath.select1('//root', formDoc)
+
+      const nodes = xpath.select(Locator.field.labelEquals("'Name'"), root)
+      expect(nodes).to.have.length(1)
+      expect(nodes[0].getAttribute('id')).to.eql('name')
+    })
+  })
 })


### PR DESCRIPTION
## Problem

`I.fillField('Country', 'Ukr')` does not work against comboboxes whose trigger is not a text field — the shadcn / Base UI pattern where a `<button role="combobox">` opens a popup containing the search input.

Worse, against Base UI it **silently passes while doing nothing**. Base UI renders:

```html
<label for="value-input" id="country-label">Country</label>
<button role="combobox" aria-labelledby="country-label"></button>
<input id="value-input" name="content" tabindex="-1" aria-hidden="true" style="clip:rect(0,0,0,0);position:fixed">
```

The `<label for>` points at the **aria-hidden form-value proxy**, not at the trigger. `Locator.field.labelEquals` is tried first in `findFields` and matches that proxy, so `fillField` types into a zero-size invisible input and the step resolves green while the app never sees the interaction.

## What changed

**`Locator.field` skips aria-hidden proxies** (`lib/locator.js`) — one predicate added to the `input | textarea | select` branches of all four builders, so all three helpers are fixed in one place. With the proxy filtered, resolution falls through to `labelContains` → `aria-labelledby` → the trigger.

**`fillField` handles combobox triggers** (`lib/helper/extras/comboBox.js`) — a `<button role="combobox">`, a `<div role="combobox">`, or a readonly input trigger is expanded, its search input located, and the value typed there. The popup is left open and filtered so an option can be picked:

```js
I.fillField('Country', 'Ukr')
I.click('Ukraine')
```

Locating the input walks, in order: an editable descendant of the trigger (ARIA 1.1 wrapper, no click needed), the `aria-controls`/`aria-owns` container, a visible `[role=dialog]`/`[role=listbox]` popup, then the focused element. Two details are measured rather than assumed:

- Focus lands **asynchronously ~80ms after `click()` resolves** in Base UI (`pointerdown t=0 → click t=3 → focusin t=82`), so the search is polled to a 1s deadline instead of sampled once.
- The element focused **before** the click is excluded, so a previously focused field never receives the keystrokes.

A combobox exposing no text input raises `combobox exposes no text input to type into. Use I.selectOption() to pick one of its options.` rather than typing into nothing.

`role="combobox"` inputs (Base UI inline, MUI, Downshift) also route through this path, so they are typed with real keystrokes rather than a one-shot `fill()` — comboboxes that filter on `keydown` need that.

Detection reuses the single `evaluate` that `richTextEditor` already runs per `fillField`, so no extra round-trip is added to ordinary fills.

## Tests

New belt in `test/helper/webapi.js`, so it runs against Playwright, Puppeteer and WebDriver — mirroring the rich-editor belt. Fixtures load Base UI 1.0.0-rc.0 from CDN with no build step (`test/data/app/view/form/combobox/`), covering the button trigger, the inline input, and `custom_select.php` as the negative case.

Each variant asserts: typing filters the options, the picked option submits, a pre-populated value is rewritten, and keystrokes do not leak to an outer focused input. `Locator.field` gets unit tests in `test/unit/locator_test.js`.

Local: 9/9 combobox belt on Playwright and Puppeteer, 75/75 `fillField` on Playwright (rich editors included, no regressions), 15/15 `selectOption`, 772 unit tests. WebDriver has no local server here — relying on CI.

Note for review: `test/data/app/view/form/combobox/*` pull React and Base UI from **esm.sh**, a CDN this repo has not used before (existing fixtures use jsdelivr). Versions are pinned exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ut1rjeUiZmKU7V61CeYhns