### PR TITLE
refactor(locator): find ARIA checkables in Locator, not in each helper

### DIFF
--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -50,7 +50,6 @@ let defaultSelectorEnginesInitialized = false
 const popupStore = new Popup()
 const consoleLogStore = new Console()
 const availableBrowsers = ['chromium', 'webkit', 'firefox', 'electron']
-const checkableRoles = ['checkbox', 'radio', 'switch']
 
 import { setRestartStrategy, restartsSession, restartsContext, restartsBrowser } from './extras/PlaywrightRestartOpts.js'
 import { createValueEngine, createDisabledEngine } from './extras/PlaywrightPropEngine.js'
@@ -4387,17 +4386,6 @@ async function findCheckable(locator, context) {
   const matchedLocator = new Locator(locator)
   if (!matchedLocator.isFuzzy()) {
     return findElements.call(this, contextEl, matchedLocator)
-  }
-
-  for (const exact of [true, false]) {
-    for (const role of checkableRoles) {
-      try {
-        const roleEls = await contextEl.getByRole(role, { name: matchedLocator.value, exact }).all()
-        if (roleEls.length) return roleEls
-      } catch (err) {
-        // getByRole not supported or failed
-      }
-    }
   }
 
   const literal = xpathLocator.literal(matchedLocator.value)

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -64,7 +64,6 @@ function wrapError(e) {
 let perfTiming
 const popupStore = new Popup()
 const consoleLogStore = new Console()
-const checkableRoles = ['checkbox', 'radio', 'switch']
 
 /**
  * ## Configuration
@@ -3196,25 +3195,22 @@ async function findCheckable(locator, context) {
     return findElements.call(this, contextEl, matchedLocator)
   }
 
-  // Try ARIA selector for accessible name
-  let els
-  for (const role of checkableRoles) {
-    try {
-      els = await contextEl.$$(`::-p-aria([name="${matchedLocator.value}"][role="${role}"])`)
-      if (els.length) return els
-    } catch (err) {
-      // ARIA selector not supported or failed
-    }
-  }
-
   const literal = xpathLocator.literal(matchedLocator.value)
-  els = await findElements.call(this, contextEl, Locator.checkable.byText(literal))
+  let els = await findElements.call(this, contextEl, Locator.checkable.byText(literal))
   if (els.length) {
     return els
   }
   els = await findElements.call(this, contextEl, Locator.checkable.byName(literal))
   if (els.length) {
     return els
+  }
+
+  // Try ARIA selector for accessible name
+  try {
+    els = await contextEl.$$(`::-p-aria(${matchedLocator.value})`)
+    if (els.length) return els
+  } catch (err) {
+    // ARIA selector not supported or failed
   }
 
   return findElements.call(this, contextEl, matchedLocator.value)

--- a/lib/helper/WebDriver.js
+++ b/lib/helper/WebDriver.js
@@ -3248,14 +3248,6 @@ async function findCheckable(locator, locateFn) {
   if (locator.isRole()) return locateFn(locator, true)
   if (!locator.isFuzzy()) return locateFn(locator, true)
 
-  // Try ARIA selector for accessible name
-  try {
-    els = await keepCheckable.call(this, await locateFn(`aria/${locator.value}`))
-    if (els.length) return els
-  } catch (e) {
-    // ARIA selector not supported or failed
-  }
-
   const literal = xpathLocator.literal(locator.value)
   els = await locateFn(Locator.checkable.byText(literal))
   if (els.length) return els
@@ -3263,23 +3255,17 @@ async function findCheckable(locator, locateFn) {
   els = await locateFn(Locator.checkable.byName(literal))
   if (els.length) return els
 
+  // Try ARIA selector for accessible name
+  try {
+    els = await locateFn(`aria/${locator.value}`)
+    if (els.length) return els
+  } catch (e) {
+    // ARIA selector not supported or failed
+  }
+
   return await locateFn(locator.value) // by css or xpath
 }
 
-async function keepCheckable(els) {
-  if (!els || !els.length) return []
-
-  const checkable = await this.browser.execute(function () {
-    return Array.prototype.slice.call(arguments).map(function (el) {
-      if (!el) return false
-      const role = el.getAttribute('role')
-      if (role) return ['checkbox', 'radio', 'switch'].indexOf(role) > -1
-      return el.tagName === 'INPUT' && (el.type === 'checkbox' || el.type === 'radio')
-    })
-  }, ...els)
-
-  return els.filter((el, index) => checkable[index])
-}
 
 function withStrictLocator(locator) {
   locator = new Locator(locator)

--- a/lib/locator.js
+++ b/lib/locator.js
@@ -649,6 +649,9 @@ Locator.field = {
     ]),
 }
 
+const checkable = `self::input[@type = 'checkbox' or @type = 'radio'] or @role = 'checkbox' or @role = 'radio' or @role = 'switch'`
+const visibleCheckable = `.//*[${checkable}][not(@aria-hidden = 'true')]`
+
 Locator.checkable = {
   /**
    * @param {string} literal
@@ -656,8 +659,10 @@ Locator.checkable = {
    */
   byText: literal =>
     xpathLocator.combine([
-      `.//input[@type = 'checkbox' or @type = 'radio'][(@id = //label[@for][contains(normalize-space(string(.)), ${literal})]/@for) or @placeholder = ${literal}]`,
-      `.//label[contains(normalize-space(string(.)), ${literal})]//input[@type = 'radio' or @type = 'checkbox']`,
+      `${visibleCheckable}[(@id = //label[@for][contains(normalize-space(string(.)), ${literal})]/@for) or @placeholder = ${literal}]`,
+      `.//label[contains(normalize-space(string(.)), ${literal})]//*[${checkable}][not(@aria-hidden = 'true')]`,
+      `${visibleCheckable}[@aria-labelledby = //*[@id][contains(normalize-space(string(.)), ${literal})]/@id]`,
+      `${visibleCheckable}[@aria-label = ${literal}]`,
     ]),
 
   /**

--- a/test/unit/locator_test.js
+++ b/test/unit/locator_test.js
@@ -808,4 +808,47 @@ describe('Locator', () => {
       expect(items[0].getAttribute('id')).to.eql('rename')
     })
   })
+
+  describe('Locator.checkable.byText', () => {
+    const select = (xml, literal) => {
+      const doc = new DOMParser().parseFromString(xml, 'text/xml')
+      return xpath.select(Locator.checkable.byText(literal), xpath.select1('//root', doc))
+    }
+
+    it('matches a native input labelled by label[for]', () => {
+      const nodes = select('<root><input type="checkbox" id="a"/><label for="a">I Agree</label></root>', "'I Agree'")
+      expect(nodes).to.have.length(1)
+      expect(nodes[0].getAttribute('id')).to.eql('a')
+    })
+
+    it('matches a role=checkbox labelled by label[for]', () => {
+      const nodes = select('<root><button role="checkbox" id="a"></button><label for="a">Accept terms</label></root>', "'Accept terms'")
+      expect(nodes).to.have.length(1)
+      expect(nodes[0].tagName).to.eql('button')
+    })
+
+    it('matches a role=switch labelled by aria-labelledby', () => {
+      const nodes = select('<root><span role="switch" aria-labelledby="l"></span><label id="l">Airplane mode</label></root>', "'Airplane mode'")
+      expect(nodes).to.have.length(1)
+      expect(nodes[0].getAttribute('role')).to.eql('switch')
+    })
+
+    it('matches a role=radio named by aria-label', () => {
+      const nodes = select('<root><span role="radio" aria-label="Compact"></span></root>', "'Compact'")
+      expect(nodes).to.have.length(1)
+      expect(nodes[0].getAttribute('role')).to.eql('radio')
+    })
+
+    it('resolves the visible control, not the aria-hidden input the label points at', () => {
+      const xml =
+        '<root>' +
+        '<span role="checkbox" aria-labelledby="l" id="visible"></span>' +
+        '<input type="checkbox" id="mirror" aria-hidden="true"/>' +
+        '<label for="mirror" id="l">Accept terms</label>' +
+        '</root>'
+      const nodes = select(xml, "'Accept terms'")
+      expect(nodes).to.have.length(1)
+      expect(nodes[0].getAttribute('id')).to.eql('visible')
+    })
+  })
 })


### PR DESCRIPTION
Follow-up to #5704, which I wrote and which you were right to find inelegant. It solved the problem three times — once per helper — and left the concept out of `Locator`, where it belongs.

## The idea

`Locator.checkable` already knows how to find a control by its label: `<label for>` → `@id`, nesting inside the label, `@aria-label`, `@aria-labelledby`. Those mechanisms are correct. The only thing wrong is that they hard-code the **tag**. Headless component libraries express the same semantics with a **role**.

```js
const checkable = `self::input[@type = 'checkbox' or @type = 'radio'] or @role = 'checkbox' or @role = 'radio' or @role = 'switch'`
const visibleCheckable = `.//*[${checkable}][not(@aria-hidden = 'true')]`
```

Generalise the tag test to a tag-or-role test, skip `aria-hidden`. Nothing else. Mechanisms 3 and 4 already existed on `Locator.field`; this brings them to `Locator.checkable`, where they were missing.

## What it removes

| | #5704 | here |
|---|---|---|
| Playwright | `getByRole` loop over 3 roles × exact/substring | — |
| Puppeteer | role-scoped `::-p-aria` loop + `checkableRoles` | — |
| WebDriver | hoisted `aria/` + `keepCheckable` filter | — |
| `Locator` | untouched | one predicate |

Puppeteer's and WebDriver's ARIA fallbacks return to their original position after the XPath. **Net −25 lines of library code**, no new public methods, and nothing in the diff names a component library.

An XPath predicate is role-scoped by construction, so the precision problem #5704 had to solve per-helper — a heading sharing the label text winning over the control — cannot arise, and the filtering that guarded against it is gone.

The `not(@aria-hidden = 'true')` guard is what skips the hidden mirror input these libraries render and point `<label for>` at, so the visible control is resolved instead. Same guard #5703 uses for `Locator.field`.

## Verification

Against real `radix-ui@1.6.7` and `@base-ui/react@1.8.0`, standalone and inside a `<form>` — `checkOption` / `seeCheckboxIsChecked` on Checkbox, Switch, Radio Group, Checkbox Group work on both libraries.

- Playwright **53 passing**, Puppeteer **49 passing**, WebDriver **41 passing / 3 pending**, 0 failing
- unit **815 passing**, plus **81** in `locator_test.js` including 5 new cases pinning the predicate
- lint clean
- On existing native fixtures the generated XPath returns an **identical node set** — no behaviour change for plain HTML

`#5704`'s own behaviour-level tests are kept unchanged and still pass; they were good, and they are what proves this is a refactor rather than a rewrite.

## Two things I checked and did *not* claim

- I expected this to fix a menu-item regression from #5704. **It doesn't reproduce** — Puppeteer `checkOption` on `menuitemcheckbox` already works on merged `4.x`. Behaviour is identical before and after this change.
- I expected to remove the WebDriver/Radix skip #5704 needed. **It can't be removed here** — that path fails in `proceedSeeCheckbox` → `findFields`, which is `Locator.field`'s territory (see #5703), not `findCheckable`'s. Skip left in place.

## Scope

Deliberately excluded: `aria-pressed` toggles (a toggle button is not a checkable, and `I.click('Bold')` already works), `role=menuitemcheckbox`, and sliders. None of them need new public API to state, and none were the ask.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TcwzSXPnfaig8nBZD2Vxfi