### PR TITLE
fix(helpers): scroll element into view in moveCursorTo

### DIFF
--- a/lib/helper/Playwright.js
+++ b/lib/helper/Playwright.js
@@ -1525,6 +1525,7 @@ class Playwright extends Helper {
       assertElementExists(el, locator)
     }
 
+    await el.scrollIntoViewIfNeeded()
     // Use manual mouse.move instead of .hover() so the offset can be added to the coordinates
     const { x, y } = await clickablePoint(el)
     await this.page.mouse.move(x + offsetX, y + offsetY)

--- a/lib/helper/Puppeteer.js
+++ b/lib/helper/Puppeteer.js
@@ -845,6 +845,9 @@ class Puppeteer extends Helper {
       }
     }
 
+    if (!(await el.isIntersectingViewport({ threshold: 1 }))) {
+      await el.evaluate(el => el.scrollIntoView({ block: 'center', inline: 'center' }))
+    }
     // Use manual mouse.move instead of .hover() so the offset can be added to the coordinates
     const { x, y } = await getClickablePoint(el)
     await this.page.mouse.move(x + offsetX, y + offsetY)

--- a/test/data/app/view/form/hover.php
+++ b/test/data/app/view/form/hover.php
@@ -7,5 +7,8 @@
 
 <div id="show"></div>
 
+<div id="offscreen_show"></div>
+<span id="offscreen_hover" style="display: inline-block; margin-top: 2000px" onmouseover="document.getElementById('offscreen_show').innerText = 'Hovered offscreen!'">Hover me too!</span>
+
 </body>
 </html>

--- a/test/helper/Playwright_test.js
+++ b/test/helper/Playwright_test.js
@@ -395,6 +395,18 @@ describe('Playwright', function () {
       I.amOnPage('/form/hover')
         .then(() => I.moveCursorTo('#hover', 'body'))
         .then(() => I.see('Hovered', '#show')))
+
+    it('should scroll element into view before hovering', async () => {
+      await I.amOnPage('/form/hover')
+      await I.moveCursorTo('#offscreen_hover')
+      await I.see('Hovered offscreen', '#offscreen_show')
+    })
+
+    it('should scroll element into view before hovering within a context', async () => {
+      await I.amOnPage('/form/hover')
+      await I.moveCursorTo('#offscreen_hover', 'body')
+      await I.see('Hovered offscreen', '#offscreen_show')
+    })
   })
 
   describe('#switchToNextTab, #switchToPreviousTab, #openNewTab, #closeCurrentTab, #closeOtherTabs, #grabNumberOfOpenTabs, #waitForNumberOfTabs', () => {

--- a/test/helper/Puppeteer_test.js
+++ b/test/helper/Puppeteer_test.js
@@ -245,6 +245,18 @@ describe('Puppeteer', function () {
       I.amOnPage('/form/hover')
         .then(() => I.moveCursorTo('#hover', 'body'))
         .then(() => I.see('Hovered', '#show')))
+
+    it('should scroll element into view before hovering', async () => {
+      await I.amOnPage('/form/hover')
+      await I.moveCursorTo('#offscreen_hover')
+      await I.see('Hovered offscreen', '#offscreen_show')
+    })
+
+    it('should scroll element into view before hovering within a context', async () => {
+      await I.amOnPage('/form/hover')
+      await I.moveCursorTo('#offscreen_hover', 'body')
+      await I.see('Hovered offscreen', '#offscreen_show')
+    })
   })
 
   describe('#switchToNextTab, #switchToPreviousTab, #openNewTab, #closeCurrentTab, #closeOtherTabs, #grabNumberOfOpenTabs, #waitForNumberOfTabs', () => {


### PR DESCRIPTION
## Problem

`moveCursorTo` moved the mouse to the element's center coordinates without scrolling first. When the element was outside the viewport, the cursor landed off-screen and no hover fired. No error was raised, so the step passed while doing nothing.

## Fix

- **Playwright:** call `scrollIntoViewIfNeeded()` on the located element before reading its clickable point. `scrollTo` already uses the same call.
- **Puppeteer:** if the element is not fully inside the viewport (`isIntersectingViewport({ threshold: 1 })`), scroll it to the center. Puppeteer's own `ElementHandle.hover()` does the same. Its `scrollIntoViewIfNeeded()` is `protected`, and Puppeteer is not a peer dependency, so this sticks to public API.
- **WebDriver:** no change. WebdriverIO's `moveTo` already scrolls into view.

The offset arguments still work: the element is scrolled into view first, then the offset is added to its center.

## Behavior change

Playwright only: if `moveCursorTo` targets a `display:none` element (reachable when `visibleLocator` is off), it used to fail immediately with `ElementNotFound`. It now fails after the helper `timeout` (5s by default) with Playwright's timeout error.

## Tests

- Added an off-screen hover target (`margin-top: 2000px`) to `test/data/app/view/form/hover.php`.
- Added two specs to `#moveCursorTo` in `Playwright_test.js` and `Puppeteer_test.js`: one plain, one with a context. All four fail without the fix and pass with it.
- Existing `#moveCursorTo`, `#scrollTo` and `#dragAndDrop` specs pass for both helpers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VmYyNa6z4o3hxPkdpDiUmB
