### PR TITLE
fix: use bunx instead of npx to read Playwright versions under Bun

### DIFF
--- a/lib/command/info.js
+++ b/lib/command/info.js
@@ -21,9 +21,16 @@ function parsePlaywrightBrowsers(output) {
   return versions.join(', ')
 }
 
+// Bun has its own package runner and a Bun-only install has no `npx` on PATH at all, so the
+// runner has to follow the runtime that is actually executing rather than what PATH happens to hold.
+function getPackageRunner() {
+  if (process.versions.bun) return 'bunx'
+  return 'npx'
+}
+
 async function getPlaywrightBrowsers() {
   try {
-    const info = execSync('npx playwright install --dry-run').toString().trim()
+    const info = execSync(`${getPackageRunner()} playwright install --dry-run`).toString().trim()
     return parsePlaywrightBrowsers(info)
   } catch (err) {
     return 'Playwright not installed'
@@ -85,7 +92,7 @@ export default async function (path) {
   output.print('***************************************')
 }
 
-export { parsePlaywrightBrowsers, getRuntimeInfo }
+export { parsePlaywrightBrowsers, getRuntimeInfo, getPackageRunner }
 
 export const getMachineInfo = async () => {
   const info = {

--- a/test/unit/command/info_test.js
+++ b/test/unit/command/info_test.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai'
-import { parsePlaywrightBrowsers, getRuntimeInfo } from '../../../lib/command/info.js'
+import { parsePlaywrightBrowsers, getRuntimeInfo, getPackageRunner } from '../../../lib/command/info.js'
 
 describe('info command', () => {
   describe('getRuntimeInfo', () => {
@@ -39,6 +39,32 @@ describe('info command', () => {
       expect(nodeInfo).to.be.an('array')
       expect(nodeInfo.length).to.be.at.least(2)
       expect(nodeInfo[1]).to.be.a('string')
+    })
+  })
+
+  describe('getPackageRunner', () => {
+    let originalBunVersion
+
+    beforeEach(() => {
+      originalBunVersion = process.versions.bun
+    })
+
+    afterEach(() => {
+      if (originalBunVersion === undefined) {
+        delete process.versions.bun
+      } else {
+        process.versions.bun = originalBunVersion
+      }
+    })
+
+    it('should use bunx when running under Bun', () => {
+      process.versions.bun = '1.4.2'
+      expect(getPackageRunner()).to.equal('bunx')
+    })
+
+    it('should use npx when not running under Bun', () => {
+      delete process.versions.bun
+      expect(getPackageRunner()).to.equal('npx')
     })
   })
 


### PR DESCRIPTION
Closes #5713

### Problem

`getPlaywrightBrowsers()` in `lib/command/info.js` hardcoded the Node package runner:

```js
const info = execSync('npx playwright install --dry-run').toString().trim()
```

A Bun-only environment has no `npx` on `PATH`, so `execSync` throws and the `catch` reports `Playwright not installed` on an install where Playwright and its browsers are present. It is a false negative rather than a visible error, so it reads as a genuine misconfiguration.

### Fix

Pick the package runner from the runtime that is actually executing rather than from whatever `PATH` holds, via `process.versions.bun` — the same detection already used by `getRuntimeInfo()` in #5700.

```js
function getPackageRunner() {
  if (process.versions.bun) return 'bunx'
  return 'npx'
}
```

`bunx playwright install --dry-run` resolves the local `node_modules/.bin/playwright` and emits output identical to the `npx` form, so `parsePlaywrightBrowsers()` needs no change and Node behaviour is unchanged.

This is the only place CodeceptJS actually shells out to `npx`; every other occurrence under `lib/` is documentation text. It removes the need to symlink `npx` to `bun` in Bun images.

### Verification

`codecept info` with `npx` absent from `PATH` entirely, before and after:

```
# before
$ PATH=/path/to/bun/bin:/usr/bin:/bin bun ./bin/codecept.js info <dir>
  bunInfo:  1.4.2
  playwrightBrowsers:  "Playwright not installed"

# after
  bunInfo:  1.4.2
  playwrightBrowsers:  "chromium: 148.0.7778.96, firefox: 150.0.2, webkit: 26.4"
```

Node is byte-identical to before the change:

```
  nodeInfo:  24.18.0
  playwrightBrowsers:  "chromium: 148.0.7778.96, firefox: 150.0.2, webkit: 26.4"
```

Unit tests cover both branches of the detection; `test/unit/command/*.js` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
