### PR TITLE
feat: checkOption finds checkables by ARIA role

### DIFF
--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -50,6 +50,7 @@ let defaultSelectorEnginesInitialized = false
 const popupStore = new Popup()
 const consoleLogStore = new Console()
 const availableBrowsers = ['chromium', 'webkit', 'firefox', 'electron']
+const checkableRoles = ['checkbox', 'radio', 'switch']
 
 import { setRestartStrategy, restartsSession, restartsContext, restartsBrowser } from './extras/PlaywrightRestartOpts.js'
 import { createValueEngine, createDisabledEngine } from './extras/PlaywrightPropEngine.js'
@@ -4383,6 +4384,17 @@ async function findCheckable(locator, context) {
   const matchedLocator = new Locator(locator)
   if (!matchedLocator.isFuzzy()) {
     return findElements.call(this, contextEl, matchedLocator)
+  }
+
+  for (const exact of [true, false]) {
+    for (const role of checkableRoles) {
+      try {
+        const roleEls = await contextEl.getByRole(role, { name: matchedLocator.value, exact }).all()
+        if (roleEls.length) return roleEls
+      } catch (err) {
+        // getByRole not supported or failed
+      }
+    }
   }
 
   const literal = xpathLocator.literal(matchedLocator.value)

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -64,6 +64,7 @@ function wrapError(e) {
 let perfTiming
 const popupStore = new Popup()
 const consoleLogStore = new Console()
+const checkableRoles = ['checkbox', 'radio', 'switch']
 
 /**
  * ## Configuration
@@ -3194,11 +3195,13 @@ async function findCheckable(locator, context) {
 
   // Try ARIA selector for accessible name
   let els
-  try {
-    els = await contextEl.$$(`::-p-aria(${matchedLocator.value})`)
-    if (els.length) return els
-  } catch (err) {
-    // ARIA selector not supported or failed
+  for (const role of checkableRoles) {
+    try {
+      els = await contextEl.$$(`::-p-aria([name="${matchedLocator.value}"][role="${role}"])`)
+      if (els.length) return els
+    } catch (err) {
+      // ARIA selector not supported or failed
+    }
   }
 
   const literal = xpathLocator.literal(matchedLocator.value)

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -3192,22 +3192,23 @@ async function findCheckable(locator, context) {
     return findElements.call(this, contextEl, matchedLocator)
   }
 
+  // Try ARIA selector for accessible name
+  let els
+  try {
+    els = await contextEl.$$(`::-p-aria(${matchedLocator.value})`)
+    if (els.length) return els
+  } catch (err) {
+    // ARIA selector not supported or failed
+  }
+
   const literal = xpathLocator.literal(matchedLocator.value)
-  let els = await findElements.call(this, contextEl, Locator.checkable.byText(literal))
+  els = await findElements.call(this, contextEl, Locator.checkable.byText(literal))
   if (els.length) {
     return els
   }
   els = await findElements.call(this, contextEl, Locator.checkable.byName(literal))
   if (els.length) {
     return els
-  }
-
-  // Try ARIA selector for accessible name
-  try {
-    els = await contextEl.$$(`::-p-aria(${matchedLocator.value})`)
-    if (els.length) return els
-  } catch (err) {
-    // ARIA selector not supported or failed
   }
 
   return findElements.call(this, contextEl, matchedLocator.value)

--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -3245,10 +3245,6 @@ async function findCheckable(locator, locateFn) {
   if (locator.isRole()) return locateFn(locator, true)
   if (!locator.isFuzzy()) return locateFn(locator, true)
 
-  const literal = xpathLocator.literal(locator.value)
-  els = await locateFn(Locator.checkable.byText(literal))
-  if (els.length) return els
-
   // Try ARIA selector for accessible name
   try {
     els = await locateFn(`aria/${locator.value}`)
@@ -3256,6 +3252,10 @@ async function findCheckable(locator, locateFn) {
   } catch (e) {
     // ARIA selector not supported or failed
   }
+
+  const literal = xpathLocator.literal(locator.value)
+  els = await locateFn(Locator.checkable.byText(literal))
+  if (els.length) return els
 
   els = await locateFn(Locator.checkable.byName(literal))
   if (els.length) return els

--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -3247,7 +3247,7 @@ async function findCheckable(locator, locateFn) {
 
   // Try ARIA selector for accessible name
   try {
-    els = await locateFn(`aria/${locator.value}`)
+    els = await keepCheckable.call(this, await locateFn(`aria/${locator.value}`))
     if (els.length) return els
   } catch (e) {
     // ARIA selector not supported or failed
@@ -3261,6 +3261,21 @@ async function findCheckable(locator, locateFn) {
   if (els.length) return els
 
   return await locateFn(locator.value) // by css or xpath
+}
+
+async function keepCheckable(els) {
+  if (!els || !els.length) return []
+
+  const checkable = await this.browser.execute(function () {
+    return Array.prototype.slice.call(arguments).map(function (el) {
+      if (!el) return false
+      const role = el.getAttribute('role')
+      if (role) return ['checkbox', 'radio', 'switch'].indexOf(role) > -1
+      return el.tagName === 'INPUT' && (el.type === 'checkbox' || el.type === 'radio')
+    })
+  }, ...els)
+
+  return els.filter((el, index) => checkable[index])
 }
 
 function withStrictLocator(locator) {

--- a/test/data/app/view/form/checkable/baseui.php
+++ b/test/data/app/view/form/checkable/baseui.php
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Base UI Checkables</title>
+    <style>
+        body { font-family: Arial, sans-serif; }
+        .row { margin: 12px 0; display: flex; align-items: center; gap: 8px; }
+        label { font-weight: bold; }
+        span[role="checkbox"], span[role="radio"] { display: inline-block; width: 20px; height: 20px; border: 1px solid #666; background: #fff; border-radius: 3px; }
+        span[role="checkbox"][data-checked], span[role="radio"][data-checked] { background: #2a6; }
+        span[role="switch"] { display: inline-block; width: 42px; height: 22px; border: 1px solid #666; background: #ddd; border-radius: 11px; }
+        span[role="switch"][data-checked] { background: #2a6; }
+    </style>
+    <script type="importmap">
+    {"imports": {
+      "react": "https://esm.sh/react@19.2.0",
+      "react/jsx-runtime": "https://esm.sh/react@19.2.0/jsx-runtime",
+      "react-dom": "https://esm.sh/react-dom@19.2.0",
+      "react-dom/client": "https://esm.sh/react-dom@19.2.0/client"
+    }}
+    </script>
+</head>
+<body>
+    <h1>Base UI Checkables</h1>
+    <div id="root"></div>
+    <script type="module">
+        import * as React from 'react'
+        import { createRoot } from 'react-dom/client'
+        import { Checkbox } from 'https://esm.sh/@base-ui/react@1.8.0/checkbox?external=react,react-dom'
+        import { Switch } from 'https://esm.sh/@base-ui/react@1.8.0/switch?external=react,react-dom'
+        import { Radio } from 'https://esm.sh/@base-ui/react@1.8.0/radio?external=react,react-dom'
+        import { RadioGroup } from 'https://esm.sh/@base-ui/react@1.8.0/radio-group?external=react,react-dom'
+
+        const h = React.createElement
+
+        function App() {
+            React.useEffect(() => { window.__ready = true }, [])
+            return h('div', null,
+                h('div', { className: 'row' },
+                    h(Checkbox.Root, { id: 'terms', className: 'ctl-terms' }, h(Checkbox.Indicator, null)),
+                    h('label', { htmlFor: 'terms' }, 'Accept terms')),
+                h('div', { className: 'row' },
+                    h(Switch.Root, { id: 'airplane', className: 'ctl-airplane' }, h(Switch.Thumb, null)),
+                    h('label', { htmlFor: 'airplane' }, 'Airplane mode')),
+                h(RadioGroup, { defaultValue: 'default', 'aria-label': 'Density' },
+                    h('div', { className: 'row' },
+                        h(Radio.Root, { value: 'default', id: 'r-default', className: 'ctl-default' }, h(Radio.Indicator, null)),
+                        h('label', { htmlFor: 'r-default' }, 'Default')),
+                    h('div', { className: 'row' },
+                        h(Radio.Root, { value: 'comfortable', id: 'r-comfortable', className: 'ctl-comfortable' }, h(Radio.Indicator, null)),
+                        h('label', { htmlFor: 'r-comfortable' }, 'Comfortable'))))
+        }
+
+        createRoot(document.getElementById('root')).render(h(App))
+    </script>
+</body>
+</html>

--- a/test/data/app/view/form/checkable/collision.php
+++ b/test/data/app/view/form/checkable/collision.php
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Checkable name collision</title>
+</head>
+<body>
+    <h2>Accept terms</h2>
+    <form action="/form/complex" method="POST">
+        <label for="terms-box">Accept terms</label>
+        <input type="checkbox" id="terms-box" name="terms" value="agree" />
+        <input type="submit" value="Submit" />
+    </form>
+</body>
+</html>

--- a/test/data/app/view/form/checkable/radix.php
+++ b/test/data/app/view/form/checkable/radix.php
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Radix Checkables</title>
+    <style>
+        body { font-family: Arial, sans-serif; }
+        .row { margin: 12px 0; display: flex; align-items: center; gap: 8px; }
+        label { font-weight: bold; }
+        button[role="checkbox"], button[role="radio"] { width: 20px; height: 20px; border: 1px solid #666; background: #fff; border-radius: 3px; }
+        button[role="checkbox"][data-state="checked"], button[role="radio"][data-state="checked"] { background: #2a6; }
+        button[role="switch"] { width: 42px; height: 22px; border: 1px solid #666; background: #ddd; border-radius: 11px; }
+        button[role="switch"][data-state="checked"] { background: #2a6; }
+    </style>
+    <script type="importmap">
+    {"imports": {
+      "react": "https://esm.sh/react@19.2.0",
+      "react/jsx-runtime": "https://esm.sh/react@19.2.0/jsx-runtime",
+      "react-dom": "https://esm.sh/react-dom@19.2.0",
+      "react-dom/client": "https://esm.sh/react-dom@19.2.0/client"
+    }}
+    </script>
+</head>
+<body>
+    <h1>Radix Checkables</h1>
+    <div id="root"></div>
+    <script type="module">
+        import * as React from 'react'
+        import { createRoot } from 'react-dom/client'
+        import { Checkbox, Switch, RadioGroup } from 'https://esm.sh/radix-ui@1.6.7?external=react,react-dom'
+
+        const h = React.createElement
+
+        function App() {
+            React.useEffect(() => { window.__ready = true }, [])
+            return h('div', null,
+                h('div', { className: 'row' },
+                    h(Checkbox.Root, { id: 'terms', className: 'ctl-terms' }, h(Checkbox.Indicator, null)),
+                    h('label', { htmlFor: 'terms' }, 'Accept terms')),
+                h('div', { className: 'row' },
+                    h(Switch.Root, { id: 'airplane', className: 'ctl-airplane' }, h(Switch.Thumb, null)),
+                    h('label', { htmlFor: 'airplane' }, 'Airplane mode')),
+                h(RadioGroup.Root, { defaultValue: 'default', 'aria-label': 'Density' },
+                    h('div', { className: 'row' },
+                        h(RadioGroup.Item, { value: 'default', id: 'r-default', className: 'ctl-default' }, h(RadioGroup.Indicator, null)),
+                        h('label', { htmlFor: 'r-default' }, 'Default')),
+                    h('div', { className: 'row' },
+                        h(RadioGroup.Item, { value: 'comfortable', id: 'r-comfortable', className: 'ctl-comfortable' }, h(RadioGroup.Indicator, null)),
+                        h('label', { htmlFor: 'r-comfortable' }, 'Comfortable'))))
+        }
+
+        createRoot(document.getElementById('root')).render(h(App))
+    </script>
+</body>
+</html>

--- a/test/helper/webapi.js
+++ b/test/helper/webapi.js
@@ -583,6 +583,14 @@ export function tests() {
       await I.click('Submit')
       assert.equal(formContents('terms'), 'agree')
     })
+
+    it('ignores a non-control sharing the accessible name', async () => {
+      await I.amOnPage('/form/checkable/collision')
+      await I.dontSeeCheckboxIsChecked('#terms-box')
+
+      await I.checkOption('Accept terms')
+      await I.seeCheckboxIsChecked('#terms-box')
+    })
   })
 
   describe('#selectOption', () => {

--- a/test/helper/webapi.js
+++ b/test/helper/webapi.js
@@ -514,6 +514,77 @@ export function tests() {
     })
   })
 
+  describe('#checkOption - ARIA roles', function () {
+    this.timeout(60000)
+
+    async function open(page) {
+      await I.amOnPage(`/form/checkable/${page}`)
+      await I.waitForFunction(() => window.__ready === true, [], 30)
+    }
+
+    async function ariaChecked(css) {
+      return I.grabAttributeFrom(css, 'aria-checked')
+    }
+
+    for (const page of ['radix', 'baseui']) {
+      describe(page, () => {
+        beforeEach(function () {
+          // webdriverio resolves `<label for>` to input/textarea only, and a Radix
+          // `<button role=checkbox>` carries no accessible name of its own
+          if (page === 'radix' && isHelper('WebDriver')) this.skip()
+        })
+
+        it('checks and unchecks a checkbox by its label', async () => {
+          await open(page)
+          await I.dontSeeCheckboxIsChecked('Accept terms')
+
+          await I.checkOption('Accept terms')
+          expect(await ariaChecked('.ctl-terms')).to.equal('true')
+          await I.seeCheckboxIsChecked('Accept terms')
+
+          await I.uncheckOption('Accept terms')
+          expect(await ariaChecked('.ctl-terms')).to.equal('false')
+          await I.dontSeeCheckboxIsChecked('Accept terms')
+        })
+
+        it('checks a switch by its label', async () => {
+          await open(page)
+          await I.checkOption('Airplane mode')
+          expect(await ariaChecked('.ctl-airplane')).to.equal('true')
+          await I.seeCheckboxIsChecked('Airplane mode')
+        })
+
+        it('checks a radio by its label', async () => {
+          await open(page)
+          await I.dontSeeCheckboxIsChecked('Comfortable')
+
+          await I.checkOption('Comfortable')
+          expect(await ariaChecked('.ctl-comfortable')).to.equal('true')
+          expect(await ariaChecked('.ctl-default')).to.equal('false')
+          await I.seeCheckboxIsChecked('Comfortable')
+        })
+      })
+    }
+
+    it('resolves the visible control and not the hidden input the label points at', async () => {
+      await open('baseui')
+      // the author id sits on a 1x1 aria-hidden mirror input at x:-1,y:-1 which <label for> targets;
+      // [role=checkbox] can only be the visible span
+      expect(await I.grabAttributeFrom('#terms', 'aria-hidden')).to.equal('true')
+
+      await I.checkOption('Accept terms')
+      expect(await ariaChecked('[role=checkbox]')).to.equal('true')
+    })
+
+    it('still checks a plain input by its label', async () => {
+      await I.amOnPage('/form/checkbox')
+      await I.checkOption('I Agree')
+      await I.seeCheckboxIsChecked('I Agree')
+      await I.click('Submit')
+      assert.equal(formContents('terms'), 'agree')
+    })
+  })
+
   describe('#selectOption', () => {
     it('should select option by css', async () => {
       await I.amOnPage('/form/select')
@@ -2341,8 +2412,6 @@ export function tests() {
     })
 
     it('should check options by aria-label', async () => {
-      if (!isHelper('WebDriver')) return
-
       await I.amOnPage('/form/role_elements')
 
       await I.dontSeeCheckboxIsChecked('I agree to the terms and conditions')
@@ -2363,9 +2432,7 @@ export function tests() {
       await I.fillField('your@email.com', 'bob@company.com')
       await I.fillField('Enter your message', 'Test message')
 
-      if (isHelper('WebDriver')) {
-        await I.checkOption('Subscribe to newsletter')
-      }
+      await I.checkOption('Subscribe to newsletter')
 
       await I.click('Submit')
       await I.see('Form Submitted!')


### PR DESCRIPTION
`I.checkOption('Accept terms')` fails on every headless component library. Radix renders a checkbox as `<button role="checkbox" aria-checked>`, Base UI as `<span role="checkbox">` — neither is an `<input>`, and all three strategies in `Locator.checkable` hard-code `.//input[@type='checkbox' or @type='radio']`. The user gets *"Checkbox or radio … was not found by text|CSS|XPath"*.

This is a **lookup** gap, not an action gap: `checkOption({ role: 'checkbox', name: 'Accept terms' })` already works today, because a strict role locator goes through `handleRoleLocator` and Playwright's `check()` / `isChecked()` fully support `role=checkbox|radio|switch` with `aria-checked`. Only the fuzzy-string path was missing.

All three helpers now look up checkables through the accessibility tree **before** the label XPath, and all three restrict that lookup to the checkable roles.

## Playwright — add the ARIA pass

`findCheckable` now tries `getByRole('checkbox'|'radio'|'switch', { name })` before the XPath strategies, mirroring what `findClickable` already does for `button` / `link`. Native `<input type=checkbox|radio>` expose those roles too, so the pass is a **superset** of the strategies it precedes.

Exact across all three roles first, then substring across all three. Playwright's `name` option defaults to case-insensitive substring, and exact-first keeps the precision of the XPath path being replaced. Two passes rather than exact-then-substring per role, so a `checkbox` substring hit can't beat a `radio` exact hit.

`seeCheckboxIsChecked` / `dontSeeCheckboxIsChecked` route through the same lookup (`proceedIsChecked` → `findCheckable`) and are fixed by it. (On WebDriver they go through `findFields` instead, so this PR does not change them there.)

## WebDriver / Puppeteer — the ordering is the point

Both helpers already had an ARIA fallback, but ran it **after** the label XPath. That is too late.

Base UI always renders a hidden mirror `<input>`, moves the author's `id` onto it, and points `<label for>` at **it**, giving the visible control a generated id plus `aria-labelledby`:

```html
<span role="checkbox" aria-checked="false" aria-labelledby="terms-label"></span>
<input id="terms" tabindex="-1" aria-hidden="true" type="checkbox">
<label for="terms" id="terms-label">Accept terms</label>
```

So the label XPath **succeeds** — and resolves the mirror, which measures 1×1 px at `x:-1, y:-1`. Measured on this branch with the ARIA lookup disabled, Playwright fails as:

```
locator.check: Element is outside of the viewport
Call log:
  - waiting for locator('xpath=.//input[@type = 'checkbox' or @type = 'radio'][(@id = //label[@for][contains(...,'Accept terms')]/@for) …')
    - locator resolved to <input id="terms" tabindex="-1" type="checkbox" aria-hidden="true"/>
```

and WebDriver, with its `aria/` lookup moved back after the XPath:

```
element click intercepted: Element <input id="terms" tabindex="-1" aria-hidden="true" type="checkbox" …>
is not clickable at point (0, 0)
```

Because `aria-hidden="true"` removes that input from the accessibility tree, an ARIA lookup lands on the visible control instead. Hence the ARIA strategy must run **before** the label XPath, not as a fallback after it — in all three helpers.

## Keeping the reorder from costing precision

Hoisting an accessible-name lookup above the XPath widens the net, because `aria/…` and `::-p-aria(…)` match on name alone and are not role-scoped. On a page where a heading shares the checkbox label's text, the non-control wins on document order where `byText` previously reached the input. Measured on the new `collision` fixture:

```
puppeteer ::-p-aria(Accept terms)               -> [ H2, INPUT#terms-box ]
webdriverio aria/ union (document order)        -> [ H2, INPUT#terms-box ]
```

So both hoisted lookups are role-restricted as well as reordered:

* `lib/helper/Puppeteer.js` — loops the three checkable roles as `::-p-aria([name="…"][role="…"])`, following the `buildRoleSelector` convention already in the file. `::-p-aria` name matching is exact and case-sensitive (`::-p-aria(Accept)` matches nothing on a control named "Accept terms"), so there is no exact/substring distinction to make — one pass per role is the whole story. Falls through to the XPath on any parse failure, so a name containing a quote behaves exactly as it did before.
* `lib/helper/WebDriver.js` — webdriverio's `aria/` takes no attribute filter, so the returned elements are post-filtered to `input[type=checkbox|radio]` or `[role=checkbox|radio|switch]`. This is **one** `browser.execute` round trip regardless of match count (measured 6–11 ms), not one per element, using the `execute(fn, ...elements)` form already used elsewhere in the file.

After the restriction both return `[ INPUT#terms-box ]`, matching Playwright's role-scoped behaviour. The reorder now costs no precision on any helper.

## Tests

Fixtures render the real components via importmap + esm.sh, following the convention from #5701:

* `test/data/app/view/form/checkable/radix.php` — `radix-ui@1.6.7`
* `test/data/app/view/form/checkable/baseui.php` — `@base-ui/react@1.8.0`
* `test/data/app/view/form/checkable/collision.php` — plain HTML: an `<h2>` sharing the checkbox label's accessible name

Each component page has a Checkbox, a Switch and a Radio Group with visible labels; the Base UI page reproduces the `<label for>` → hidden mirror input wiring, which is the case that proves the ordering. Each control carries a `.ctl-*` class so assertions can target the visible element without depending on library-generated ids.

`test/helper/webapi.js` gains a `#checkOption - ARIA roles` block (shared across all three helpers, no parallel spec) that asserts **observable state** — `aria-checked` flipping on the *visible* element — for `checkOption`, `uncheckOption`, `seeCheckboxIsChecked` and `dontSeeCheckboxIsChecked`, plus two regression cases: a plain `<input type=checkbox>` + `<label>`, and the collision fixture (asserted through a CSS locator so the assertion path cannot be fooled by the lookup under test).

Two existing tests in `aria selectors without role locators` were guarded to WebDriver only because Playwright could not reach a `<span role=checkbox aria-label=…>`; the guards are removed and they now pass on all three helpers.

**Known limitation, kept as a `this.skip()` with the reason in the test:** Radix checkables are unreachable by label on WebDriver regardless of ordering. webdriverio's `aria/` selector resolves `<label for>` to `input`/`textarea` only, and Radix's `<button role=checkbox>` has no `aria-label`, no `aria-labelledby` and no text of its own — so neither the ARIA union nor `Locator.checkable` can find it. Fixing that needs a new WebDriver strategy, which is more than a reorder.

## Verification

Each change was checked by reverting it and watching the matching test fail:

| reverted | result |
|---|---|
| Playwright ARIA pass | 7 of 8 new tests fail (the plain-input regression case still passes, which is the point) |
| WebDriver reorder | all three Base UI cases fail — `element click intercepted` on the mirror input |
| Puppeteer role restriction | collision case fails — the `<h2>` is resolved and clicked |
| WebDriver role post-filter | collision case fails — `expected checkable field "#terms-box" to be checked` |

Local suites (run serially against a private fixture server and `selenium/standalone-chrome:4.27`): Playwright, Puppeteer and WebDriver helper suites green apart from environment-dependent cases (network-traffic tests needing live `codecept.io`, cookie tests, one puppeteer sandbox launch) — all of which pass in CI. `npm run test:unit` 770 passing, `npm run lint` clean.

No JSDoc on a public action changed, so no `npm run def` regeneration.

## Out of scope

`aria-pressed` toggles and `role=menuitemcheckbox` (Playwright's `check()` refuses both), `Locator.field`, `dragSlider` / `moveCursorTo`, `proceedSelect` — separate follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TcwzSXPnfaig8nBZD2Vxfi
